### PR TITLE
add allowed methods to handleUnknownAction

### DIFF
--- a/core/src/main/java/com/opensymphony/xwork2/config/entities/PackageConfig.java
+++ b/core/src/main/java/com/opensymphony/xwork2/config/entities/PackageConfig.java
@@ -346,6 +346,13 @@ public class PackageConfig extends Located implements Comparable, Serializable, 
         return globalExceptionMappingConfigs;
     }
 
+    /**
+     * gets the GlobalAllowedMethods local to this package
+     *
+     * @return a Set of method names allowed to be executed if strict method invocation is enabled
+     */
+    public Set<String> getGlobalAllowedMethods() { return globalAllowedMethods; }
+
     public boolean isStrictMethodInvocation() {
         return strictMethodInvocation;
     }

--- a/plugins/convention/src/main/java/org/apache/struts2/convention/ConventionUnknownHandler.java
+++ b/plugins/convention/src/main/java/org/apache/struts2/convention/ConventionUnknownHandler.java
@@ -221,7 +221,7 @@ public class ConventionUnknownHandler implements UnknownHandler {
         return new ActionConfig.Builder(defaultParentPackageName, "execute", ActionSupport.class.getName()).
                 addInterceptors(interceptors).
                 addResultConfigs(results).
-                addAllowedMethod(allowedMethods).
+                addAllowedMethod(pkg.getGlobalAllowedMethods()).
                 build();
     }
 

--- a/plugins/convention/src/main/java/org/apache/struts2/convention/ConventionUnknownHandler.java
+++ b/plugins/convention/src/main/java/org/apache/struts2/convention/ConventionUnknownHandler.java
@@ -106,7 +106,7 @@ public class ConventionUnknownHandler implements UnknownHandler {
 
         this.redirectToSlash = Boolean.parseBoolean(redirectToSlash);
 
-        allowedMethods = TextParseUtil.commaDelimitedStringToSet("execute,input,back,cancel,browse");
+        allowedMethods = TextParseUtil.commaDelimitedStringToSet("execute,input,back,cancel,browse,index");
     }
 
     public ActionConfig handleUnknownAction(String namespace, String actionName)
@@ -219,7 +219,10 @@ public class ConventionUnknownHandler implements UnknownHandler {
         results.put(Action.SUCCESS, config);
 
         return new ActionConfig.Builder(defaultParentPackageName, "execute", ActionSupport.class.getName()).
-                addInterceptors(interceptors).addResultConfigs(results).build();
+                addInterceptors(interceptors).
+                addResultConfigs(results).
+                addAllowedMethod(allowedMethods).
+                build();
     }
 
     private Result scanResultsByExtension(String ns, String actionName, String pathPrefix,


### PR DESCRIPTION
Prior to strict-method-invocation, the convention plugin would allow for executing results (JSP) without an associated Action via the ConventionUnknownHandler.handleUnknownAction method.  This continues to work with SMI disabled but when enabled the allowedMethods list in the ActionConfig does not get populated which causes a 404.  There was already a member Set hard coded to the most common methods to which I added "index" used by the REST plugin.  

Ideally, line 224 would use the globalAllowedMethods set from the PackageConfig instead of a hard coded list but there is currently no associated getter method and I figured it would be better to discuss adding that functionality via the PR.
