### PR TITLE
make test passed for people not using GMT.

### DIFF
--- a/plugins/rest/src/test/java/org/apache/struts2/rest/DefaultHttpHeadersTest.java
+++ b/plugins/rest/src/test/java/org/apache/struts2/rest/DefaultHttpHeadersTest.java
@@ -27,6 +27,8 @@ import org.springframework.mock.web.MockHttpServletResponse;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
 
 import static javax.servlet.http.HttpServletResponse.*;
 
@@ -130,7 +132,7 @@ public class DefaultHttpHeadersTest extends TestCase {
         Date now = new Date();
         DefaultHttpHeaders headers = new DefaultHttpHeaders()
                 .lastModified(now);
-        mockRequest.addHeader("If-Modified-Since", new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz").format(now));
+        mockRequest.addHeader("If-Modified-Since", getGMTDateFormat().format(now));
         headers.apply(mockRequest, mockResponse, new Object());
 
         assertEquals(SC_NOT_MODIFIED, mockResponse.getStatus());
@@ -149,7 +151,7 @@ public class DefaultHttpHeadersTest extends TestCase {
     public void testLastModifiedSince() {
         Date now = new Date();
         DefaultHttpHeaders headers = new DefaultHttpHeaders().lastModified(now);
-        mockRequest.addHeader("If-Modified-Since", new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz").format(now));
+        mockRequest.addHeader("If-Modified-Since", getGMTDateFormat().format(now));
         headers.apply(mockRequest, mockResponse, new Object());
 
         assertEquals(SC_NOT_MODIFIED, mockResponse.getStatus());
@@ -158,7 +160,7 @@ public class DefaultHttpHeadersTest extends TestCase {
     public void testLastModifiedSinceIsOlder() {
         Date now = new Date();
         DefaultHttpHeaders headers = new DefaultHttpHeaders().lastModified(now);
-        mockRequest.addHeader("If-Modified-Since", new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz").format(new Date(now.getTime() - 1000 * 60 * 60)));
+        mockRequest.addHeader("If-Modified-Since", getGMTDateFormat().format(new Date(now.getTime() - 1000 * 60 * 60)));
         headers.apply(mockRequest, mockResponse, new Object());
 
         assertEquals(SC_NOT_MODIFIED, mockResponse.getStatus());
@@ -170,7 +172,7 @@ public class DefaultHttpHeadersTest extends TestCase {
                 .lastModified(now)
                 .withETag("asdf");
         mockRequest.addHeader("If-None-Match", "asdf");
-        mockRequest.addHeader("If-Modified-Since", new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz").format(now));
+        mockRequest.addHeader("If-Modified-Since", getGMTDateFormat().format(now));
         headers.apply(mockRequest, mockResponse, new Object());
 
         assertEquals(SC_NOT_MODIFIED, mockResponse.getStatus());
@@ -215,5 +217,11 @@ public class DefaultHttpHeadersTest extends TestCase {
         assertEquals(methods, mockResponse.getHeader(allow));
         assertEquals(SC_OK, mockResponse.getStatus());
 
+    }
+    
+    private SimpleDateFormat getGMTDateFormat() {
+        SimpleDateFormat format = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.US);
+        format.setTimeZone(TimeZone.getTimeZone("GMT"));
+        return format;
     }
 }


### PR DESCRIPTION
In DefaultHttpHeadersTest.java some tests fail when somebody's timezone is not GMT. So I add codes using GMT date format and US locale to ensure tests pass in anywhere.