### PR TITLE
WW-4210: Type conversion class

### DIFF
--- a/core/src/main/java/com/opensymphony/xwork2/conversion/TypeConverterCreator.java
+++ b/core/src/main/java/com/opensymphony/xwork2/conversion/TypeConverterCreator.java
@@ -14,4 +14,13 @@ public interface TypeConverterCreator {
      */
     TypeConverter createTypeConverter(String className) throws Exception;
 
+    /**
+     * Creates {@link TypeConverter} from given class
+     *
+     * @param clazz convert class
+     * @return instance of {@link TypeConverter}
+     * @throws Exception when cannot create/cast to {@link TypeConverter}
+     */
+    TypeConverter createTypeConverter(Class<?> clazz) throws Exception;
+
 }

--- a/core/src/main/java/com/opensymphony/xwork2/conversion/annotations/TypeConversion.java
+++ b/core/src/main/java/com/opensymphony/xwork2/conversion/annotations/TypeConversion.java
@@ -79,9 +79,15 @@ import java.lang.annotation.Target;
  * </tr>
  * <tr>
  * <td>converter</td>
- * <td>either this or value</td>
+ * <td>DEPRECATED: either this or value</td>
  * <td>&nbsp;</td>
  * <td>The class name of the TypeConverter to be used as converter.</td>
+ * </tr>
+ * <tr>
+ * <td>converterClass</td>
+ * <td>either this or value</td>
+ * <td>&nbsp;</td>
+ * <td>The class of the TypeConverter to be used as converter. XWorkBasicConverter by default.</td>
  * </tr>
  * <tr>
  * <td>value</td>
@@ -108,27 +114,27 @@ import java.lang.annotation.Target;
  *
  *   private HashMap keyValues = null;
  *
- *   &#64;TypeConversion(type = ConversionType.APPLICATION, converter = "com.opensymphony.xwork2.util.XWorkBasicConverter")
+ *   &#64;TypeConversion(type = ConversionType.APPLICATION)
  *   public void setConvertInt( String convertInt ) {
  *       this.convertInt = convertInt;
  *   }
  *
- *   &#64;TypeConversion(converter = "com.opensymphony.xwork2.util.XWorkBasicConverter")
+ *   &#64;TypeConversion(converterClass = XWorkBasicConverter.class)
  *   public void setConvertDouble( String convertDouble ) {
  *       this.convertDouble = convertDouble;
  *   }
  *
- *   &#64;TypeConversion(rule = ConversionRule.COLLECTION, converter = "java.util.String")
+ *   &#64;TypeConversion(rule = ConversionRule.COLLECTION, converterClass = String.class)
  *   public void setUsers( List users ) {
  *       this.users = users;
  *   }
  *
- *   &#64;TypeConversion(rule = ConversionRule.MAP, converter = "java.math.BigInteger")
+ *   &#64;TypeConversion(rule = ConversionRule.MAP, converterClass = BigInteger.class)
  *   public void setKeyValues( HashMap keyValues ) {
  *       this.keyValues = keyValues;
  *   }
  *
- *   &#64;TypeConversion(type = ConversionType.APPLICATION, property = "java.util.Date", converter = "com.opensymphony.xwork2.util.XWorkBasicConverter")
+ *   &#64;TypeConversion(type = ConversionType.APPLICATION, property = "java.util.Date", converterClass = XWorkBasicConverter.class)
  *   public String execute() throws Exception {
  *       return SUCCESS;
  *   }

--- a/core/src/main/java/com/opensymphony/xwork2/conversion/annotations/TypeConversion.java
+++ b/core/src/main/java/com/opensymphony/xwork2/conversion/annotations/TypeConversion.java
@@ -15,6 +15,8 @@
  */
 package com.opensymphony.xwork2.conversion.annotations;
 
