### PR TITLE
Change to the documentation

### DIFF
--- a/core/src/main/java/com/opensymphony/xwork2/interceptor/DefaultWorkflowInterceptor.java
+++ b/core/src/main/java/com/opensymphony/xwork2/interceptor/DefaultWorkflowInterceptor.java
@@ -27,7 +27,8 @@ import java.lang.reflect.Method;
 /**
  * <!-- START SNIPPET: description -->
  * <p>
- * An interceptor that makes sure there are not validation errors before allowing the interceptor chain to continue.
+ * An interceptor that makes sure there are not validation, conversion or action errors before allowing the interceptor chain to continue. 
+ * If a single FieldError or ActionError (including the ones replicated by the Message Store Interceptor in a redirection) is found, the INPUT result will be triggered.
  * <b>This interceptor does not perform any validation</b>.
  * </p>
  *


### PR DESCRIPTION
To make it clear that the behavior is not limited to validation errors, but also extendend to conversion errors and (most important) to action errors, that will be stored and retrieved by the Message Store Interceptor during a redirection, and that will generate an undesired result.