### PR TITLE
Make it easier to extend to override interceptor stack

### DIFF
--- a/core/src/main/java/com/opensymphony/xwork2/DefaultActionInvocation.java
+++ b/core/src/main/java/com/opensymphony/xwork2/DefaultActionInvocation.java
@@ -396,7 +396,11 @@ public class DefaultActionInvocation implements ActionInvocation {
         invocationContext = new ActionContext(contextMap);
         invocationContext.setName(proxy.getActionName());
 
-        // get a new List so we don't get problems with the iterator if someone changes the list
+        createInterceptors(proxy);
+    }
+
+    protected void createInterceptors(ActionProxy proxy) {
+        // Get a new List so we don't get problems with the iterator if someone changes the original list
         List<InterceptorMapping> interceptorList = new ArrayList<>(proxy.getConfig().getInterceptors());
         interceptors = interceptorList.iterator();
     }


### PR DESCRIPTION
Just as createAction is split out from init, it would be great to split out creating the interceptor iterator creation so it can be overridden without having to override all of init().  (Needed this to always prepend an i18n interceptor to all stacks).