+import com.opensymphony.xwork2.conversion.impl.XWorkBasicConverter;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -175,8 +177,19 @@ public @interface TypeConversion {
      * Note: This can not be used with ConversionRule.KEY_PROPERTY!
      *
      * @return class of the TypeConverter to be used as converter
+     * @deprecated user {@link #converterClass()} instead
      */
+    @Deprecated
     String converter() default "";
+
+    /**
+     * The class of the TypeConverter to be used as converter.
+     *
+     * Note: This can not be used with ConversionRule.KEY_PROPERTY!
+     *
+     * @return class of the TypeConverter to be used as converter
+     */
+    Class<?> converterClass() default XWorkBasicConverter.class;
 
     /**
      * If used with ConversionRule.KEY_PROPERTY specify a value here!

--- a/core/src/main/java/com/opensymphony/xwork2/conversion/impl/DefaultTypeConverterCreator.java
+++ b/core/src/main/java/com/opensymphony/xwork2/conversion/impl/DefaultTypeConverterCreator.java
@@ -19,8 +19,16 @@ public class DefaultTypeConverterCreator implements TypeConverterCreator {
     }
 
     public TypeConverter createTypeConverter(String className) throws Exception {
-        // type converters are used across users
         Object obj = objectFactory.buildBean(className, null);
+        return getTypeConverter(obj);
+    }
+
+    public TypeConverter createTypeConverter(Class<?> clazz) throws Exception {
+        Object obj = objectFactory.buildBean(clazz, null);
+        return getTypeConverter(obj);
+    }
+
+    protected TypeConverter getTypeConverter(Object obj) {
         if (obj instanceof TypeConverter) {
             return (TypeConverter) obj;
 

--- a/core/src/main/java/com/opensymphony/xwork2/conversion/impl/XWorkConverter.java
+++ b/core/src/main/java/com/opensymphony/xwork2/conversion/impl/XWorkConverter.java
@@ -487,9 +487,9 @@ public class XWorkConverter extends DefaultTypeConverter {
                     }
                     if (LOG.isDebugEnabled()) {
                         if (StringUtils.isEmpty(tc.key())) {
-                            LOG.debug("WARNING! key of @TypeConversion [{}] applied to [{}] is empty!", tc.converter(), clazz.getName());
+                            LOG.debug("WARNING! key of @TypeConversion [{}/{}] applied to [{}] is empty!", tc.converter(), tc.converterClass(), clazz.getName());
                         } else {
-                            LOG.debug("TypeConversion [{}] with key: [{}]", tc.converter(), tc.key());
+                            LOG.debug("TypeConversion [{}/{}] with key: [{}]", tc.converter(), tc.converterClass(), tc.key());
                         }
                     }
                     annotationProcessor.process(mapping, tc, tc.key());

--- a/core/src/test/java/com/opensymphony/xwork2/conversion/ConversionTestAction.java
+++ b/core/src/test/java/com/opensymphony/xwork2/conversion/ConversionTestAction.java
@@ -21,6 +21,7 @@ import com.opensymphony.xwork2.conversion.annotations.ConversionRule;
 import com.opensymphony.xwork2.conversion.annotations.ConversionType;
 import com.opensymphony.xwork2.conversion.annotations.TypeConversion;
 
+import java.math.BigInteger;
 import java.util.HashMap;
 import java.util.List;
 
@@ -49,7 +50,7 @@ public class ConversionTestAction implements Action {
         return convertInt;
     }
 
-    @TypeConversion(type = ConversionType.APPLICATION, converter = "com.opensymphony.xwork2.util.XWorkBasicConverter")
+    @TypeConversion(type = ConversionType.APPLICATION)
     public void setConvertInt( String convertInt ) {
         this.convertInt = convertInt;
     }
@@ -67,7 +68,7 @@ public class ConversionTestAction implements Action {
         return users;
     }
 
-    @TypeConversion(rule = ConversionRule.COLLECTION, converter = "java.lang.String")
+    @TypeConversion(rule = ConversionRule.COLLECTION, converterClass = String.class)
     public void setUsers( List users ) {
         this.users = users;
     }
@@ -76,7 +77,7 @@ public class ConversionTestAction implements Action {
         return keyValues;
     }
 
-    @TypeConversion(rule = ConversionRule.MAP, converter = "java.math.BigInteger")
+    @TypeConversion(rule = ConversionRule.MAP, converterClass = BigInteger.class)
     public void setKeyValues( HashMap keyValues ) {
         this.keyValues = keyValues;
     }
@@ -90,7 +91,7 @@ public class ConversionTestAction implements Action {
      *                   Application level exceptions should be handled by returning
      *                   an error value, such as Action.ERROR.
      */
-    @TypeConversion(type = ConversionType.APPLICATION, key = "java.util.Date", converter = "com.opensymphony.xwork2.util.XWorkBasicConverter")
+    @TypeConversion(type = ConversionType.APPLICATION, key = "java.util.Date")
     public String execute() throws Exception {
         return SUCCESS;
     }

--- a/core/src/test/java/com/opensymphony/xwork2/test/AnnotationDataAware.java
+++ b/core/src/test/java/com/opensymphony/xwork2/test/AnnotationDataAware.java
@@ -17,6 +17,7 @@ package com.opensymphony.xwork2.test;
 
 import com.opensymphony.xwork2.conversion.annotations.Conversion;
 import com.opensymphony.xwork2.conversion.annotations.TypeConversion;
+import com.opensymphony.xwork2.conversion.impl.FooBarConverter;
 import com.opensymphony.xwork2.util.Bar;
 import com.opensymphony.xwork2.validator.annotations.RequiredFieldValidator;
 import com.opensymphony.xwork2.validator.annotations.RequiredStringValidator;
@@ -29,15 +30,12 @@ import com.opensymphony.xwork2.validator.annotations.Validation;
  * @author Mark Woon
  * @author Rainer Hermanns
  */
-@Validation()
 @Conversion()
 public interface AnnotationDataAware {
 
     void setBarObj(Bar b);
 
-    @TypeConversion(
-            converter = "com.opensymphony.xwork2.conversion.impl.FooBarConverter"
-    )
+    @TypeConversion(converterClass = FooBarConverter.class)
     Bar getBarObj();
 
     @RequiredFieldValidator(message = "You must enter a value for data.")

--- a/core/src/test/java/com/opensymphony/xwork2/test/AnnotationTestBean2.java
+++ b/core/src/test/java/com/opensymphony/xwork2/test/AnnotationTestBean2.java
@@ -18,6 +18,7 @@ package com.opensymphony.xwork2.test;
 import com.opensymphony.xwork2.AnnotatedTestBean;
 import com.opensymphony.xwork2.conversion.annotations.Conversion;
 import com.opensymphony.xwork2.conversion.annotations.TypeConversion;
+import com.opensymphony.xwork2.conversion.impl.FooBarConverter;
 import com.opensymphony.xwork2.util.Bar;
 import com.opensymphony.xwork2.util.Cat;
 
@@ -56,9 +57,7 @@ public class AnnotationTestBean2 extends AnnotatedTestBean implements Annotation
         return cat;
     }
 
-    @TypeConversion(
-            key = "cat", converter = "com.opensymphony.xwork2.conversion.impl.FooBarConverter"
-    )
+    @TypeConversion(key = "cat", converterClass = FooBarConverter.class)
     public void setCat(Cat cat) {
         this.cat = cat;
     }

--- a/core/src/test/java/com/opensymphony/xwork2/test/AnnotationUser.java
+++ b/core/src/test/java/com/opensymphony/xwork2/test/AnnotationUser.java
@@ -82,12 +82,12 @@ public class AnnotationUser implements AnnotationUserMarker {
     }
 
     @KeyProperty( value = "name")
-    @TypeConversion( converter = "java.lang.String", rule = ConversionRule.COLLECTION)
+    @TypeConversion(converterClass = String.class, rule = ConversionRule.COLLECTION)
     public List getList() {
         return list;
     }
 
-    @TypeConversion( converter = "java.lang.String", rule = ConversionRule.MAP)
+    @TypeConversion(converterClass = String.class, rule = ConversionRule.MAP)
     public void setMap(Map m) {
         map = m;
     }

--- a/core/src/test/java/com/opensymphony/xwork2/test/annotations/PersonAction.java
+++ b/core/src/test/java/com/opensymphony/xwork2/test/annotations/PersonAction.java
@@ -11,10 +11,10 @@ import java.util.List;
 	conversions={
 		@TypeConversion(type=ConversionType.APPLICATION,
 						key="com.opensymphony.xwork2.test.annotations.Address",
-						converter="com.opensymphony.xwork2.test.annotations.AddressTypeConverter"),
+						converterClass=AddressTypeConverter.class),
 		@TypeConversion(type=ConversionType.APPLICATION,
 						key="com.opensymphony.xwork2.test.annotations.Person",
-						converter="com.opensymphony.xwork2.test.annotations.PersonTypeConverter")})
+						converterClass=PersonTypeConverter.class)})
 public class PersonAction {
 	List<Person> users;
 	private List<Address> address;

--- a/core/src/test/java/com/opensymphony/xwork2/util/AnnotatedCat.java
+++ b/core/src/test/java/com/opensymphony/xwork2/util/AnnotatedCat.java
@@ -50,9 +50,7 @@ public class AnnotatedCat {
         this.kittens = kittens;
     }
 
-    @TypeConversion(
-            key = "kittens", converter = "com.opensymphony.xwork2.util.Cat"
-    )
+    @TypeConversion(key = "kittens", converterClass = Cat.class)
     public List getKittens() {
         return kittens;
     }


### PR DESCRIPTION
This PR extends existing `TypeConversion` annotation to allow define converters as a class instead of a raw string.

Implements [WW-4210](https://issues.apache.org/jira/browse/WW-4210)