### PR TITLE
WW-4757: LocaleProvider factory

### DIFF
--- a/core/src/main/java/com/opensymphony/xwork2/ActionSupport.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ActionSupport.java
@@ -19,7 +19,6 @@ import com.opensymphony.xwork2.inject.Container;
 import com.opensymphony.xwork2.inject.Inject;
 import com.opensymphony.xwork2.interceptor.ValidationAware;
 import com.opensymphony.xwork2.util.ValueStack;
-import net.sf.cglib.core.Local;
 
 import java.io.Serializable;
 import java.util.*;

--- a/core/src/main/java/com/opensymphony/xwork2/ActionSupport.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ActionSupport.java
@@ -19,6 +19,7 @@ import com.opensymphony.xwork2.inject.Container;
 import com.opensymphony.xwork2.inject.Inject;
 import com.opensymphony.xwork2.interceptor.ValidationAware;
 import com.opensymphony.xwork2.util.ValueStack;
+import net.sf.cglib.core.Local;
 
 import java.io.Serializable;
 import java.util.*;
@@ -32,6 +33,7 @@ public class ActionSupport implements Action, Validateable, ValidationAware, Tex
     private final ValidationAwareSupport validationAware = new ValidationAwareSupport();
 
     private transient TextProvider textProvider;
+    private transient LocaleProvider localeProvider;
 
     protected Container container;
 
