### PR TITLE
Localized by classloader

### DIFF
--- a/xwork-core/src/test/java/com/opensymphony/xwork2/util/LocalizedTextUtilTest.java
+++ b/xwork-core/src/test/java/com/opensymphony/xwork2/util/LocalizedTextUtilTest.java
@@ -133,11 +133,6 @@ public class LocalizedTextUtilTest extends XWorkTestCase {
         assertEquals("Error during Action invocation", message);
     }
 
-    /* FIXME
-    Stated that property's management does not care about ordering,
-    in fact it's held by a Set instead of List,
-    you cannot override a previous bundle, thus the test is wrong.
-
     public void testDefaultMessageOverride() throws Exception {
         String message = LocalizedTextUtil.findDefaultText(XWorkMessages.ACTION_EXECUTION_ERROR, Locale.getDefault());
         assertEquals("Error during Action invocation", message);
@@ -147,7 +142,6 @@ public class LocalizedTextUtilTest extends XWorkTestCase {
         message = LocalizedTextUtil.findDefaultText(XWorkMessages.ACTION_EXECUTION_ERROR, Locale.getDefault());
         assertEquals("Testing resource bundle override", message);
     }
-    */
 
     public void testFindTextInChildProperty() throws Exception {
         ModelDriven action = new ModelDrivenAction2();


### PR DESCRIPTION
**This improvement enables struts to be used as JBoss AS 7/WildFly 8/JBoss EAP 6 module.**

_**Issue:**_
having two or more applications using the same "struts-module" (meant as JBoss AS 7 module),
each application with its own resource bundle, the first one which initialized the LocalizedTextUtil "wins" over the second and next application's resource bundles. Furthermore, to avoid overwriting bundles, now each bundle is indexed into the bundlesMap by its key (resourceBundleName) and prefixed by ClassLoader hash code.

https://issues.apache.org/jira/browse/WW-4379
