### PR TITLE
WW-4412  Context started without being closed

### DIFF
--- a/plugins/jasperreports/src/main/java/org/apache/struts2/views/jasperreports/JasperReportsResult.java
+++ b/plugins/jasperreports/src/main/java/org/apache/struts2/views/jasperreports/JasperReportsResult.java
@@ -386,7 +386,11 @@ public class JasperReportsResult extends StrutsResultSupport implements JasperRe
             LOG.error("Error producing {} report for uri {}", format, systemId, e);
             throw new ServletException(e.getMessage(), e);
         } finally {
-            conn.close();
+            try {
+                conn.close();
+            } catch (Exception e) {
+                LOG.warn("Could not close db connection properly", e);
+            }
         }
 
         response.setContentLength(output.size());

--- a/plugins/tiles3/src/main/java/org/apache/struts2/views/tiles/TilesResult.java
+++ b/plugins/tiles3/src/main/java/org/apache/struts2/views/tiles/TilesResult.java
@@ -70,6 +70,7 @@ public class TilesResult extends ServletDispatcherResult {
 
         container.startContext(servletRequest);
         container.render(location, servletRequest);
+        container.endContext(servletRequest);
     }
 
     protected TilesContainer initTilesContainer(ApplicationContext applicationContext, ServletRequest servletRequest) {


### PR DESCRIPTION
Patch   WW-4412

Context started without being closed

Now the context is closed after been used.