### PR TITLE
Make it easier to extend to use own ActionInvocation

### DIFF
--- a/core/src/main/java/com/opensymphony/xwork2/DefaultActionProxyFactory.java
+++ b/core/src/main/java/com/opensymphony/xwork2/DefaultActionProxyFactory.java
@@ -53,9 +53,13 @@ public class DefaultActionProxyFactory implements ActionProxyFactory {
 
     public ActionProxy createActionProxy(String namespace, String actionName, String methodName, Map<String, Object> extraContext, boolean executeResult, boolean cleanupContext) {
         
-        ActionInvocation inv = new DefaultActionInvocation(extraContext, true);
+        ActionInvocation inv = createActionInvocation(extraContext, true);
         container.inject(inv);
         return createActionProxy(inv, namespace, actionName, methodName, executeResult, cleanupContext);
+    }
+    
+    protected ActionInvocation createActionInvocation(Map<String, Object> extraContext, boolean pushAction) {
+        return DefaultActionInvocation(extraContext, pushAction);
     }
     
     public ActionProxy createActionProxy(ActionInvocation inv, String namespace, String actionName, boolean executeResult, boolean cleanupContext) {


### PR DESCRIPTION
I needed to extend DefaultActionProxyFactory to return my own ActionInvocation, but I had to override all of createActionProxy() to do so.  Seems like a safe change to break out the ActionInvocation creation to make it easier to just override that piece.