### PR TITLE
Immutable context

### DIFF
--- a/core/src/main/java/com/opensymphony/xwork2/ActionContext.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ActionContext.java
@@ -18,8 +18,10 @@
  */
 package com.opensymphony.xwork2;
 
+import com.opensymphony.xwork2.conversion.TypeConverter;
 import com.opensymphony.xwork2.inject.Container;
 import com.opensymphony.xwork2.util.ValueStack;
+import ognl.OgnlContext;
 import org.apache.struts2.dispatcher.HttpParameters;
 
 import java.io.Serializable;
@@ -184,6 +186,10 @@ public class ActionContext implements Serializable {
      * @return the context map.
      */
     public Map<String, Object> getContextMap() {
+        Map<String, Object> context = getContext().context;
+        if (context instanceof OgnlContext) {
+            ((OgnlContext) context).put(TypeConverter.TYPE_CONVERTER_CONTEXT_KEY, ((OgnlContext) context).getTypeConverter());
+        }
         return context;
     }
 

--- a/core/src/main/java/com/opensymphony/xwork2/ActionContext.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ActionContext.java
@@ -84,11 +84,6 @@ public class ActionContext implements Serializable {
     public static final String LOCALE = "com.opensymphony.xwork2.ActionContext.locale";
 
     /**
-     * Constant for the action's type converter.
-     */
-    public static final String TYPE_CONVERTER = "com.opensymphony.xwork2.ActionContext.typeConverter";
-
-    /**
      * Constant for the action's {@link com.opensymphony.xwork2.ActionInvocation invocation} context.
      */
     public static final String ACTION_INVOCATION = "com.opensymphony.xwork2.ActionContext.actionInvocation";
@@ -171,21 +166,12 @@ public class ActionContext implements Serializable {
     }
 
     /**
-     * Sets the action's context map.
-     *
-     * @param contextMap the context map.
-     */
-    public void setContextMap(Map<String, Object> contextMap) {
-        getContext().context = contextMap;
-    }
-
-    /**
      * Gets the context map.
      *
      * @return the context map.
      */
     public Map<String, Object> getContextMap() {
-        return new HashMap<>(getContext().context);
+        return getContext().context;
     }
 
     /**

--- a/core/src/main/java/com/opensymphony/xwork2/ActionContext.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ActionContext.java
@@ -187,11 +187,7 @@ public class ActionContext implements Serializable {
      * @return the context map.
      */
     public Map<String, Object> getContextMap() {
-        Map<String, Object> context = getContext().context;
-        if (context instanceof OgnlContext) {
-            ((OgnlContext) context).put(TypeConverter.TYPE_CONVERTER_CONTEXT_KEY, ((OgnlContext) context).getTypeConverter());
-        }
-        return context;
+        return new HashMap<>(getContext().context);
     }
 
     /**

--- a/core/src/main/java/com/opensymphony/xwork2/ActionContext.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ActionContext.java
@@ -19,10 +19,8 @@
 package com.opensymphony.xwork2;
 
 import com.opensymphony.xwork2.conversion.impl.ConversionData;
-import com.opensymphony.xwork2.conversion.TypeConverter;
 import com.opensymphony.xwork2.inject.Container;
 import com.opensymphony.xwork2.util.ValueStack;
-import ognl.OgnlContext;
 import org.apache.struts2.dispatcher.HttpParameters;
 
 import java.io.Serializable;

--- a/core/src/main/java/com/opensymphony/xwork2/conversion/TypeConverter.java
+++ b/core/src/main/java/com/opensymphony/xwork2/conversion/TypeConverter.java
@@ -44,9 +44,10 @@ public interface TypeConverter
        * @return Converted value of type toType or TypeConverter.NoConversionPossible to indicate that the
                  conversion was not possible.
      */
-    public Object convertValue(Map<String, Object> context, Object target, Member member, String propertyName, Object value, Class toType);
+    Object convertValue(Map<String, Object> context, Object target, Member member, String propertyName, Object value, Class toType);
     
-    public static final Object NO_CONVERSION_POSSIBLE = "ognl.NoConversionPossible";
-    
-    public static final String TYPE_CONVERTER_CONTEXT_KEY = "_typeConverter";
+    Object NO_CONVERSION_POSSIBLE = "ognl.NoConversionPossible";
+
+    @Deprecated
+    String TYPE_CONVERTER_CONTEXT_KEY = "_typeConverter";
 }

--- a/core/src/main/java/com/opensymphony/xwork2/conversion/TypeConverter.java
+++ b/core/src/main/java/com/opensymphony/xwork2/conversion/TypeConverter.java
@@ -23,29 +23,29 @@ import java.util.Map;
 
 /**
  * Interface for accessing the type conversion facilities within a context.
- * 
+ *
  * This interface was copied from OGNL's TypeConverter
- * 
+ *
  * @author Luke Blanshard (blanshlu@netscape.net)
  * @author Drew Davidson (drew@ognl.org)
  */
-public interface TypeConverter
-{
+public interface TypeConverter {
     /**
-       * Converts the given value to a given type.  The OGNL context, target, member and
-       * name of property being set are given.  This method should be able to handle
-       * conversion in general without any context, target, member or property name specified.
-       * @param context context under which the conversion is being done
-       * @param target target object in which the property is being set
-       * @param member member (Constructor, Method or Field) being set
-       * @param propertyName property name being set
-       * @param value value to be converted
-       * @param toType type to which value is converted
-       * @return Converted value of type toType or TypeConverter.NoConversionPossible to indicate that the
-                 conversion was not possible.
+     * Converts the given value to a given type.  The OGNL context, target, member and
+     * name of property being set are given.  This method should be able to handle
+     * conversion in general without any context, target, member or property name specified.
+     *
+     * @param context      context under which the conversion is being done
+     * @param target       target object in which the property is being set
+     * @param member       member (Constructor, Method or Field) being set
+     * @param propertyName property name being set
+     * @param value        value to be converted
+     * @param toType       type to which value is converted
+     * @return Converted value of type toType or TypeConverter.NoConversionPossible to indicate that the
+     * conversion was not possible.
      */
     Object convertValue(Map<String, Object> context, Object target, Member member, String propertyName, Object value, Class toType);
-    
+
     Object NO_CONVERSION_POSSIBLE = "ognl.NoConversionPossible";
 
     @Deprecated

--- a/core/src/main/java/com/opensymphony/xwork2/conversion/TypeConverter.java
+++ b/core/src/main/java/com/opensymphony/xwork2/conversion/TypeConverter.java
@@ -50,4 +50,5 @@ public interface TypeConverter {
 
     @Deprecated
     String TYPE_CONVERTER_CONTEXT_KEY = "_typeConverter";
+
 }

--- a/core/src/main/java/com/opensymphony/xwork2/conversion/impl/DefaultTypeConverter.java
+++ b/core/src/main/java/com/opensymphony/xwork2/conversion/impl/DefaultTypeConverter.java
@@ -19,12 +19,12 @@
 package com.opensymphony.xwork2.conversion.impl;
 
 import com.opensymphony.xwork2.ActionContext;
-import com.opensymphony.xwork2.LocaleProvider;
 import com.opensymphony.xwork2.LocaleProviderFactory;
 import com.opensymphony.xwork2.conversion.TypeConverter;
 import com.opensymphony.xwork2.inject.Container;
 import com.opensymphony.xwork2.inject.Inject;
 import com.opensymphony.xwork2.ognl.XWorkTypeConverterWrapper;
+import ognl.OgnlContext;
 
 import java.lang.reflect.Array;
 import java.lang.reflect.Member;
@@ -81,17 +81,22 @@ public abstract class DefaultTypeConverter implements TypeConverter {
         return convertValue(context, value, toType);
     }
     
-    public TypeConverter getTypeConverter( Map<String, Object> context )
-    {
-        Object obj = context.get(TypeConverter.TYPE_CONVERTER_CONTEXT_KEY);
-        if (obj instanceof TypeConverter) {
-            return (TypeConverter) obj;
-            
-        // for backwards-compatibility
-        } else if (obj instanceof ognl.TypeConverter) {
-            return new XWorkTypeConverterWrapper((ognl.TypeConverter) obj);
+    public TypeConverter getTypeConverter( Map<String, Object> context ) {
+        ognl.TypeConverter converter = null;
+
+        if (context instanceof OgnlContext) {
+            converter = ((OgnlContext) context).getTypeConverter();
         }
-        return null; 
+
+        if (converter != null) {
+            if (converter instanceof TypeConverter) {
+                return (TypeConverter) converter;
+            } else {
+                return new XWorkTypeConverterWrapper(converter);
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlUtil.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlUtil.java
@@ -677,7 +677,7 @@ public class OgnlUtil {
         memberAccess.setExcludedPackageNames(excludedPackageNames);
         memberAccess.setDisallowProxyMemberAccess(disallowProxyMemberAccess);
 
-        return Ognl.createDefaultContext(root, resolver, defaultConverter, memberAccess);
+        return Ognl.createDefaultContext(root, memberAccess, resolver, defaultConverter);
     }
 
     private interface OgnlTask<T> {

--- a/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlUtil.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlUtil.java
@@ -184,8 +184,6 @@ public class OgnlUtil {
             return;
         }
 
-        Ognl.setTypeConverter(context, getTypeConverterFromContext(context));
-
         Object oldRoot = Ognl.getRoot(context);
         Ognl.setRoot(context, o);
 
@@ -245,7 +243,6 @@ public class OgnlUtil {
      *                                problems setting the property
      */
     public void setProperty(String name, Object value, Object o, Map<String, Object> context, boolean throwPropertyExceptions) {
-        Ognl.setTypeConverter(context, getTypeConverterFromContext(context));
 
         Object oldRoot = Ognl.getRoot(context);
         Ognl.setRoot(context, o);
@@ -487,11 +484,8 @@ public class OgnlUtil {
             return;
         }
 
-        TypeConverter converter = getTypeConverterFromContext(context);
         final Map contextFrom = createDefaultContext(from, null);
-        Ognl.setTypeConverter(contextFrom, converter);
         final Map contextTo = createDefaultContext(to, null);
-        Ognl.setTypeConverter(contextTo, converter);
 
         PropertyDescriptor[] fromPds;
         PropertyDescriptor[] toPds;
@@ -665,18 +659,6 @@ public class OgnlUtil {
                 LOG.warn(msg, exception);
             }
         }
-    }
-
-    TypeConverter getTypeConverterFromContext(Map<String, Object> context) {
-        /*ValueStack stack = (ValueStack) context.get(ActionContext.VALUE_STACK);
-        Container cont = (Container)stack.getContext().get(ActionContext.CONTAINER);
-        if (cont != null) {
-            return new OgnlTypeConverterWrapper(cont.getInstance(XWorkConverter.class));
-        } else {
-            throw new IllegalArgumentException("Cannot find type converter in context map");
-        }
-        */
-        return defaultConverter;
     }
 
     protected Map createDefaultContext(Object root) {

--- a/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlValueStack.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlValueStack.java
@@ -94,7 +94,7 @@ public class OgnlValueStack implements Serializable, ValueStack, ClearableValueS
                            boolean allowStaticMethodAccess) {
         this.root = compoundRoot;
         this.securityMemberAccess = new SecurityMemberAccess(allowStaticMethodAccess);
-        this.context = Ognl.createDefaultContext(this.root, accessor, new OgnlTypeConverterWrapper(xworkConverter), securityMemberAccess);
+        this.context = Ognl.createDefaultContext(this.root, securityMemberAccess, accessor, new OgnlTypeConverterWrapper(xworkConverter));
         context.put(VALUE_STACK, this);
         ((OgnlContext) context).setTraceEvaluations(false);
         ((OgnlContext) context).setKeepLastEvaluation(false);

--- a/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlValueStack.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlValueStack.java
@@ -96,7 +96,6 @@ public class OgnlValueStack implements Serializable, ValueStack, ClearableValueS
         this.securityMemberAccess = new SecurityMemberAccess(allowStaticMethodAccess);
         this.context = Ognl.createDefaultContext(this.root, accessor, new OgnlTypeConverterWrapper(xworkConverter), securityMemberAccess);
         context.put(VALUE_STACK, this);
-        Ognl.setClassResolver(context, accessor);
         ((OgnlContext) context).setTraceEvaluations(false);
         ((OgnlContext) context).setKeepLastEvaluation(false);
     }

--- a/core/src/main/java/com/opensymphony/xwork2/ognl/SecurityMemberAccess.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/SecurityMemberAccess.java
@@ -64,7 +64,7 @@ public class SecurityMemberAccess implements MemberAccess {
             AccessibleObject accessible = (AccessibleObject) member;
 
             if (!accessible.isAccessible()) {
-                result = Boolean.TRUE;
+                result = Boolean.FALSE;
                 accessible.setAccessible(true);
             }
         }

--- a/core/src/main/java/org/apache/struts2/views/jsp/ui/OgnlTool.java
+++ b/core/src/main/java/org/apache/struts2/views/jsp/ui/OgnlTool.java
@@ -18,7 +18,7 @@
  */
 package org.apache.struts2.views.jsp.ui;
 
-import ognl.Ognl;
+import com.opensymphony.xwork2.ActionContext;
 import ognl.OgnlException;
 
 import com.opensymphony.xwork2.inject.Inject;
@@ -30,18 +30,18 @@ import com.opensymphony.xwork2.ognl.OgnlUtil;
 public class OgnlTool {
 
     private OgnlUtil ognlUtil;
-    
+
     public OgnlTool() {
     }
-    
+
     @Inject
     public void setOgnlUtil(OgnlUtil ognlUtil) {
         this.ognlUtil = ognlUtil;
     }
-    
+
     public Object findValue(String expr, Object context) {
         try {
-            return Ognl.getValue(ognlUtil.compile(expr), context);
+            return ognlUtil.getValue(expr, ActionContext.getContext().getContextMap(), context);
         } catch (OgnlException e) {
             return null;
         }

--- a/core/src/main/resources/struts-default.xml
+++ b/core/src/main/resources/struts-default.xml
@@ -49,7 +49,6 @@
                 ognl.ClassResolver,
                 ognl.TypeConverter,
                 ognl.MemberAccess,
-                ognl.DefaultMemberAccess,
                 com.opensymphony.xwork2.ognl.SecurityMemberAccess,
                 com.opensymphony.xwork2.ActionContext" />
 

--- a/core/src/test/java/com/opensymphony/xwork2/ActionContextTest.java
+++ b/core/src/test/java/com/opensymphony/xwork2/ActionContextTest.java
@@ -88,8 +88,9 @@ public class ActionContextTest extends XWorkTestCase {
 
     public void testContextMap() {
         Map<String, Object> map = new HashMap<>();
-        context.setContextMap(map);
-        assertEquals(map, context.getContextMap());
+        ActionContext.setContext(new ActionContext(map));
+
+        assertEquals(map, ActionContext.getContext().getContextMap());
     }
 
     public void testParameters() {

--- a/core/src/test/java/com/opensymphony/xwork2/DefaultActionInvocationTest.java
+++ b/core/src/test/java/com/opensymphony/xwork2/DefaultActionInvocationTest.java
@@ -105,11 +105,8 @@ public class DefaultActionInvocationTest extends XWorkTestCase {
 
     public void testInvokingExistingExecuteMethod() throws Exception {
         // given
-        DefaultActionInvocation dai = new DefaultActionInvocation(new HashMap<String, Object>(), false) {
-            public ValueStack getStack() {
-                return new StubValueStack();
-            }
-        };
+        DefaultActionInvocation dai = new DefaultActionInvocation(ActionContext.getContext().getContextMap(), false);
+        container.inject(dai);
 
         SimpleAction action = new SimpleAction() {
             @Override
@@ -120,6 +117,7 @@ public class DefaultActionInvocationTest extends XWorkTestCase {
         MockActionProxy proxy = new MockActionProxy();
         proxy.setMethod("execute");
 
+        dai.stack = container.getInstance(ValueStackFactory.class).createValueStack();
         dai.proxy = proxy;
         dai.ognlUtil = new OgnlUtil();
 
@@ -132,11 +130,8 @@ public class DefaultActionInvocationTest extends XWorkTestCase {
 
     public void testInvokingMissingMethod() throws Exception {
         // given
-        DefaultActionInvocation dai = new DefaultActionInvocation(new HashMap<String, Object>(), false) {
-            public ValueStack getStack() {
-                return new StubValueStack();
-            }
-        };
+        DefaultActionInvocation dai = new DefaultActionInvocation(ActionContext.getContext().getContextMap(), false);
+        container.inject(dai);
 
         SimpleAction action = new SimpleAction() {
             @Override
@@ -154,6 +149,7 @@ public class DefaultActionInvocationTest extends XWorkTestCase {
             }
         };
 
+        dai.stack = container.getInstance(ValueStackFactory.class).createValueStack();
         dai.proxy = proxy;
         dai.ognlUtil = new OgnlUtil();
         dai.unknownHandlerManager = uhm;
@@ -173,11 +169,8 @@ public class DefaultActionInvocationTest extends XWorkTestCase {
 
     public void testInvokingExistingMethodThatThrowsException() throws Exception {
         // given
-        DefaultActionInvocation dai = new DefaultActionInvocation(new HashMap<String, Object>(), false) {
-            public ValueStack getStack() {
-                return new StubValueStack();
-            }
-        };
+        DefaultActionInvocation dai = new DefaultActionInvocation(ActionContext.getContext().getContextMap(), false);
+        container.inject(dai);
 
         SimpleAction action = new SimpleAction() {
             @Override
@@ -188,6 +181,7 @@ public class DefaultActionInvocationTest extends XWorkTestCase {
         MockActionProxy proxy = new MockActionProxy();
         proxy.setMethod("execute");
 
+        dai.stack = container.getInstance(ValueStackFactory.class).createValueStack();
         dai.proxy = proxy;
         dai.ognlUtil = new OgnlUtil();
 
@@ -206,11 +200,8 @@ public class DefaultActionInvocationTest extends XWorkTestCase {
 
     public void testUnknownHandlerManagerThatThrowsException() throws Exception {
         // given
-        DefaultActionInvocation dai = new DefaultActionInvocation(new HashMap<String, Object>(), false) {
-            public ValueStack getStack() {
-                return new StubValueStack();
-            }
-        };
+        DefaultActionInvocation dai = new DefaultActionInvocation(ActionContext.getContext().getContextMap(), false);
+        container.inject(dai);
 
         UnknownHandlerManager uhm = new DefaultUnknownHandlerManager() {
             @Override
@@ -227,6 +218,7 @@ public class DefaultActionInvocationTest extends XWorkTestCase {
         MockActionProxy proxy = new MockActionProxy();
         proxy.setMethod("notExists");
 
+        dai.stack = container.getInstance(ValueStackFactory.class).createValueStack();
         dai.proxy = proxy;
         dai.ognlUtil = new OgnlUtil();
         dai.unknownHandlerManager = uhm;
@@ -247,11 +239,8 @@ public class DefaultActionInvocationTest extends XWorkTestCase {
 
     public void testUnknownHandlerManagerThatReturnsNull() throws Exception {
         // given
-        DefaultActionInvocation dai = new DefaultActionInvocation(new HashMap<String, Object>(), false) {
-            public ValueStack getStack() {
-                return new StubValueStack();
-            }
-        };
+        DefaultActionInvocation dai = new DefaultActionInvocation(ActionContext.getContext().getContextMap(), false);
+        container.inject(dai);
 
         UnknownHandlerManager uhm = new DefaultUnknownHandlerManager() {
             @Override
@@ -268,6 +257,7 @@ public class DefaultActionInvocationTest extends XWorkTestCase {
         MockActionProxy proxy = new MockActionProxy();
         proxy.setMethod("notExists");
 
+        dai.stack = container.getInstance(ValueStackFactory.class).createValueStack();
         dai.proxy = proxy;
         dai.ognlUtil = new OgnlUtil();
         dai.unknownHandlerManager = uhm;
@@ -287,11 +277,8 @@ public class DefaultActionInvocationTest extends XWorkTestCase {
 
     public void testUnknownHandlerManagerThatReturnsSuccess() throws Exception {
         // given
-        DefaultActionInvocation dai = new DefaultActionInvocation(new HashMap<String, Object>(), false) {
-            public ValueStack getStack() {
-                return new StubValueStack();
-            }
-        };
+        DefaultActionInvocation dai = new DefaultActionInvocation(ActionContext.getContext().getContextMap(), false);
+        container.inject(dai);
 
         UnknownHandlerManager uhm = new DefaultUnknownHandlerManager() {
             @Override
@@ -308,6 +295,7 @@ public class DefaultActionInvocationTest extends XWorkTestCase {
         MockActionProxy proxy = new MockActionProxy();
         proxy.setMethod("notExists");
 
+        dai.stack = container.getInstance(ValueStackFactory.class).createValueStack();
         dai.proxy = proxy;
         dai.ognlUtil = new OgnlUtil();
         dai.unknownHandlerManager = uhm;

--- a/core/src/test/java/com/opensymphony/xwork2/conversion/impl/AnnotationXWorkConverterTest.java
+++ b/core/src/test/java/com/opensymphony/xwork2/conversion/impl/AnnotationXWorkConverterTest.java
@@ -24,6 +24,7 @@ import com.opensymphony.xwork2.test.ModelDrivenAnnotationAction2;
 import com.opensymphony.xwork2.util.Bar;
 import com.opensymphony.xwork2.util.ValueStack;
 import com.opensymphony.xwork2.util.reflection.ReflectionContextState;
+import ognl.Ognl;
 import ognl.OgnlException;
 import ognl.OgnlRuntime;
 

--- a/core/src/test/java/com/opensymphony/xwork2/ognl/OgnlUtilTest.java
+++ b/core/src/test/java/com/opensymphony/xwork2/ognl/OgnlUtilTest.java
@@ -803,6 +803,24 @@ public class OgnlUtilTest extends XWorkTestCase {
         assertEquals(expected.getMessage(), "It isn't a simple method which can be called!");
     }
 
+    public void testAccessContext() throws Exception {
+        Map<String, Object> context = ognlUtil.createDefaultContext(null);
+
+        Foo foo = new Foo();
+        
+        Object result = ognlUtil.getValue("#context", context, null);
+        Object root = ognlUtil.getValue("#root", context, foo);
+        Object that = ognlUtil.getValue("#this", context, foo);
+
+        assertNotSame(context, result);
+        assertNull(result);
+        assertNotNull(root);
+        assertSame(root.getClass(), Foo.class);
+        assertNotNull(that);
+        assertSame(that.getClass(), Foo.class);
+        assertSame(that, root);
+    }
+
     public static class Email {
         String address;
 

--- a/core/src/test/java/com/opensymphony/xwork2/ognl/SetPropertiesTest.java
+++ b/core/src/test/java/com/opensymphony/xwork2/ognl/SetPropertiesTest.java
@@ -57,7 +57,7 @@ public class SetPropertiesTest extends XWorkTestCase {
     }
     public void testOgnlUtilEmptyStringAsLong() {
         Bar bar = new Bar();
-        Map context = Ognl.createDefaultContext(bar);
+        Map context = Ognl.createDefaultContext(bar, new SecurityMemberAccess(false));
         context.put(XWorkConverter.REPORT_CONVERSION_ERRORS, Boolean.TRUE);
         bar.setId(null);
 

--- a/core/src/test/java/org/apache/struts2/factory/StrutsResultFactoryTest.java
+++ b/core/src/test/java/org/apache/struts2/factory/StrutsResultFactoryTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.struts2.factory;
 
+import com.opensymphony.xwork2.ActionContext;
 import com.opensymphony.xwork2.ActionInvocation;
 import com.opensymphony.xwork2.Result;
 import com.opensymphony.xwork2.config.entities.ResultConfig;
@@ -39,10 +40,9 @@ public class StrutsResultFactoryTest extends StrutsInternalTestCase {
         params.put("accept", "ok");
         params.put("reject", "bad");
         ResultConfig config = new ResultConfig.Builder("struts", MyResult.class.getName()).addParams(params).build();
-        Map<String, Object> context = new HashMap<String, Object>();
 
         // when
-        Result result = builder.buildResult(config, context);
+        Result result = builder.buildResult(config, ActionContext.getContext().getContextMap());
 
         // then
         assertEquals("ok", ((MyResult)result).getAccept());

--- a/core/src/test/java/org/apache/struts2/result/ServletActionRedirectResultTest.java
+++ b/core/src/test/java/org/apache/struts2/result/ServletActionRedirectResultTest.java
@@ -179,7 +179,7 @@ public class ServletActionRedirectResultTest extends StrutsInternalTestCase {
             .build();
 
         ObjectFactory factory = container.getInstance(ObjectFactory.class);
-        ServletActionRedirectResult result = (ServletActionRedirectResult) factory.buildResult(resultConfig, new HashMap<String, Object>());
+        ServletActionRedirectResult result = (ServletActionRedirectResult) factory.buildResult(resultConfig, ActionContext.getContext().getContextMap());
         assertNotNull(result);
     }
     

--- a/core/src/test/java/org/apache/struts2/result/ServletDispatcherResultTest.java
+++ b/core/src/test/java/org/apache/struts2/result/ServletDispatcherResultTest.java
@@ -57,8 +57,6 @@ public class ServletDispatcherResultTest extends StrutsInternalTestCase implemen
         Mock responseMock = new Mock(HttpServletResponse.class);
         responseMock.expectAndReturn("isCommitted", Boolean.TRUE);
 
-        ActionContext ac = new ActionContext(Ognl.createDefaultContext(null));
-        ActionContext.setContext(ac);
         ServletActionContext.setRequest((HttpServletRequest) requestMock.proxy());
         ServletActionContext.setResponse((HttpServletResponse) responseMock.proxy());
 
@@ -92,8 +90,6 @@ public class ServletDispatcherResultTest extends StrutsInternalTestCase implemen
         Mock responseMock = new Mock(HttpServletResponse.class);
         responseMock.expectAndReturn("isCommitted", Boolean.FALSE);
 
-        ActionContext ac = new ActionContext(Ognl.createDefaultContext(null));
-        ActionContext.setContext(ac);
         ServletActionContext.setRequest((HttpServletRequest) requestMock.proxy());
         ServletActionContext.setResponse((HttpServletResponse) responseMock.proxy());
 
@@ -127,14 +123,11 @@ public class ServletDispatcherResultTest extends StrutsInternalTestCase implemen
         Mock responseMock = new Mock(HttpServletResponse.class);
         responseMock.expectAndReturn("isCommitted", Boolean.FALSE);
 
-        ActionContext ac = new ActionContext(Ognl.createDefaultContext(null));
-        ac.setContainer(container);
-        ActionContext.setContext(ac);
         ServletActionContext.setRequest((HttpServletRequest) requestMock.proxy());
         ServletActionContext.setResponse((HttpServletResponse) responseMock.proxy());
 
         MockActionInvocation mockActionInvocation = new MockActionInvocation();
-        mockActionInvocation.setInvocationContext(ac);
+        mockActionInvocation.setInvocationContext(ActionContext.getContext());
         mockActionInvocation.setStack(container.getInstance(ValueStackFactory.class).createValueStack());
 
         try {

--- a/core/src/test/java/org/apache/struts2/result/ServletRedirectResultTest.java
+++ b/core/src/test/java/org/apache/struts2/result/ServletRedirectResultTest.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import com.opensymphony.xwork2.ognl.SecurityMemberAccess;
 import ognl.Ognl;
 
 import org.apache.struts2.ServletActionContext;
@@ -342,7 +343,7 @@ public class ServletRedirectResultTest extends StrutsInternalTestCase implements
         ActionConfig actionConfig = new ActionConfig.Builder("", "", "")
                 .addResultConfigs(results).build();
 
-        ActionContext ac = new ActionContext(Ognl.createDefaultContext(null));
+        ActionContext ac = new ActionContext(Ognl.createDefaultContext(null, new SecurityMemberAccess(false)));
         ac.put(ServletActionContext.HTTP_REQUEST, requestMock.proxy());
         ac.put(ServletActionContext.HTTP_RESPONSE, responseMock.proxy());
         MockActionInvocation ai = new MockActionInvocation();

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <struts2.springPlatformVersion>4.1.9.RELEASE</struts2.springPlatformVersion>
-        <ognl.version>3.2.3</ognl.version>
+        <ognl.version>3.2.4</ognl.version>
         <asm.version>5.2</asm.version>
         <tiles.version>3.0.7</tiles.version>
         <tiles-request.version>1.0.6</tiles-request.version>

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <spring.platformVersion>4.3.13.RELEASE</spring.platformVersion>
-        <ognl.version>3.2.4</ognl.version>
+        <ognl.version>3.2.5</ognl.version>
         <asm.version>5.2</asm.version>
         <tiles.version>3.0.7</tiles.version>
         <tiles-request.version>1.0.6</tiles-request.version>

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <struts2.springPlatformVersion>4.1.9.RELEASE</struts2.springPlatformVersion>
-        <ognl.version>3.1.15</ognl.version>
+        <ognl.version>3.2.3</ognl.version>
         <asm.version>5.2</asm.version>
         <tiles.version>3.0.7</tiles.version>
         <tiles-request.version>1.0.6</tiles-request.version>


### PR DESCRIPTION
This PR uses the latest OGNL version which drops access to `#context` via a magical key and makes `OgnlContext` a bit immutable.

[OGNL 3.2 version notes](https://github.com/jkuhnert/ognl#release-notes---version-32)

Implements [WW-4927](https://issues.apache.org/jira/browse/WW-4927)