@@ -61,17 +63,17 @@ public class ActionSupport implements Action, Validateable, ValidationAware, Tex
 
     @Override
     public Locale getLocale() {
-        return container.getInstance(LocaleProvider.class).getLocale();
+        return getLocaleProvider().getLocale();
     }
 
     @Override
     public boolean isValidLocaleString(String localeStr) {
-        return container.getInstance(LocaleProvider.class).isValidLocaleString(localeStr);
+        return getLocaleProvider().isValidLocaleString(localeStr);
     }
 
     @Override
     public boolean isValidLocale(Locale locale) {
-        return container.getInstance(LocaleProvider.class).isValidLocale(locale);
+        return getLocaleProvider().isValidLocale(locale);
     }
 
     public boolean hasKey(String key) {
@@ -272,12 +274,20 @@ public class ActionSupport implements Action, Validateable, ValidationAware, Tex
      *
      * @return reference to field with TextProvider
      */
-    private TextProvider getTextProvider() {
+    protected TextProvider getTextProvider() {
         if (textProvider == null) {
             TextProviderFactory tpf = container.inject(TextProviderFactory.class);
             textProvider = tpf.createInstance(getClass());
         }
         return textProvider;
+    }
+
+    protected LocaleProvider getLocaleProvider() {
+        if (localeProvider == null) {
+            LocaleProviderFactory localeProviderFactory = container.getInstance(LocaleProviderFactory.class);
+            localeProvider = localeProviderFactory.createLocaleProvider();
+        }
+        return localeProvider;
     }
 
     @Inject

--- a/core/src/main/java/com/opensymphony/xwork2/DefaultLocaleProvider.java
+++ b/core/src/main/java/com/opensymphony/xwork2/DefaultLocaleProvider.java
@@ -14,6 +14,7 @@ public class DefaultLocaleProvider implements LocaleProvider {
 
     private final static Logger LOG = LogManager.getLogger(DefaultLocaleProvider.class);
 
+    @Override
     public Locale getLocale() {
         ActionContext ctx = ActionContext.getContext();
         if (ctx != null) {

--- a/core/src/main/java/com/opensymphony/xwork2/DefaultLocaleProviderFactory.java
+++ b/core/src/main/java/com/opensymphony/xwork2/DefaultLocaleProviderFactory.java
@@ -1,0 +1,10 @@
+package com.opensymphony.xwork2;
+
+public class DefaultLocaleProviderFactory implements LocaleProviderFactory {
+
+    @Override
+    public LocaleProvider createLocaleProvider() {
+        return new DefaultLocaleProvider();
+    }
+
+}

--- a/core/src/main/java/com/opensymphony/xwork2/LocaleProviderFactory.java
+++ b/core/src/main/java/com/opensymphony/xwork2/LocaleProviderFactory.java
@@ -23,9 +23,9 @@ package com.opensymphony.xwork2;
 public interface LocaleProviderFactory {
 
     /**
-     * Gets the provided locale.
+     * Create a new instance of {@link LocaleProvider}.
      *
-     * @return the locale.
+     * @return the localeProvider.
      */
     LocaleProvider createLocaleProvider();
 

--- a/core/src/main/java/com/opensymphony/xwork2/LocaleProviderFactory.java
+++ b/core/src/main/java/com/opensymphony/xwork2/LocaleProviderFactory.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2002-2006,2009 The Apache Software Foundation.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.opensymphony.xwork2;
+
+/**
+ * Allows delegate creation of {@link LocaleProvider} to another implementation provided
+ * by a user. It also allows avoid problems with too many dependencies as {@link LocaleProvider}
+ * is implemented by the {@link ActionSupport} which can be defined as a bean in Spring.
+ */
+public interface LocaleProviderFactory {
+
+    /**
+     * Gets the provided locale.
+     *
+     * @return the locale.
+     */
+    LocaleProvider createLocaleProvider();
+
+}

--- a/core/src/main/java/com/opensymphony/xwork2/TextProviderFactory.java
+++ b/core/src/main/java/com/opensymphony/xwork2/TextProviderFactory.java
@@ -28,7 +28,7 @@ import java.util.ResourceBundle;
 public class TextProviderFactory {
 
     private TextProvider textProvider;
-    private LocaleProvider localeProvider;
+    private LocaleProviderFactory localeProviderFactory;
     private LocalizedTextProvider localizedTextProvider;
 
     @Inject
@@ -37,8 +37,8 @@ public class TextProviderFactory {
     }
 
     @Inject
-    public void setLocaleProvider(LocaleProvider localeProvider) {
-        this.localeProvider = localeProvider;
+    public void setLocaleProviderFactory(LocaleProviderFactory localeProviderFactory) {
+        this.localeProviderFactory = localeProviderFactory;
     }
 
     @Inject
@@ -50,7 +50,7 @@ public class TextProviderFactory {
         TextProvider instance = getTextProvider(clazz);
         if (instance instanceof ResourceBundleTextProvider) {
             ((ResourceBundleTextProvider) instance).setClazz(clazz);
-            ((ResourceBundleTextProvider) instance).setLocaleProvider(localeProvider);
+            ((ResourceBundleTextProvider) instance).setLocaleProvider(localeProviderFactory.createLocaleProvider());
         }
         return instance;
     }
@@ -59,14 +59,14 @@ public class TextProviderFactory {
         TextProvider instance = getTextProvider(bundle);
         if (instance instanceof ResourceBundleTextProvider) {
             ((ResourceBundleTextProvider) instance).setBundle(bundle);
-            ((ResourceBundleTextProvider) instance).setLocaleProvider(localeProvider);
+            ((ResourceBundleTextProvider) instance).setLocaleProvider(localeProviderFactory.createLocaleProvider());
         }
         return instance;
     }
 
     protected TextProvider getTextProvider(Class clazz) {
         if (this.textProvider == null) {
-            return new TextProviderSupport(clazz, localeProvider, localizedTextProvider);
+            return new TextProviderSupport(clazz, localeProviderFactory.createLocaleProvider(), localizedTextProvider);
         } else {
             return textProvider;
         }
@@ -74,7 +74,7 @@ public class TextProviderFactory {
 
     private TextProvider getTextProvider(ResourceBundle bundle) {
         if (this.textProvider == null) {
-            return new TextProviderSupport(bundle, localeProvider, localizedTextProvider);
+            return new TextProviderSupport(bundle, localeProviderFactory.createLocaleProvider(), localizedTextProvider);
         }
         return textProvider;
     }

--- a/core/src/main/java/com/opensymphony/xwork2/TextProviderSupport.java
+++ b/core/src/main/java/com/opensymphony/xwork2/TextProviderSupport.java
@@ -67,6 +67,7 @@ public class TextProviderSupport implements ResourceBundleTextProvider {
     /**
      * @param bundle the resource bundle.
      */
+    @Override
     public void setBundle(ResourceBundle bundle) {
         this.bundle = bundle;
     }
@@ -74,17 +75,22 @@ public class TextProviderSupport implements ResourceBundleTextProvider {
     /**
      * @param clazz a clazz to use for reading the resource bundle.
      */
+    @Override
     public void setClazz(Class clazz) {
         this.clazz = clazz;
     }
 
-
     /**
      * @param localeProvider a locale provider.
      */
-    @Inject
+    @Override
     public void setLocaleProvider(LocaleProvider localeProvider) {
         this.localeProvider = localeProvider;
+    }
+
+    @Inject
+    public void setLocaleProviderFactory(LocaleProviderFactory localeProviderFactory) {
+        this.localeProvider = localeProviderFactory.createLocaleProvider();
     }
 
     @Inject

--- a/core/src/main/java/com/opensymphony/xwork2/config/impl/DefaultConfiguration.java
+++ b/core/src/main/java/com/opensymphony/xwork2/config/impl/DefaultConfiguration.java
@@ -264,7 +264,7 @@ public class DefaultConfiguration implements Configuration {
         builder.factory(TextParser.class, OgnlTextParser.class, Scope.SINGLETON);
         builder.factory(TextProvider.class, "system", DefaultTextProvider.class, Scope.SINGLETON);
         builder.factory(TextProvider.class, TextProviderSupport.class, Scope.SINGLETON);
-        builder.factory(LocaleProvider.class, DefaultLocaleProvider.class, Scope.SINGLETON);
+        builder.factory(LocaleProviderFactory.class, DefaultLocaleProviderFactory.class, Scope.SINGLETON);
 
         builder.factory(ObjectTypeDeterminer.class, DefaultObjectTypeDeterminer.class, Scope.SINGLETON);
         builder.factory(PropertyAccessor.class, CompoundRoot.class.getName(), CompoundRootAccessor.class, Scope.SINGLETON);

--- a/core/src/main/java/com/opensymphony/xwork2/config/providers/XWorkConfigurationProvider.java
+++ b/core/src/main/java/com/opensymphony/xwork2/config/providers/XWorkConfigurationProvider.java
@@ -2,6 +2,8 @@ package com.opensymphony.xwork2.config.providers;
 
 import com.opensymphony.xwork2.ActionProxyFactory;
 import com.opensymphony.xwork2.DefaultActionProxyFactory;
+import com.opensymphony.xwork2.DefaultLocaleProviderFactory;
+import com.opensymphony.xwork2.LocaleProviderFactory;
 import com.opensymphony.xwork2.TextProviderFactory;
 import com.opensymphony.xwork2.factory.DefaultUnknownHandlerFactory;
 import com.opensymphony.xwork2.factory.UnknownHandlerFactory;
@@ -186,7 +188,7 @@ public class XWorkConfigurationProvider implements ConfigurationProvider {
                 .factory(TextProvider.class, "system", DefaultTextProvider.class, Scope.SINGLETON)
                 .factory(TextProvider.class, TextProviderSupport.class, Scope.SINGLETON)
 
-                .factory(LocaleProvider.class, DefaultLocaleProvider.class, Scope.SINGLETON)
+                .factory(LocaleProviderFactory.class, DefaultLocaleProviderFactory.class, Scope.SINGLETON)
                 .factory(OgnlUtil.class, Scope.SINGLETON)
                 .factory(CollectionConverter.class, Scope.SINGLETON)
                 .factory(ArrayConverter.class, Scope.SINGLETON)

--- a/core/src/main/java/com/opensymphony/xwork2/conversion/impl/DefaultTypeConverter.java
+++ b/core/src/main/java/com/opensymphony/xwork2/conversion/impl/DefaultTypeConverter.java
@@ -32,6 +32,7 @@ package com.opensymphony.xwork2.conversion.impl;
 
 import com.opensymphony.xwork2.ActionContext;
 import com.opensymphony.xwork2.LocaleProvider;
+import com.opensymphony.xwork2.LocaleProviderFactory;
 import com.opensymphony.xwork2.conversion.TypeConverter;
 import com.opensymphony.xwork2.inject.Container;
 import com.opensymphony.xwork2.inject.Inject;
@@ -349,7 +350,8 @@ public abstract class DefaultTypeConverter implements TypeConverter {
             locale = (Locale) context.get(ActionContext.LOCALE);
         }
         if (locale == null) {
-            locale = container.getInstance(LocaleProvider.class).getLocale();
+            LocaleProviderFactory localeProviderFactory = container.getInstance(LocaleProviderFactory.class);
+            locale = localeProviderFactory.createLocaleProvider().getLocale();
         }
         return locale;
     }

--- a/core/src/main/java/com/opensymphony/xwork2/validator/DelegatingValidatorContext.java
+++ b/core/src/main/java/com/opensymphony/xwork2/validator/DelegatingValidatorContext.java
@@ -253,18 +253,30 @@ public class DelegatingValidatorContext implements ValidatorContext {
      * An implementation of LocaleProvider which gets the locale from the action context.
      */
     private static class ActionContextLocaleProvider implements LocaleProvider {
+
+        private LocaleProvider localeProvider;
+
+        private LocaleProvider getLocaleProvider() {
+            if (localeProvider == null) {
+                LocaleProviderFactory localeProviderFactory = ActionContext.getContext().getInstance(LocaleProviderFactory.class);
+                localeProvider = localeProviderFactory.createLocaleProvider();
+            }
+            return localeProvider;
+        }
+
+        @Override
         public Locale getLocale() {
-            return ActionContext.getContext().getInstance(LocaleProvider.class).getLocale();
+            return getLocaleProvider().getLocale();
         }
 
         @Override
         public boolean isValidLocaleString(String localeStr) {
-            return ActionContext.getContext().getInstance(LocaleProvider.class).isValidLocaleString(localeStr);
+            return getLocaleProvider().isValidLocaleString(localeStr);
         }
 
         @Override
         public boolean isValidLocale(Locale locale) {
-            return ActionContext.getContext().getInstance(LocaleProvider.class).isValidLocale(locale);
+            return getLocaleProvider().isValidLocale(locale);
         }
     }
 

--- a/core/src/main/java/org/apache/struts2/StrutsConstants.java
+++ b/core/src/main/java/org/apache/struts2/StrutsConstants.java
@@ -201,7 +201,11 @@ public final class StrutsConstants {
     public static final String STRUTS_XWORKTEXTPROVIDER = "struts.xworkTextProvider";
 
     /** The {@link com.opensymphony.xwork2.LocaleProvider} implementation class */
+    @Deprecated
     public static final String STRUTS_LOCALE_PROVIDER = "struts.localeProvider";
+
+    /** The {@link com.opensymphony.xwork2.LocaleProviderFactory} implementation class */
+    public static final String STRUTS_LOCALE_PROVIDER_FACTORY = "struts.localeProviderFactory";
 
     /** The name of the parameter to create when mapping an id (used by some action mappers) */
 	public static final String STRUTS_ID_PARAMETER_NAME = "struts.mapper.idParameterName";

--- a/core/src/main/java/org/apache/struts2/StrutsConstants.java
+++ b/core/src/main/java/org/apache/struts2/StrutsConstants.java
@@ -200,7 +200,10 @@ public final class StrutsConstants {
     /** XWork default text provider */
     public static final String STRUTS_XWORKTEXTPROVIDER = "struts.xworkTextProvider";
 
-    /** The {@link com.opensymphony.xwork2.LocaleProvider} implementation class */
+    /**
+     * The {@link com.opensymphony.xwork2.LocaleProvider} implementation class
+     * @deprecated use {@link StrutsConstants#STRUTS_LOCALE_PROVIDER_FACTORY} instead
+     */
     @Deprecated
     public static final String STRUTS_LOCALE_PROVIDER = "struts.localeProvider";
 

--- a/core/src/main/java/org/apache/struts2/components/I18n.java
+++ b/core/src/main/java/org/apache/struts2/components/I18n.java
@@ -24,6 +24,7 @@ package org.apache.struts2.components;
 import java.io.Writer;
 import java.util.ResourceBundle;
 
+import com.opensymphony.xwork2.LocaleProviderFactory;
 import org.apache.struts2.views.annotations.StrutsTag;
 import org.apache.struts2.views.annotations.StrutsTagAttribute;
 import org.apache.struts2.StrutsException;
@@ -109,8 +110,8 @@ public class I18n extends Component {
     }
 
     @Inject
-    public void setLocaleProvider(LocaleProvider localeProvider) {
-        this.localeProvider = localeProvider;
+    public void setLocaleProviderFactory(LocaleProviderFactory localeProviderFactory) {
+        this.localeProvider = localeProviderFactory.createLocaleProvider();
     }
 
     public boolean start(Writer writer) {

--- a/core/src/main/java/org/apache/struts2/config/DefaultBeanSelectionProvider.java
+++ b/core/src/main/java/org/apache/struts2/config/DefaultBeanSelectionProvider.java
@@ -22,6 +22,7 @@
 package org.apache.struts2.config;
 
 import com.opensymphony.xwork2.ActionProxyFactory;
+import com.opensymphony.xwork2.LocaleProviderFactory;
 import com.opensymphony.xwork2.LocalizedTextProvider;
 import com.opensymphony.xwork2.TextProviderFactory;
 import com.opensymphony.xwork2.factory.UnknownHandlerFactory;
@@ -29,7 +30,6 @@ import com.opensymphony.xwork2.security.AcceptedPatternsChecker;
 import com.opensymphony.xwork2.security.ExcludedPatternsChecker;
 import com.opensymphony.xwork2.FileManager;
 import com.opensymphony.xwork2.FileManagerFactory;
-import com.opensymphony.xwork2.LocaleProvider;
 import com.opensymphony.xwork2.ObjectFactory;
 import com.opensymphony.xwork2.TextProvider;
 import com.opensymphony.xwork2.UnknownHandlerManager;
@@ -221,7 +221,13 @@ import org.apache.struts2.views.velocity.VelocityManager;
  *     <td>com.opensymphony.xwork2.LocaleProvider</td>
  *     <td>struts.localeProvider</td>
  *     <td>singleton</td>
- *     <td>Allows provide custom TextProvider for whole application</td>
+ *     <td>DEPRECATED! Allows provide custom TextProvider for whole application</td>
+ *   </tr>
+ *   <tr>
+ *     <td>com.opensymphony.xwork2.LocaleProviderFactory</td>
+ *     <td>struts.localeProviderFactory</td>
+ *     <td>singleton</td>
+ *     <td>Allows provide custom LocaleProvider for whole application</td>
  *   </tr>
  *   <tr>
  *     <td>org.apache.struts2.components.UrlRenderer</td>
@@ -393,7 +399,7 @@ public class DefaultBeanSelectionProvider extends AbstractBeanSelectionProvider 
 
         alias(TextProvider.class, StrutsConstants.STRUTS_XWORKTEXTPROVIDER, builder, props, Scope.PROTOTYPE);
         alias(TextProviderFactory.class, StrutsConstants.STRUTS_TEXT_PROVIDER_FACTORY, builder, props, Scope.PROTOTYPE);
-        alias(LocaleProvider.class, StrutsConstants.STRUTS_LOCALE_PROVIDER, builder, props);
+        alias(LocaleProviderFactory.class, StrutsConstants.STRUTS_LOCALE_PROVIDER_FACTORY, builder, props);
         alias(LocalizedTextProvider.class, StrutsConstants.STRUTS_LOCALIZED_TEXT_PROVIDER, builder, props);
 
         alias(ActionProxyFactory.class, StrutsConstants.STRUTS_ACTIONPROXYFACTORY, builder, props);

--- a/core/src/main/java/org/apache/struts2/config/DefaultBeanSelectionProvider.java
+++ b/core/src/main/java/org/apache/struts2/config/DefaultBeanSelectionProvider.java
@@ -221,7 +221,7 @@ import org.apache.struts2.views.velocity.VelocityManager;
  *     <td>com.opensymphony.xwork2.LocaleProvider</td>
  *     <td>struts.localeProvider</td>
  *     <td>singleton</td>
- *     <td>DEPRECATED! Allows provide custom TextProvider for whole application</td>
+ *     <td>DEPRECATED! Allows provide custom TextProvider for whole application - instead this endpoint use <b>struts.localeProviderFactory</b></td>
  *   </tr>
  *   <tr>
  *     <td>com.opensymphony.xwork2.LocaleProviderFactory</td>

--- a/core/src/main/java/org/apache/struts2/dispatcher/Dispatcher.java
+++ b/core/src/main/java/org/apache/struts2/dispatcher/Dispatcher.java
@@ -783,9 +783,16 @@ public class Dispatcher {
 
         String content_type = request.getContentType();
         if (content_type != null && content_type.contains("multipart/form-data")) {
-            MultiPartRequest mpr = getMultiPartRequest();
-            LocaleProvider provider = getContainer().getInstance(LocaleProvider.class);
-            request = new MultiPartRequestWrapper(mpr, request, getSaveDir(), provider, disableRequestAttributeValueStackLookup);
+            MultiPartRequest multiPartRequest = getMultiPartRequest();
+            LocaleProviderFactory localeProviderFactory = getContainer().getInstance(LocaleProviderFactory.class);
+
+            request = new MultiPartRequestWrapper(
+                    multiPartRequest,
+                    request,
+                    getSaveDir(),
+                    localeProviderFactory.createLocaleProvider(),
+                    disableRequestAttributeValueStackLookup
+            );
         } else {
             request = new StrutsRequestWrapper(request, disableRequestAttributeValueStackLookup);
         }

--- a/core/src/main/java/org/apache/struts2/dispatcher/multipart/AbstractMultiPartRequest.java
+++ b/core/src/main/java/org/apache/struts2/dispatcher/multipart/AbstractMultiPartRequest.java
@@ -1,6 +1,7 @@
 package org.apache.struts2.dispatcher.multipart;
 
 import com.opensymphony.xwork2.LocaleProvider;
+import com.opensymphony.xwork2.LocaleProviderFactory;
 import com.opensymphony.xwork2.inject.Inject;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -70,12 +71,9 @@ public abstract class AbstractMultiPartRequest implements MultiPartRequest {
         this.maxSize = Long.parseLong(maxSize);
     }
 
-    /**
-     * @param provider Injects the Struts locale provider.
-     */
     @Inject
-    public void setLocaleProvider(LocaleProvider provider) {
-        defaultLocale = provider.getLocale();
+    public void setLocaleProviderFactory(LocaleProviderFactory localeProviderFactory) {
+        defaultLocale = localeProviderFactory.createLocaleProvider().getLocale();
     }
 
     /**

--- a/core/src/main/java/org/apache/struts2/interceptor/FileUploadInterceptor.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/FileUploadInterceptor.java
@@ -455,7 +455,8 @@ public class FileUploadInterceptor extends AbstractInterceptor {
         if (action instanceof LocaleProvider) {
             localeProvider = (LocaleProvider) action;
         } else {
-            localeProvider = container.getInstance(LocaleProvider.class);
+            LocaleProviderFactory localeProviderFactory = container.getInstance(LocaleProviderFactory.class);
+            localeProvider = localeProviderFactory.createLocaleProvider();
         }
         return localeProvider;
     }

--- a/core/src/main/java/org/apache/struts2/interceptor/I18nInterceptor.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/I18nInterceptor.java
@@ -22,6 +22,7 @@ package org.apache.struts2.interceptor;
 
 import com.opensymphony.xwork2.ActionInvocation;
 import com.opensymphony.xwork2.LocaleProvider;
+import com.opensymphony.xwork2.LocaleProviderFactory;
 import com.opensymphony.xwork2.inject.Inject;
 import com.opensymphony.xwork2.interceptor.AbstractInterceptor;
 import com.opensymphony.xwork2.util.DefaultLocalizedTextProvider;
@@ -93,8 +94,8 @@ public class I18nInterceptor extends AbstractInterceptor {
     }
 
     @Inject
-    public void setLocaleProvider(LocaleProvider localeProvider) {
-        this.localeProvider = localeProvider;
+    public void setLocaleProviderFactory(LocaleProviderFactory localeProviderFactory) {
+        this.localeProvider = localeProviderFactory.createLocaleProvider();
     }
 
     @Override

--- a/core/src/main/java/org/apache/struts2/interceptor/I18nInterceptor.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/I18nInterceptor.java
@@ -59,7 +59,7 @@ public class I18nInterceptor extends AbstractInterceptor {
     protected String requestCookieParameterName = DEFAULT_COOKIE_PARAMETER;
     protected Storage storage = Storage.SESSION;
 
-    protected LocaleProvider localeProvider;
+    protected LocaleProviderFactory localeProviderFactory;
 
     // Request-Only = None
     protected enum Storage { COOKIE, SESSION, NONE }
@@ -95,7 +95,7 @@ public class I18nInterceptor extends AbstractInterceptor {
 
     @Inject
     public void setLocaleProviderFactory(LocaleProviderFactory localeProviderFactory) {
-        this.localeProvider = localeProviderFactory.createLocaleProvider();
+        this.localeProviderFactory = localeProviderFactory;
     }
 
     @Override
@@ -157,6 +157,8 @@ public class I18nInterceptor extends AbstractInterceptor {
      * @return the Locale
      */
     protected Locale getLocaleFromParam(Object requestedLocale) {
+        LocaleProvider localeProvider = localeProviderFactory.createLocaleProvider();
+
         Locale locale = null;
         if (requestedLocale != null) {
             if (requestedLocale instanceof Locale) {

--- a/core/src/main/resources/struts-default.xml
+++ b/core/src/main/resources/struts-default.xml
@@ -133,7 +133,7 @@
     <bean type="com.opensymphony.xwork2.TextProviderFactory" name="struts" class="com.opensymphony.xwork2.TextProviderFactory" scope="prototype" />
     <bean type="com.opensymphony.xwork2.LocalizedTextProvider" name="struts" class="com.opensymphony.xwork2.util.DefaultLocalizedTextProvider" scope="singleton" />
     <bean type="com.opensymphony.xwork2.TextProvider" name="struts" class="com.opensymphony.xwork2.TextProviderSupport" scope="prototype" />
-    <bean type="com.opensymphony.xwork2.LocaleProvider" name="struts" class="com.opensymphony.xwork2.DefaultLocaleProvider" scope="singleton" />
+    <bean type="com.opensymphony.xwork2.LocaleProviderFactory" name="struts" class="com.opensymphony.xwork2.DefaultLocaleProviderFactory" scope="singleton" />
 
     <bean type="org.apache.struts2.components.UrlRenderer" name="struts" class="org.apache.struts2.components.ServletUrlRenderer"/>
     <bean type="org.apache.struts2.views.util.UrlHelper" name="struts" class="org.apache.struts2.views.util.DefaultUrlHelper"/>

--- a/core/src/test/java/org/apache/struts2/interceptor/I18nInterceptorTest.java
+++ b/core/src/test/java/org/apache/struts2/interceptor/I18nInterceptorTest.java
@@ -24,6 +24,7 @@ import com.opensymphony.xwork2.Action;
 import com.opensymphony.xwork2.ActionContext;
 import com.opensymphony.xwork2.ActionInvocation;
 import com.opensymphony.xwork2.DefaultLocaleProvider;
+import com.opensymphony.xwork2.DefaultLocaleProviderFactory;
 import com.opensymphony.xwork2.mock.MockActionInvocation;
 import com.opensymphony.xwork2.mock.MockActionProxy;
 import junit.framework.TestCase;
@@ -217,7 +218,7 @@ public class I18nInterceptorTest extends TestCase {
 
     public void setUp() throws Exception {
         interceptor = new I18nInterceptor();
-        interceptor.setLocaleProvider(new DefaultLocaleProvider());
+        interceptor.setLocaleProviderFactory(new DefaultLocaleProviderFactory());
         interceptor.init();
         session = new HashMap();
 

--- a/plugins/tiles/src/main/java/org/apache/struts2/tiles/StrutsTilesLocaleResolver.java
+++ b/plugins/tiles/src/main/java/org/apache/struts2/tiles/StrutsTilesLocaleResolver.java
@@ -21,6 +21,7 @@ package org.apache.struts2.tiles;
 
 import com.opensymphony.xwork2.ActionContext;
 import com.opensymphony.xwork2.LocaleProvider;
+import com.opensymphony.xwork2.LocaleProviderFactory;
 import com.opensymphony.xwork2.config.ConfigurationException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -46,9 +47,9 @@ public class StrutsTilesLocaleResolver implements LocaleResolver {
             throw new ConfigurationException("There is no ActionContext for current request!");
         }
 
-        LocaleProvider provider = ctx.getInstance(LocaleProvider.class);
+        LocaleProviderFactory localeProviderFactory = ctx.getInstance(LocaleProviderFactory.class);
 
-        return provider.getLocale();
+        return localeProviderFactory.createLocaleProvider().getLocale();
     }
 
 }


### PR DESCRIPTION
Replaces injectable `LocaleProvider` with `LocaleProviderFactory` to avoid problems with multiple beans implementing the `LocaleProvider` interface.

Implements [WW-4757](https://issues.apache.org/jira/browse/WW-4757)