### PR TITLE
Fix freemaker error in checkbox.ftl of css_xhtml template 

### DIFF
--- a/core/src/main/resources/template/css_xhtml/checkbox.ftl
+++ b/core/src/main/resources/template/css_xhtml/checkbox.ftl
@@ -46,7 +46,7 @@ lables
 <#elseif parameters.labelposition??>
 <#assign labelpos = parameters.labelposition/>
 </#if>
-<#if labelpos!"" == 'left'>
+<#if (labelpos!"") == 'left'>
 <span <#rt/>
 <#if parameters.id??>id="wwlbl_${parameters.id}"<#rt/></#if> class="wwlbl">
 <label<#t/>


### PR DESCRIPTION
Fix freemaker error when set label position to left on a checkbox tag of a form (Missing brackets).