### PR TITLE
WW-4539 Support list of tokens to prevent CSRF attack in async requests

### DIFF
--- a/core/src/main/java/org/apache/struts2/components/Token.java
+++ b/core/src/main/java/org/apache/struts2/components/Token.java
@@ -21,6 +21,7 @@
 
 package org.apache.struts2.components;
 
+import java.util.ArrayList;
 import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
@@ -101,13 +102,18 @@ public class Token extends UIBean {
 
     private String buildToken(String name) {
         Map context = stack.getContext();
-        Object myToken = context.get(name);
+        String myToken = TokenHelper.setToken(name);
+        Object myTokens = context.get(name);
 
-        if (myToken == null) {
-            myToken = TokenHelper.setToken(name);
-            context.put(name, myToken);
+        if (myTokens == null) {
+            myTokens = new ArrayList<String>();
+            context.put(name, myTokens);
         }
+        ArrayList<String> myTokensList = (ArrayList<String>) myTokens;
+        if(myTokensList.size() < TokenHelper.SESSION_TOKEN_LIST_MAX_SIZE &&
+        		!myTokensList.contains(myToken))
+        	myTokensList.add(myToken);
 
-        return myToken.toString();
+        return myToken;
     }
 }

--- a/core/src/test/java/org/apache/struts2/util/TokenHelperTest.java
+++ b/core/src/test/java/org/apache/struts2/util/TokenHelperTest.java
@@ -21,6 +21,7 @@
 
 package org.apache.struts2.util;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.TreeMap;
@@ -47,14 +48,20 @@ public class TokenHelperTest extends TestCase {
     public void testSetToken() {
         String token = TokenHelper.setToken();
 		final String defaultSessionTokenName = TokenHelper.buildTokenSessionAttributeName(TokenHelper.DEFAULT_TOKEN_NAME);
-		assertEquals(token, session.get(defaultSessionTokenName));
+		Object sessionTokens = session.get(defaultSessionTokenName);
+		assertNotNull(sessionTokens);
+		ArrayList<String> sessionTokensList = (ArrayList<String>) sessionTokens;
+		assertTrue(sessionTokensList.contains(token));
     }
 
     public void testSetTokenWithName() {
         String tokenName = "myTestToken";
         String token = TokenHelper.setToken(tokenName);
 		final String sessionTokenName = TokenHelper.buildTokenSessionAttributeName(tokenName);
-		assertEquals(token, session.get(sessionTokenName));
+		Object sessionTokens = session.get(sessionTokenName);
+		assertNotNull(sessionTokens);
+		ArrayList<String> sessionTokensList = (ArrayList<String>) sessionTokens;
+		assertTrue(sessionTokensList.contains(token));
     }
 
 	public void testSetSessionToken() {
@@ -62,14 +69,20 @@ public class TokenHelperTest extends TestCase {
 		String token = "foobar";
 		TokenHelper.setSessionToken(tokenName, token);
 		final String sessionTokenName = TokenHelper.buildTokenSessionAttributeName(tokenName);
-		assertEquals(token, session.get(sessionTokenName));
+		Object sessionTokens = session.get(sessionTokenName);
+		assertNotNull(sessionTokens);
+		ArrayList<String> sessionTokensList = (ArrayList<String>) sessionTokens;
+		assertTrue(sessionTokensList.contains(token));
 	}
 
 	public void testValidToken() {
         String tokenName = "validTokenTest";
         String token = TokenHelper.setToken(tokenName);
 		final String sessionTokenName = TokenHelper.buildTokenSessionAttributeName(tokenName);
-		assertEquals(token, session.get(sessionTokenName));
+		Object sessionTokens = session.get(sessionTokenName);
+		assertNotNull(sessionTokens);
+		ArrayList<String> sessionTokensList = (ArrayList<String>) sessionTokens;
+		assertTrue(sessionTokensList.contains(token));
         ActionContext.getContext().getParameters().put(TokenHelper.TOKEN_NAME_FIELD, new String[]{tokenName});
         ActionContext.getContext().getParameters().put(tokenName, new String[]{token});
         assertTrue(TokenHelper.validToken());

--- a/core/src/test/java/org/apache/struts2/views/jsp/ui/TokenTagTest.java
+++ b/core/src/test/java/org/apache/struts2/views/jsp/ui/TokenTagTest.java
@@ -21,6 +21,8 @@
 
 package org.apache.struts2.views.jsp.ui;
 
+import java.util.ArrayList;
+
 import javax.servlet.jsp.JspException;
 
 import org.apache.struts2.util.TokenHelper;
@@ -44,13 +46,16 @@ public class TokenTagTest extends AbstractUITagTest {
         TokenTag tag = new TokenTag();
         tag.setName(tokenName);
 
-        String token = doTokenTest(tokenName, tag);
+        ArrayList<String> tokens = doTokenTest(tokenName, tag);
 
         TokenTag anotherTag = new TokenTag();
         anotherTag.setName(tokenName);
 
-        String anotherToken = doTokenTest(tokenName, anotherTag);
-        assertEquals(token, anotherToken);
+        ArrayList<String> anotherTokens = doTokenTest(tokenName, anotherTag);
+        
+        assertEquals(tokens, anotherTokens);
+        assertEquals(2, tokens.size());
+        assertNotSame(tokens.get(0), tokens.get(1));
     }
 
     /**
@@ -77,24 +82,27 @@ public class TokenTagTest extends AbstractUITagTest {
         doTokenTest(tokenName, tag);
     }
 
-    private String doTokenTest(String tokenName, TokenTag tag) {
+    private ArrayList<String> doTokenTest(String tokenName, TokenTag tag) {
         tag.setPageContext(pageContext);
 
-        String token = null;
+        ArrayList<String> tokens = null;
 
         try {
             tag.doStartTag();
             tag.doEndTag();
 
-            token = (String) context.get(tokenName);
-			assertNotNull(token);
+            tokens = (ArrayList<String>) context.get(tokenName);
+			assertNotNull(tokens);
 			final String sessionTokenName = TokenHelper.buildTokenSessionAttributeName(tokenName);
-			assertEquals(token, pageContext.getSession().getAttribute(sessionTokenName));
+			Object mySessionTokens = pageContext.getSession().getAttribute(sessionTokenName);
+			assertNotNull(mySessionTokens);
+			ArrayList<String> mySessionTokensList = (ArrayList<String>) mySessionTokens;
+			assertTrue(mySessionTokensList.containsAll(tokens));
         } catch (JspException e) {
             e.printStackTrace();
             fail();
         }
 
-        return token;
+        return tokens;
     }
 }


### PR DESCRIPTION
Nowadays, modern web applications use JQuery, and so, they can send multiple async requests in parallel to the web server. Struts has a great token mechanism which one of it's use cases is preventing from CSRF attack, but it's not usable or hard to use when the user application has multiple valid submission from one jsp using JQuery.

This pull request contains all changes needed to enable Struts to handle this, transparently (i.e. these changes do not break current user application which uses previous token mechanism). Also, this is protected from DOS attack by supplying a maximum for count of concurrent valid requests.

I hope you enjoy it.
Thanks!