### PR TITLE
loadedFileUrls only contains the last one of urls with same file name

### DIFF
--- a/xwork-core/src/main/java/com/opensymphony/xwork2/config/providers/XmlConfigurationProvider.java
+++ b/xwork-core/src/main/java/com/opensymphony/xwork2/config/providers/XmlConfigurationProvider.java
@@ -1015,6 +1015,7 @@ public class XmlConfigurationProvider implements ConfigurationProvider {
                     in.setSystemId(url.toString());
 
                     docs.add(DomHelper.parse(in, dtdMappings));
+                    loadedFileUrls.add(url.toString());
                 } catch (XWorkException e) {
                     if (includeElement != null) {
                         throw new ConfigurationException("Unable to load " + url, e, includeElement);
@@ -1071,7 +1072,6 @@ public class XmlConfigurationProvider implements ConfigurationProvider {
                     }
                 }
                 finalDocs.add(doc);
-                loadedFileUrls.add(url.toString());
             }
 
             if (LOG.isDebugEnabled()) {


### PR DESCRIPTION
In XmlConfigurationProvider, the field `loadedFileUrls` contains the xml files loaded. The loaded files will be checked if they are modified for configuration reloading.

``` java
    public boolean needsReload() {

        for (String url : loadedFileUrls) {
            if (fileManager.fileNeedsReloading(url)) {
                return true;
            }
        }
        return false;
    }
```

But in method `private List<Document> loadConfigurationFiles(String fileName, Element includeElement)`, after the `while (urls.hasNext())` loop, the variable `url` is assigned by the last one of urls with same file name.

So when `loadedFileUrls.add(url.toString());` is called in the `for (Document doc : docs)` loop, only _THE LAST ONE_ is added to  loadedFileUrls.

I wrote a demo. I set `<constant name="struts.configuration.xml.reload" value="true"/>
`.  I wrote two configuration files: `struts-plugin.xml` and `struts-biz.xml` in my web project. I use struts plugins such as `struts-spring-plugin`, `struts-json-plugin` and so on. 

The reloading works when I changed the file `struts-biz.xml` in my project. But it does not work when I changed `struts-plugin.xml` in my project. I debug XmlConfigurationProvider and see  only the `struts-plugin.xml` in struts-spring-plugin is contained in loadedFileUrls.

I tried to fix it by moving the `loadedFileUrls.add(url.toString());` into the  `while (urls.hasNext())` loop.
