### PR TITLE
[WW-4105] OgnlUtil improved in order to only setting properties defined

### DIFF
--- a/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlReflectionProvider.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlReflectionProvider.java
@@ -70,7 +70,12 @@ public class OgnlReflectionProvider implements ReflectionProvider {
 
     public void copy(Object from, Object to, Map<String, Object> context,
             Collection<String> exclusions, Collection<String> inclusions) {
-        ognlUtil.copy(from, to, context, exclusions, inclusions);
+        copy(from, to, context, exclusions, inclusions, null);
+    }
+
+    public void copy(Object from, Object to, Map<String, Object> context,
+            Collection<String> exclusions, Collection<String> inclusions, Class<?> editable) {
+        ognlUtil.copy(from, to, context, exclusions, inclusions, editable);
     }
 
     public Object getRealTarget(String property, Map<String, Object> context, Object root)

--- a/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlUtil.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlUtil.java
@@ -415,7 +415,7 @@ public class OgnlUtil {
             }
         });
     }
-    
+
     private void checkEnableEvalExpression(Object tree, Map<String, Object> context) throws OgnlException {
         if (!enableEvalExpression && isEvalExpression(tree, context)) {
             throw new OgnlException("Eval expressions/chained expressions have been disabled!");
@@ -441,9 +441,37 @@ public class OgnlUtil {
      *                   note if exclusions AND inclusions are supplied and not null nothing will get copied.
      */
     public void copy(final Object from, final Object to, final Map<String, Object> context, Collection<String> exclusions, Collection<String> inclusions) {
+        copy(from, to, context, exclusions, inclusions, null);
+    }
+
+    /**
+     * Copies the properties in the object "from" and sets them in the object "to"
+     * only setting properties defined in the given "editable" class (or interface)
+     * using specified type converter, or {@link com.opensymphony.xwork2.conversion.impl.XWorkConverter} if none
+     * is specified.
+     *
+     * @param from       the source object
+     * @param to         the target object
+     * @param context    the action context we're running under
+     * @param exclusions collection of method names to excluded from copying ( can be null)
+     * @param inclusions collection of method names to included copying  (can be null)
+     *                   note if exclusions AND inclusions are supplied and not null nothing will get copied.
+     * @param editable the class (or interface) to restrict property setting to
+     */
+    public void copy(final Object from, final Object to, final Map<String, Object> context, Collection<String> exclusions, Collection<String> inclusions, Class<?> editable) {
         if (from == null || to == null) {
             LOG.warn("Attempting to copy from or to a null source. This is illegal and is bein skipped. This may be due to an error in an OGNL expression, action chaining, or some other event.");
             return;
+        }
+
+        Class<?> toClass = to.getClass();
+        if (editable != null) {
+            if (!editable.isInstance(to)) {
+                LOG.warn("Target class [" + to.getClass().getName() +
+                        "] not assignable to Editable class [" + editable.getName() + "]");
+                return;
+            }
+            toClass = editable;
         }
 
         TypeConverter converter = getTypeConverterFromContext(context);
@@ -457,7 +485,7 @@ public class OgnlUtil {
 
         try {
             fromPds = getPropertyDescriptors(from);
-            toPds = getPropertyDescriptors(to);
+            toPds = getPropertyDescriptors(toClass);
         } catch (IntrospectionException e) {
             LOG.error("An error occurred", e);
             return;
@@ -629,7 +657,7 @@ public class OgnlUtil {
         } else {
             throw new IllegalArgumentException("Cannot find type converter in context map");
         }
-        */
+         */
         return defaultConverter;
     }
 

--- a/core/src/main/java/com/opensymphony/xwork2/util/reflection/ReflectionProvider.java
+++ b/core/src/main/java/com/opensymphony/xwork2/util/reflection/ReflectionProvider.java
@@ -72,6 +72,22 @@ public interface ReflectionProvider {
      *                   note if exclusions AND inclusions are supplied and not null nothing will get copied.
      */
     void copy(Object from, Object to, Map<String, Object> context, Collection<String> exclusions, Collection<String> inclusions);
+
+    /**
+     * Copies the properties in the object "from" and sets them in the object "to"
+     * only setting properties defined in the given "editable" class (or interface)
+     * using specified type converter, or {@link com.opensymphony.xwork2.conversion.impl.XWorkConverter} if none
+     * is specified.
+     *
+     * @param from       the source object
+     * @param to         the target object
+     * @param context    the action context we're running under
+     * @param exclusions collection of method names to excluded from copying ( can be null)
+     * @param inclusions collection of method names to included copying  (can be null)
+     *                   note if exclusions AND inclusions are supplied and not null nothing will get copied.
+	 * @param editable the class (or interface) to restrict property setting to
+     */
+    void copy(Object from, Object to, Map<String, Object> context, Collection<String> exclusions, Collection<String> inclusions, Class<?> editable);
     
     /**
      * Looks for the real target with the specified property given a root Object which may be a

--- a/core/src/test/java/com/opensymphony/xwork2/TestSubBean.java
+++ b/core/src/test/java/com/opensymphony/xwork2/TestSubBean.java
@@ -1,0 +1,14 @@
+package com.opensymphony.xwork2;
+
+public class TestSubBean extends TestBean {
+
+    private String issueId;
+
+    public String getIssueId() {
+        return issueId;
+    }
+
+    public void setIssueId(String issueId) {
+        this.issueId = issueId;
+    }
+}

--- a/core/src/test/java/com/opensymphony/xwork2/interceptor/ChainingInterceptorTest.java
+++ b/core/src/test/java/com/opensymphony/xwork2/interceptor/ChainingInterceptorTest.java
@@ -17,7 +17,6 @@ package com.opensymphony.xwork2.interceptor;
 
 import com.mockobjects.dynamic.Mock;
 import com.opensymphony.xwork2.*;
-import com.opensymphony.xwork2.config.entities.ActionConfig;
 import com.opensymphony.xwork2.util.ValueStack;
 
 import java.util.*;
@@ -34,15 +33,11 @@ public class ChainingInterceptorTest extends XWorkTestCase {
     ChainingInterceptor interceptor;
     Mock mockInvocation;
     ValueStack stack;
-    ActionConfig config;
-    Mock proxy;
 
 
     public void testActionErrorsCanBeAddedAfterChain() throws Exception {
         SimpleAction action1 = new SimpleAction();
         SimpleAction action2 = new SimpleAction();
-        config = new ActionConfig.Builder("", "action", action1.getClass().getName()).build();
-        proxy.matchAndReturn("getConfig", config);
         action1.addActionError("foo");
         mockInvocation.matchAndReturn("getAction", action2);
         stack.push(action1);
@@ -62,8 +57,6 @@ public class ChainingInterceptorTest extends XWorkTestCase {
     public void testActionErrorsNotCopiedAfterChain() throws Exception {
         SimpleAction action1 = new SimpleAction();
         SimpleAction action2 = new SimpleAction();
-        config = new ActionConfig.Builder("", "action", action1.getClass().getName()).build();
-        proxy.matchAndReturn("getConfig", config);
         action1.addActionError("foo");
         mockInvocation.matchAndReturn("getAction", action2);
         stack.push(action1);
@@ -82,8 +75,6 @@ public class ChainingInterceptorTest extends XWorkTestCase {
     public void testPropertiesChained() throws Exception {
         TestBean bean = new TestBean();
         TestBeanAction action = new TestBeanAction();
-        config = new ActionConfig.Builder("", "action", bean.getClass().getName()).build();
-        proxy.matchAndReturn("getConfig", config);
         mockInvocation.matchAndReturn("getAction", action);
         bean.setBirth(new Date());
         bean.setName("foo");
@@ -103,8 +94,6 @@ public class ChainingInterceptorTest extends XWorkTestCase {
     public void testExcludesPropertiesChained() throws Exception {
         TestBean bean = new TestBean();
         TestBeanAction action = new TestBeanAction();
-        config = new ActionConfig.Builder("", "action", bean.getClass().getName()).build();
-        proxy.matchAndReturn("getConfig", config);
         mockInvocation.matchAndReturn("getAction", action);
         bean.setBirth(new Date());
         bean.setName("foo");
@@ -128,8 +117,6 @@ public class ChainingInterceptorTest extends XWorkTestCase {
     public void testTwoExcludesPropertiesChained() throws Exception {
         TestBean bean = new TestBean();
         TestBeanAction action = new TestBeanAction();
-        config = new ActionConfig.Builder("", "action", bean.getClass().getName()).build();
-        proxy.matchAndReturn("getConfig", config);
         mockInvocation.matchAndReturn("getAction", action);
         bean.setBirth(new Date());
         bean.setName("foo");
@@ -159,8 +146,6 @@ public class ChainingInterceptorTest extends XWorkTestCase {
     public void testEditablePropertiesChained() throws Exception {
         TestSubBean subbean = new TestSubBean();
         TestSubBeanAction action = new TestSubBeanAction();
-        config = new ActionConfig.Builder("", "action", TestBean.class.getName()).build();
-        proxy.matchAndReturn("getConfig", config);
         mockInvocation.matchAndReturn("getAction", action);
         subbean.setBirth(new Date());
         subbean.setName("foo");
@@ -169,7 +154,9 @@ public class ChainingInterceptorTest extends XWorkTestCase {
         stack.push(subbean);
         stack.push(action);
 
+        interceptor.setEditableClass(TestBean.class.getName());
         interceptor.intercept(invocation);
+        interceptor.setEditableClass(null);
         assertEquals(subbean.getBirth(), action.getBirth());
         assertEquals(subbean.getName(), action.getName());
         assertEquals(subbean.getCount(), action.getCount());
@@ -186,8 +173,6 @@ public class ChainingInterceptorTest extends XWorkTestCase {
         mockInvocation.expectAndReturn("invoke", Action.SUCCESS);
         mockInvocation.expectAndReturn("getInvocationContext", new ActionContext(new HashMap<String, Object>()));
         mockInvocation.expectAndReturn("getResult", new ActionChainResult());
-        proxy = new Mock(ActionProxy.class);
-        mockInvocation.matchAndReturn("getProxy", (ActionProxy) proxy.proxy());
         invocation = (ActionInvocation) mockInvocation.proxy();
         interceptor = new ChainingInterceptor();
         container.inject(interceptor);

--- a/core/src/test/java/com/opensymphony/xwork2/spring/ActionsFromSpringTest.java
+++ b/core/src/test/java/com/opensymphony/xwork2/spring/ActionsFromSpringTest.java
@@ -77,4 +77,20 @@ public class ActionsFromSpringTest extends XWorkTestCase {
     	        assertTrue(springResult.isInitialize());
     	        assertNotNull(springResult.getStringParameter());
     }
+
+    public void testChainingAOPedActions() throws Exception {
+        ActionProxy proxy = actionProxyFactory.createActionProxy(null, "chainedAOPedTestBeanAction", null, null);
+
+        proxy.execute();              
+
+        TestSubBean chaintoAOPedAction = (TestSubBean) appContext.getBean("pointcutted-test-sub-bean");
+        TestSubBean aspectState = (TestSubBean) appContext.getBean("aspected-test-sub-bean");
+
+        assertEquals(1, chaintoAOPedAction.getCount()); //check if chain
+        assertEquals("WW-4105", chaintoAOPedAction.getName());
+        assertNotNull(aspectState.getIssueId());   //and AOP
+        assertNotNull(aspectState.getName());
+        assertEquals(aspectState.getName(), aspectState.getIssueId());
+        assertEquals("WW-4105", aspectState.getIssueId());   //work together without any problem
+    }
 }

--- a/core/src/test/resources/com/opensymphony/xwork2/spring/actionContext-spring.xml
+++ b/core/src/test/resources/com/opensymphony/xwork2/spring/actionContext-spring.xml
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aop="http://www.springframework.org/schema/aop"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-          http://www.springframework.org/schema/beans/spring-beans.xsd">
+          http://www.springframework.org/schema/beans/spring-beans.xsd
+          http://www.springframework.org/schema/aop
+          http://www.springframework.org/schema/aop/spring-aop.xsd">
 
 	<bean id="simple-action" class="com.opensymphony.xwork2.SimpleAction" scope="prototype"/>
 
@@ -40,4 +43,25 @@
     <bean id="springResult" class="com.opensymphony.xwork2.spring.SpringResult" init-method="initialize">
 		<property name="stringParameter" value="my string"/>
 	</bean>
+
+    <bean id="pointcutted-test-bean" class="com.opensymphony.xwork2.TestBean">
+        <property name="name"><value>WW-4105</value></property>
+        <property name="count"><value>1</value></property>
+    </bean>
+    <bean id="pointcutted-test-sub-bean" class="com.opensymphony.xwork2.TestSubBean">
+        <property name="issueId"><value>WW-4105</value></property>
+    </bean>
+    <bean id="aspected-test-sub-bean" class="com.opensymphony.xwork2.TestSubBean" />
+    <aop:config>
+        <aop:aspect id="myAspect" ref="aspected-test-sub-bean">
+            <aop:pointcut id="testBeanGetName"
+                expression="execution(String com.opensymphony.xwork2.TestBean.getName()) and bean(pointcutted-test-bean)" />
+            <aop:after-returning pointcut-ref="testBeanGetName"
+                method="setIssueId" returning="issueId" />
+            <aop:pointcut id="testSubBeanGetIssueId"
+                expression="execution(String com.opensymphony.xwork2.TestSubBean.getIssueId()) and bean(pointcutted-test-sub-bean)" />
+            <aop:after-returning pointcut-ref="testSubBeanGetIssueId"
+                method="setName" returning="name" />
+        </aop:aspect>
+    </aop:config>
 </beans>

--- a/core/src/test/resources/com/opensymphony/xwork2/spring/actionContext-xwork.xml
+++ b/core/src/test/resources/com/opensymphony/xwork2/spring/actionContext-xwork.xml
@@ -6,7 +6,14 @@
         <result-types>
             <result-type name="null" class="com.opensymphony.xwork2.mock.MockResult" default="true"/>
             <result-type name="springResult" class="springResult" />
+            <result-type name="chain"
+                class="com.opensymphony.xwork2.ActionChainResult" />
         </result-types>
+
+        <interceptors>
+            <interceptor name="chain"
+                class="com.opensymphony.xwork2.interceptor.ChainingInterceptor"></interceptor>
+        </interceptors>
 
 		<action name="simpleAction" class="simple-action"/>
 
@@ -19,5 +26,20 @@
         <action name="simpleActionSpringResult" class="simple-action">
 			<result name="error" type="springResult"/>
 		</action>
+
+        <action name="chainedAOPedTestBeanAction" class="pointcutted-test-bean"
+            method="getName">
+            <result name="WW-4105" type="chain">
+                <param name="actionName">chaintoAOPedTestSubBeanAction</param>
+            </result>
+        </action>
+        <action name="chaintoAOPedTestSubBeanAction" class="pointcutted-test-sub-bean"
+            method="getIssueId">
+            <interceptor-ref name="chain">
+                <!-- without following line, this chain my break AOP -->
+                <param name="editableClass">com.opensymphony.xwork2.TestBean</param>
+            </interceptor-ref>
+            <result name="WW-4105" type="null" />
+        </action>
     </package>
 </xwork>


### PR DESCRIPTION
With these changes, [OgnlUtil](https://github.com/apache/struts/blob/master/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlUtil.java) can set only properties defined in the given "editable" class (or interface) which can be used e.g. in chaining interceptor to skip proxy properties of proxied chained actions, that avoid breaking upper level technologies like Spring Proxying.

ChainingInterceptor equipped with an optional param (editableClass) which user can set to a custom class (or interface) fully qualified name to restrict property setting like below:
```xml
<interceptor-ref name="chainStack">
	<param name="chain.editableClass">me.myname.myactions.MyClassOrInterface</param>
</interceptor-ref>
```
**It is useful when chained actions are unknown proxies created by an unknown object factory and we do not want to copy upper level proxy information which usually breaks their functionality** 👌 