### PR TITLE
    WW-4610  ServletActionContext.getRequest() doesn't return the MultiPartRequestWrapper (or StrutsRequestWrapper) when using StrutsPrepareFilter

### DIFF
--- a/core/src/main/java/org/apache/struts2/dispatcher/PrepareOperations.java
+++ b/core/src/main/java/org/apache/struts2/dispatcher/PrepareOperations.java
@@ -26,6 +26,7 @@ import com.opensymphony.xwork2.util.ValueStackFactory;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.struts2.RequestUtils;
+import org.apache.struts2.ServletActionContext;
 import org.apache.struts2.StrutsException;
 import org.apache.struts2.dispatcher.mapper.ActionMapper;
 import org.apache.struts2.dispatcher.mapper.ActionMapping;
@@ -145,6 +146,7 @@ public class PrepareOperations {
             // Wrap request first, just in case it is multipart/form-data
             // parameters might not be accessible through before encoding (ww-1278)
             request = dispatcher.wrapRequest(request);
+            ServletActionContext.setRequest(request);
         } catch (IOException e) {
             throw new ServletException("Could not wrap servlet request with MultipartRequestWrapper!", e);
         }


### PR DESCRIPTION
Now StrutsPrepareFilter set the ServletActionContext with the proper MultiPartRequestWrapper (or StrutsRequestWrapper) 