### PR TITLE
patch ww-3266 getFieldValue() method of ValueStackDataSource uses getDescription() to get field value may not appropriate.

### DIFF
--- a/plugins/jasperreports/src/main/java/org/apache/struts2/views/jasperreports/ValueStackDataSource.java
+++ b/plugins/jasperreports/src/main/java/org/apache/struts2/views/jasperreports/ValueStackDataSource.java
@@ -92,12 +92,7 @@ public class ValueStackDataSource implements JRRewindableDataSource {
         //TODO: move the code to return a ValueStackDataSource to a seperate
         //      method when and if the JRDataSource interface is updated to support
         //      this.
-        String expression = field.getDescription();
-
-        if (expression == null) {
-            //Description is optional so use the field name as a default
-            expression = field.getName();
-        }
+        String expression = field.getName();
 
         Object value = valueStack.findValue(expression);
         LOG.debug("Field [{}] = [{}]", field.getName(), value);


### PR DESCRIPTION
patch ww-3266

getFieldValue() method of ValueStackDataSource uses getDescription() to get field value may not appropriate.

Reason:
In JasperReports, a description of a field is just like a documentation for this field. So it may not good to use it as expression