### PR TITLE
Fix Memory leak in CDI plugin

### DIFF
--- a/plugins/cdi/src/main/java/org/apache/struts2/cdi/CdiObjectFactory.java
+++ b/plugins/cdi/src/main/java/org/apache/struts2/cdi/CdiObjectFactory.java
@@ -70,7 +70,6 @@ public class CdiObjectFactory extends ObjectFactory {
 	}
 
 	protected BeanManager beanManager;
-    protected CreationalContext ctx;
 
     Map<Class<?>, InjectionTarget<?>> injectionTargetCache = new ConcurrentHashMap<Class<?>, InjectionTarget<?>>();
 
@@ -79,7 +78,6 @@ public class CdiObjectFactory extends ObjectFactory {
         LOG.info("Initializing Struts2 CDI integration...");
         this.beanManager = findBeanManager();
         if (beanManager != null) {
-            this.ctx = buildNonContextualCreationalContext(beanManager);
             LOG.info("Struts2 CDI integration initialized.");
         } else {
             LOG.error("Struts2 CDI integration could not be initialized.");
@@ -152,12 +150,15 @@ public class CdiObjectFactory extends ObjectFactory {
 	}
 
 	@Override
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({ "rawtypes", "unchecked" })
     public Object buildBean(String className, Map<String, Object> extraContext, boolean injectInternal)
             throws Exception {
 
         Class<?> clazz = getClassInstance(className);
         InjectionTarget injectionTarget = getInjectionTarget(clazz);
+
+        // a separate CreationalContext is required for every bean
+        final CreationalContext ctx = buildNonContextualCreationalContext(beanManager);
 
         Object o = injectionTarget.produce(ctx);
         injectionTarget.inject(o, ctx);


### PR DESCRIPTION
The CDI plugin was using a single 'CreationalContext' for all beans created by the CDIObjectFactory. This is incorrect and the size of the 'dependentInstances' (in the WELD implementation) grows indefinately with no beans being removed. 
Fix is to use a new 'CreationalContext' for every bean created. In our tests with WELD this does not effect the applications performance. Idealy a single 'CreationalContext' should be created for the request lifecycle. However the struts ObjectFactory API does not appear to provide any information able the lifecycle.
