### PR TITLE
WW-4456 Got NPE when File Upload Limitation exceeds in portal env

### DIFF
--- a/core/src/main/java/org/apache/struts2/dispatcher/multipart/JakartaMultiPartRequest.java
+++ b/core/src/main/java/org/apache/struts2/dispatcher/multipart/JakartaMultiPartRequest.java
@@ -83,9 +83,17 @@ public class JakartaMultiPartRequest implements MultiPartRequest {
         try {
             setLocale(request);
             processUpload(request, saveDir);
-        } catch (FileUploadBase.SizeLimitExceededException e) {
+        } catch (FileUploadException e) {
             LOG.warn("Request exceeded size limit!", e);
-            String errorMessage = buildErrorMessage(e, new Object[]{e.getPermittedSize(), e.getActualSize()});
+            String errorMessage = null;
+            
+            if(e instanceof FileUploadBase.SizeLimitExceededException) {
+                FileUploadBase.SizeLimitExceededException ex = (FileUploadBase.SizeLimitExceededException) e;
+                errorMessage = buildErrorMessage(e, new Object[]{ex.getPermittedSize(), ex.getActualSize()});
+            } else {
+                errorMessage = buildErrorMessage(e, new Object[]{});
+            }
+            
             if (!errors.contains(errorMessage)) {
                 errors.add(errorMessage);
             }


### PR DESCRIPTION


HI Lukasz,

This is a proposal to fix WW-4456 - Got NPE when File Upload Limitation exceeds in portal env.

We should catch in any case a FileUploadException, then try to cast down if we want any info about the exception. Valid subtype of FileUploadException:
InvalidContentTypeException
IOFileUploadException
SizeLimitExceededException
FileSizeLimitExceededException

I couldn't get the complete test on a running test env, because I had issues getting the logging to work.

But it seems to works.
