### PR TITLE
fix for WW-4573

### DIFF
--- a/core/src/main/java/com/opensymphony/xwork2/util/CompoundRoot.java
+++ b/core/src/main/java/com/opensymphony/xwork2/util/CompoundRoot.java
@@ -15,8 +15,8 @@
  */
 package com.opensymphony.xwork2.util;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 
 /**
@@ -25,12 +25,14 @@ import java.util.List;
  * @author plightbo
  * @version $Revision$
  */
-public class CompoundRoot extends ArrayList {
+public class CompoundRoot extends CopyOnWriteArrayList<Object> {
+
+    private static final long serialVersionUID = 8563229069192473995L;
 
     public CompoundRoot() {
     }
 
-    public CompoundRoot(List list) {
+    public CompoundRoot(List<?> list) {
         super(list);
     }
 


### PR DESCRIPTION
NPE/ concurrent modification exception

using a CopyOnWriteArrayList. This is to keep Memory consistency on the
ValueStack.