### PR TITLE
Defend for NPE when performing async request

### DIFF
--- a/plugins/sitemesh/src/main/java/org/apache/struts2/sitemesh/StrutsSiteMeshFactory.java
+++ b/plugins/sitemesh/src/main/java/org/apache/struts2/sitemesh/StrutsSiteMeshFactory.java
@@ -2,6 +2,7 @@ package org.apache.struts2.sitemesh;
 
 import com.opensymphony.module.sitemesh.Config;
 import com.opensymphony.module.sitemesh.factory.DefaultFactory;
+import com.opensymphony.xwork2.ActionContext;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.struts2.ServletActionContext;
 import org.apache.struts2.StrutsStatics;
@@ -22,6 +23,8 @@ public class StrutsSiteMeshFactory extends DefaultFactory {
     }
 
     private boolean isInsideActionTag() {
+        if(ActionContext.getContext() == null)
+    		return false;
         Object attribute = ServletActionContext.getRequest().getAttribute(StrutsStatics.STRUTS_ACTION_TAG_INVOCATION);
         return (Boolean) ObjectUtils.defaultIfNull(attribute, Boolean.FALSE);
     }


### PR DESCRIPTION
when I combined spring async mvc with struts2 sitemesh plugin, It will throw NPE

java.lang.NullPointerException
    at org.apache.struts2.ServletActionContext.getRequest(ServletActionContext.java:112)
    at org.apache.struts2.sitemesh.StrutsSiteMeshFactory.isInsideActionTag(StrutsSiteMeshFactory.java:25)
    at org.apache.struts2.sitemesh.StrutsSiteMeshFactory.shouldParsePage(StrutsSiteMeshFactory.java:21)
    at com.opensymphony.sitemesh.compatability.PageParser2ContentProcessor.handles(PageParser2ContentProcessor.java:45)
    at com.opensymphony.sitemesh.webapp.ContentBufferingResponse$1.shouldParsePage(ContentBufferingResponse.java:29)
    at com.opensymphony.module.sitemesh.filter.PageResponseWrapper.setContentType(PageResponseWrapper.java:63)
    at com.opensymphony.sitemesh.webapp.ContentBufferingResponse$2.setContentType(ContentBufferingResponse.java:39)
    at com.opensymphony.module.sitemesh.filter.PageResponseWrapper.addHeader(PageResponseWrapper.java:135)
    at javax.servlet.http.HttpServletResponseWrapper.addHeader(HttpServletResponseWrapper.java:173)
    at org.springframework.http.server.ServletServerHttpResponse.writeHeaders(ServletServerHttpResponse.java:103)
    at org.springframework.http.server.ServletServerHttpResponse.getBody(ServletServerHttpResponse.java:83)
    at org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter.writeInternal(AbstractJackson2HttpMessageConverter.java:217)
    at org.springframework.http.converter.AbstractHttpMessageConverter.write(AbstractHttpMessageConverter.java:208)
    at org.springframework.web.servlet.mvc.method.annotation.AbstractMessageConverterMethodProcessor.writeWithMessageConverters(AbstractMessageConverterMethodProcessor.java:161)
    at org.springframework.web.servlet.mvc.method.annotation.AbstractMessageConverterMethodProcessor.writeWithMessageConverters(AbstractMessageConverterMethodProcessor.java:101)
    at org.springframework.web.servlet.mvc.method.annotation.RequestResponseBodyMethodProcessor.handleReturnValue(RequestResponseBodyMethodProcessor.java:199)
    at org.springframework.web.method.support.HandlerMethodReturnValueHandlerComposite.handleReturnValue(HandlerMethodReturnValueHandlerComposite.java:71)
    at org.springframework.web.servlet.mvc.method.annotation.ServletInvocableHandlerMethod.invokeAndHandle(ServletInvocableHandlerMethod.java:128)
    at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.invokeHandleMethod(RequestMappingHandlerAdapter.java:781)
    at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.handleInternal(RequestMappingHandlerAdapter.java:721)
    at org.springframework.web.servlet.mvc.method.AbstractHandlerMethodAdapter.handle(AbstractHandlerMethodAdapter.java:83)
    at org.springframework.web.servlet.DispatcherServlet.doDispatch(DispatcherServlet.java:943)
    at org.springframework.web.servlet.DispatcherServlet.doService(DispatcherServlet.java:877)
    at org.springframework.web.servlet.FrameworkServlet.processRequest(FrameworkServlet.java:966)
    at org.springframework.web.servlet.FrameworkServlet.doGet(FrameworkServlet.java:857)
    at javax.servlet.http.HttpServlet.service(HttpServlet.java:620)
    at org.springframework.web.servlet.FrameworkServlet.service(FrameworkServlet.java:842)
    at javax.servlet.http.HttpServlet.service(HttpServlet.java:727)
    at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:303)
    at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:208)
    at org.apache.catalina.core.ApplicationDispatcher.invoke(ApplicationDispatcher.java:748)
    at org.apache.catalina.core.ApplicationDispatcher.doDispatch(ApplicationDispatcher.java:659)
    at org.apache.catalina.core.ApplicationDispatcher.dispatch(ApplicationDispatcher.java:625)
    at org.apache.catalina.core.AsyncContextImpl$1.run(AsyncContextImpl.java:239)
    at org.apache.catalina.core.AsyncContextImpl.doInternalDispatch(AsyncContextImpl.java:382)
    at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:215)
    at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:122)
    at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:171)
    at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:103)
    at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:116)
    at org.apache.catalina.connector.CoyoteAdapter.asyncDispatch(CoyoteAdapter.java:299)
    at org.apache.coyote.http11.AbstractHttp11Processor.asyncDispatch(AbstractHttp11Processor.java:1652)
    at org.apache.coyote.AbstractProtocol$AbstractConnectionHandler.process(AbstractProtocol.java:603)
    at org.apache.tomcat.util.net.JIoEndpoint$SocketProcessor.run(JIoEndpoint.java:314)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
    at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61)
    at java.lang.Thread.run(Thread.java:745)
