### PR TITLE
Improve LocalizedTextUtil.getMessage() defend NPE

### DIFF
--- a/core/src/main/java/com/opensymphony/xwork2/util/LocalizedTextUtil.java
+++ b/core/src/main/java/com/opensymphony/xwork2/util/LocalizedTextUtil.java
@@ -736,9 +736,12 @@ public class LocalizedTextUtil {
         if (bundle == null) {
             return null;
         }
+        if (valueStack != null) 
             reloadBundles(valueStack.getContext());
         try {
-            String message = TextParseUtil.translateVariables(bundle.getString(key), valueStack);
+        	String message = bundle.getString(key);
+        	if (valueStack != null) 
+        		message = TextParseUtil.translateVariables(bundle.getString(key), valueStack);
             MessageFormat mf = buildMessageFormat(message, locale);
             return formatWithNullDetection(mf, args);
         } catch (MissingResourceException e) {


### PR DESCRIPTION
Defend NPE if not ValueStack presented, for example non-struts request like static util method or backend thread.
reopen #35 