### PR TITLE
WW-4589 do not overwrite explicit method name

### DIFF
--- a/plugins/rest/src/main/java/org/apache/struts2/rest/RestActionMapper.java
+++ b/plugins/rest/src/main/java/org/apache/struts2/rest/RestActionMapper.java
@@ -224,7 +224,8 @@ public class RestActionMapper extends DefaultActionMapper {
 
                 // fun trickery to parse 'actionName/id/methodName' in the case of 'animals/dog/edit'
                 int prevSlashPos = fullName.lastIndexOf('/', lastSlashPos - 1);
-                if (prevSlashPos > -1) {
+                //WW-4589 do not overwrite explicit method name
+                if (prevSlashPos > -1 && mapping.getMethod() == null) {
                     mapping.setMethod(fullName.substring(lastSlashPos + 1));
                     fullName = fullName.substring(0, lastSlashPos);
                     lastSlashPos = prevSlashPos;

--- a/plugins/rest/src/test/java/org/apache/struts2/rest/RestActionMapperTest.java
+++ b/plugins/rest/src/test/java/org/apache/struts2/rest/RestActionMapperTest.java
@@ -207,6 +207,45 @@ public class RestActionMapperTest extends TestCase {
         assertEquals("fido", ((String[]) mapping.getParams().get("id"))[0]);
         assertEquals("update", mapping.getMethod());
     }
+	
+    public void testMappingWithMethodAndId() throws Exception {
+        req.setRequestURI("/myapp/animals/dog/fido/test/some-id!create;jsessionid=29fefpv23do1g");
+        req.setServletPath("/animals/dog/fido/test/some-id");
+        req.setMethod("GET");
+        mapper.setAllowDynamicMethodCalls("true");
+        ActionMapping mapping = mapper.getMapping(req, configManager);
+
+        assertEquals("/animals", mapping.getNamespace());
+        assertEquals("dog/fido/test", mapping.getName());
+        assertEquals("some-id", ((String[]) mapping.getParams().get("id"))[0]);
+        assertEquals("create", mapping.getMethod());
+    }
+
+    public void testMappingForStaticFiles() throws Exception {
+        req.setRequestURI("/myApp/custom/menu/Yosemite/Vernal_Fall/Vernal_Fall_Image!iframe");
+        req.setServletPath("/custom/menu/Yosemite/Vernal_Fall/Vernal_Fall_Image");
+        req.setMethod("GET");
+        mapper.setAllowDynamicMethodCalls("true");
+        final ActionMapping mapping = mapper.getMapping(req, configManager);
+
+        assertEquals("", mapping.getNamespace());
+        assertEquals("custom/menu/Yosemite/Vernal_Fall", mapping.getName());
+        assertEquals("Vernal_Fall_Image", ((String[]) mapping.getParams().get("id"))[0]);
+        assertEquals("iframe", mapping.getMethod());
+    }
+
+    public void testMappingForStaticFilesWithJsessionId() throws Exception {
+        req.setRequestURI("/myApp/custom/menu/Yosemite/Vernal_Fall/Vernal_Fall_Image!iframe;jsessionid=29fefpv23do1g");
+        req.setServletPath("/custom/menu/Yosemite/Vernal_Fall/Vernal_Fall_Image");
+        req.setMethod("GET");
+        mapper.setAllowDynamicMethodCalls("true");
+        final ActionMapping mapping = mapper.getMapping(req, configManager);
+
+        assertEquals("", mapping.getNamespace());
+        assertEquals("custom/menu/Yosemite/Vernal_Fall", mapping.getName());
+        assertEquals("Vernal_Fall_Image", ((String[]) mapping.getParams().get("id"))[0]);
+        assertEquals("iframe", mapping.getMethod());
+    }	
 
     public void testParseNameAndNamespace() {
         tryUri("/foo/23", "", "foo/23");


### PR DESCRIPTION
Lukasz,

here is a proposed fix for WW-4589.  This makes sure a url specified method name is not overwritten by an implied method name.  It passes the unit tests that I have added