### PR TITLE
WW-4105 Considers config time class in actions chain

### DIFF
--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/source/ViewSourceAction.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/source/ViewSourceAction.java
@@ -43,6 +43,7 @@ public class ViewSourceAction extends ActionSupport implements ServletContextAwa
 
 	private String page;
 	private String className;
+	private String beanName;
 	private String config;
 
 	private List pageLines;
@@ -110,6 +111,15 @@ public class ViewSourceAction extends ActionSupport implements ServletContextAwa
 	}
 
 	/**
+	 * @param beanName the beanName to set
+	 */
+	public void setBeanName(String beanName) {
+		if (beanName != null && beanName.trim().length() > 0) {
+			this.beanName = beanName;
+		}
+	}
+
+	/**
 	 * @param config the config to set
 	 */
 	public void setConfig(String config) {
@@ -161,6 +171,13 @@ public class ViewSourceAction extends ActionSupport implements ServletContextAwa
 	 */
 	public String getClassName() {
 		return className;
+	}
+
+	/**
+	 * @return the beanName
+	 */
+	public String getBeanName() {
+		return beanName;
 	}
 
 	/**

--- a/apps/showcase/src/main/resources/struts-hangman.xml
+++ b/apps/showcase/src/main/resources/struts-hangman.xml
@@ -5,19 +5,23 @@
 
 <struts>
 	<package name="hangman" extends="struts-default" namespace="/hangman">
-		<action name="hangmanAjax" class="startHangmanAction">
+		<action name="hangmanAjax" class="org.apache.struts2.showcase.hangman.StartHangmanAction"
+				bean="startHangmanAction">
 			<result type="freemarker">/WEB-INF/hangman/hangmanAjax.ftl</result>
 		</action>
-		<action name="hangmanNonAjax" class="startHangmanAction">
+		<action name="hangmanNonAjax" class="org.apache.struts2.showcase.hangman.StartHangmanAction"
+				bean="startHangmanAction">
 			<result type="freemarker">/WEB-INF/hangman/hangmanNonAjax.ftl</result>
 		</action>
 		<action name="test">
 			<result type="freemarker">/hangman/test.ftl</result>
 		</action>
-		<action name="guessCharacter" class="guessCharacterAction">
+		<action name="guessCharacter" class="org.apache.struts2.showcase.hangman.GuessCharacterAction"
+				bean="guessCharacterAction">
 			<result type="freemarker">/WEB-INF/hangman/blank.ftl</result>
 		</action>
-		<action name="guessCharacterNonAjax" class="guessCharacterAction">
+		<action name="guessCharacterNonAjax" class="org.apache.struts2.showcase.hangman.GuessCharacterAction"
+				bean="guessCharacterAction">
 			<result type="freemarker">/WEB-INF/hangman/hangmanNonAjax.ftl</result>
 		</action>
 	</package>
@@ -28,16 +32,20 @@
 		<action name="blank">
 			<result type="freemarker">/WEB-INF/hangman/blank.ftl</result>
 		</action>
-		<action name="updateVocabCharacters" class="getUpdatedHangmanAction">
+		<action name="updateVocabCharacters" class="org.apache.struts2.showcase.hangman.GetUpdatedHangmanAction"
+				bean="getUpdatedHangmanAction">
 			<result type="freemarker">/WEB-INF/hangman/updateVocabCharacters.ftl</result>
 		</action>
-		<action name="updateCharacterAvailable" class="getUpdatedHangmanAction">
+		<action name="updateCharacterAvailable" class="org.apache.struts2.showcase.hangman.GetUpdatedHangmanAction"
+				bean="getUpdatedHangmanAction">
 			<result type="freemarker">/WEB-INF/hangman/updateCharacterAvailable.ftl</result>
 		</action>
-		<action name="updateScaffold" class="getUpdatedHangmanAction">
+		<action name="updateScaffold" class="org.apache.struts2.showcase.hangman.GetUpdatedHangmanAction"
+				bean="getUpdatedHangmanAction">
 			<result type="freemarker">/WEB-INF/hangman/updateScaffold.ftl</result>
 		</action>
-		<action name="updateGuessLeft" class="getUpdatedHangmanAction">
+		<action name="updateGuessLeft" class="org.apache.struts2.showcase.hangman.GetUpdatedHangmanAction"
+				bean="getUpdatedHangmanAction">
 			<result type="freemarker">/WEB-INF/hangman/updateGuessLeft.ftl</result>
 		</action>
 	</package>

--- a/apps/showcase/src/main/webapp/WEB-INF/decorators/main.jsp
+++ b/apps/showcase/src/main/webapp/WEB-INF/decorators/main.jsp
@@ -22,6 +22,10 @@
         }
         sourceUrl += "&className=" + inv.getProxy().getConfig().getClassName();
 
+        String beanName = inv.getProxy().getConfig().getBeanName();
+        if(null != beanName)
+            sourceUrl += "&beanName=" + beanName;
+
         if (inv.getResult() != null && inv.getResult() instanceof StrutsResultSupport) {
             sourceUrl += "&page=" + mapping.getNamespace() + "/" + ((StrutsResultSupport) inv.getResult()).getLastFinalLocation();
         }

--- a/apps/showcase/src/main/webapp/WEB-INF/viewSource.jsp
+++ b/apps/showcase/src/main/webapp/WEB-INF/viewSource.jsp
@@ -32,7 +32,8 @@
 					</pre>
 				</div>
 				<div class="tab-pane" id="java">
-					<h3><s:property default="Unknown or unavailable Action class" value="className"/></h3>
+					<h3><s:property default="Unknown or unavailable Action class" value="className"/>
+						<s:if test="%{beanName != null}">@<s:property value="beanName"/></s:if></h3>
 					<pre class="prettyprint lang-java linenums">
 						<s:iterator value="classLines" status="row">
 <s:property/></s:iterator>

--- a/core/src/main/java/com/opensymphony/xwork2/config/entities/ActionConfig.java
+++ b/core/src/main/java/com/opensymphony/xwork2/config/entities/ActionConfig.java
@@ -50,6 +50,7 @@ public class ActionConfig extends Located implements Serializable {
     protected Map<String, ResultConfig> results;
     protected List<ExceptionMappingConfig> exceptionMappings;
     protected String className;
+    protected String beanName;
     protected String methodName;
     protected String packageName;
     protected String name;
@@ -74,6 +75,7 @@ public class ActionConfig extends Located implements Serializable {
     protected ActionConfig(ActionConfig orig) {
         this.name = orig.name;
         this.className = orig.className;
+        this.beanName = orig.beanName;
         this.methodName = orig.methodName;
         this.packageName = orig.packageName;
         this.params = new LinkedHashMap<>(orig.params);
@@ -90,6 +92,10 @@ public class ActionConfig extends Located implements Serializable {
 
     public String getClassName() {
         return className;
+    }
+
+    public String getBeanName() {
+        return beanName;
     }
 
     public List<ExceptionMappingConfig> getExceptionMappings() {
@@ -151,6 +157,10 @@ public class ActionConfig extends Located implements Serializable {
             return false;
         }
 
+        if ((beanName != null) ? (!beanName.equals(actionConfig.beanName)) : (actionConfig.beanName != null)) {
+            return false;
+        }
+
         if ((name != null) ? (!name.equals(actionConfig.name)) : (actionConfig.name != null)) {
             return false;
         }
@@ -186,6 +196,7 @@ public class ActionConfig extends Located implements Serializable {
         result = 31 * result + (results != null ? results.hashCode() : 0);
         result = 31 * result + (exceptionMappings != null ? exceptionMappings.hashCode() : 0);
         result = 31 * result + (className != null ? className.hashCode() : 0);
+        result = 31 * result + (beanName != null ? beanName.hashCode() : 0);
         result = 31 * result + (methodName != null ? methodName.hashCode() : 0);
         result = 31 * result + (packageName != null ? packageName.hashCode() : 0);
         result = 31 * result + (name != null ? name.hashCode() : 0);
@@ -198,6 +209,9 @@ public class ActionConfig extends Located implements Serializable {
         sb.append("{ActionConfig ");
         sb.append(name).append(" (");
         sb.append(className);
+        if (beanName != null) {
+            sb.append("@").append(beanName);
+        }
         if (methodName != null) {
             sb.append(".").append(methodName).append("()");
         }
@@ -241,6 +255,11 @@ public class ActionConfig extends Located implements Serializable {
 
         public Builder className(String name) {
             target.className = name;
+            return this;
+        }
+
+        public Builder beanName(String name) {
+            target.beanName = name;
             return this;
         }
 

--- a/core/src/main/java/com/opensymphony/xwork2/config/impl/ActionConfigMatcher.java
+++ b/core/src/main/java/com/opensymphony/xwork2/config/impl/ActionConfigMatcher.java
@@ -112,6 +112,7 @@ public class ActionConfigMatcher extends AbstractMatcher<ActionConfig> implement
         }
 
         return new ActionConfig.Builder(pkgName, orig.getName(), className)
+                .beanName(orig.getBeanName())
                 .methodName(methodName)
                 .addParams(params)
                 .addResultConfigs(results)

--- a/core/src/main/java/com/opensymphony/xwork2/config/providers/XmlConfigurationProvider.java
+++ b/core/src/main/java/com/opensymphony/xwork2/config/providers/XmlConfigurationProvider.java
@@ -432,6 +432,7 @@ public class XmlConfigurationProvider implements ConfigurationProvider {
     protected void addAction(Element actionElement, PackageConfig.Builder packageContext) throws ConfigurationException {
         String name = actionElement.getAttribute("name");
         String className = actionElement.getAttribute("class");
+        String beanName = StringUtils.trimToNull(actionElement.getAttribute("bean"));
         //methodName should be null if it's not set
         String methodName = StringUtils.trimToNull(actionElement.getAttribute("method"));
         Location location = DomHelper.getLocationObject(actionElement);
@@ -471,6 +472,7 @@ public class XmlConfigurationProvider implements ConfigurationProvider {
         Set<String> allowedMethods = buildAllowedMethods(actionElement, packageContext);
 
         ActionConfig actionConfig = new ActionConfig.Builder(packageContext.getName(), name, className)
+                .beanName(beanName)
                 .methodName(methodName)
                 .addResultConfigs(results)
                 .addInterceptors(interceptorList)

--- a/core/src/main/java/com/opensymphony/xwork2/factory/DefaultActionFactory.java
+++ b/core/src/main/java/com/opensymphony/xwork2/factory/DefaultActionFactory.java
@@ -19,7 +19,11 @@ public class DefaultActionFactory implements ActionFactory {
     }
 
     public Object buildAction(String actionName, String namespace, ActionConfig config, Map<String, Object> extraContext) throws Exception {
-        return objectFactory.buildBean(config.getClassName(), extraContext);
+        String beanName = config.getBeanName();
+        if(null == beanName) {
+            beanName = config.getClassName();
+        }
+        return objectFactory.buildBean(beanName, extraContext);
     }
 
 }

--- a/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlReflectionProvider.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlReflectionProvider.java
@@ -70,7 +70,12 @@ public class OgnlReflectionProvider implements ReflectionProvider {
 
     public void copy(Object from, Object to, Map<String, Object> context,
             Collection<String> exclusions, Collection<String> inclusions) {
-        ognlUtil.copy(from, to, context, exclusions, inclusions);
+        copy(from, to, context, exclusions, inclusions, null);
+    }
+
+    public void copy(Object from, Object to, Map<String, Object> context,
+            Collection<String> exclusions, Collection<String> inclusions, Class<?> editable) {
+        ognlUtil.copy(from, to, context, exclusions, inclusions, editable);
     }
 
     public Object getRealTarget(String property, Map<String, Object> context, Object root)

--- a/core/src/main/java/com/opensymphony/xwork2/util/reflection/ReflectionProvider.java
+++ b/core/src/main/java/com/opensymphony/xwork2/util/reflection/ReflectionProvider.java
@@ -72,7 +72,23 @@ public interface ReflectionProvider {
      *                   note if exclusions AND inclusions are supplied and not null nothing will get copied.
      */
     void copy(Object from, Object to, Map<String, Object> context, Collection<String> exclusions, Collection<String> inclusions);
-    
+
+    /**
+     * Copies the properties in the object "from" and sets them in the object "to"
+     * only setting properties defined in the given "editable" class (or interface)
+     * using specified type converter, or {@link com.opensymphony.xwork2.conversion.impl.XWorkConverter} if none
+     * is specified.
+     *
+     * @param from       the source object
+     * @param to         the target object
+     * @param context    the action context we're running under
+     * @param exclusions collection of method names to excluded from copying ( can be null)
+     * @param inclusions collection of method names to included copying  (can be null)
+     *                   note if exclusions AND inclusions are supplied and not null nothing will get copied.
+	 * @param editable the class (or interface) to restrict property setting to
+     */
+    void copy(Object from, Object to, Map<String, Object> context, Collection<String> exclusions, Collection<String> inclusions, Class<?> editable);
+
     /**
      * Looks for the real target with the specified property given a root Object which may be a
      * CompoundRoot.

--- a/core/src/main/resources/struts-2.5.dtd
+++ b/core/src/main/resources/struts-2.5.dtd
@@ -98,6 +98,7 @@
 <!ATTLIST action
     name CDATA #REQUIRED
     class CDATA #IMPLIED
+    bean CDATA #IMPLIED
     method CDATA #IMPLIED
     converter CDATA #IMPLIED
 >

--- a/core/src/main/resources/xwork-2.5.dtd
+++ b/core/src/main/resources/xwork-2.5.dtd
@@ -77,6 +77,7 @@
 <!ATTLIST action
     name CDATA #REQUIRED
     class CDATA #IMPLIED
+    bean CDATA #IMPLIED
     method CDATA #IMPLIED
     converter CDATA #IMPLIED
 >

--- a/core/src/test/java/com/opensymphony/xwork2/TestSubBean.java
+++ b/core/src/test/java/com/opensymphony/xwork2/TestSubBean.java
@@ -1,0 +1,14 @@
+package com.opensymphony.xwork2;
+
+public class TestSubBean extends TestBean {
+
+    private String issueId;
+
+    public String getIssueId() {
+        return issueId;
+    }
+
+    public void setIssueId(String issueId) {
+        this.issueId = issueId;
+    }
+}

--- a/core/src/test/java/com/opensymphony/xwork2/config/entities/ActionConfigTest.java
+++ b/core/src/test/java/com/opensymphony/xwork2/config/entities/ActionConfigTest.java
@@ -25,12 +25,13 @@ public class ActionConfigTest extends XWorkTestCase {
 
     public void testToString() {
         ActionConfig cfg = new ActionConfig.Builder("", "bob", "foo.Bar")
+                .beanName("bean")
                 .methodName("execute")
                 .location(new LocationImpl(null, "foo/xwork.xml", 10, 12))
                 .build();
 
         assertTrue("Wrong toString(): "+cfg.toString(), 
-            "{ActionConfig bob (foo.Bar.execute()) - foo/xwork.xml:10:12 - allowedMethods=[LiteralAllowedMethod{allowedMethod='execute'}]}".equals(cfg.toString()));
+            "{ActionConfig bob (foo.Bar@bean.execute()) - foo/xwork.xml:10:12 - allowedMethods=[LiteralAllowedMethod{allowedMethod='execute'}]}".equals(cfg.toString()));
     }
     
     public void testToStringWithNoMethod() {

--- a/core/src/test/java/com/opensymphony/xwork2/interceptor/ChainingInterceptorTest.java
+++ b/core/src/test/java/com/opensymphony/xwork2/interceptor/ChainingInterceptorTest.java
@@ -17,6 +17,8 @@ package com.opensymphony.xwork2.interceptor;
 
 import com.mockobjects.dynamic.Mock;
 import com.opensymphony.xwork2.*;
+import com.opensymphony.xwork2.config.entities.ActionConfig;
+import com.opensymphony.xwork2.mock.MockActionProxy;
 import com.opensymphony.xwork2.util.ValueStack;
 
 import java.util.*;
@@ -31,6 +33,8 @@ public class ChainingInterceptorTest extends XWorkTestCase {
 
     ActionInvocation invocation;
     ChainingInterceptor interceptor;
+    MockActionProxy mockActionProxy;
+    ActionConfig actionConfig;
     Mock mockInvocation;
     ValueStack stack;
 
@@ -148,11 +152,18 @@ public class ChainingInterceptorTest extends XWorkTestCase {
     protected void setUp() throws Exception {
         super.setUp();
         stack = ActionContext.getContext().getValueStack();
+
+        mockActionProxy = new MockActionProxy();
+        actionConfig = new ActionConfig.Builder("", "", "")
+                .build();
+        mockActionProxy.setConfig(actionConfig);
+
         mockInvocation = new Mock(ActionInvocation.class);
         mockInvocation.expectAndReturn("getStack", stack);
         mockInvocation.expectAndReturn("invoke", Action.SUCCESS);
         mockInvocation.expectAndReturn("getInvocationContext", new ActionContext(new HashMap<String, Object>()));
         mockInvocation.expectAndReturn("getResult", new ActionChainResult());
+        mockInvocation.expectAndReturn("getProxy", mockActionProxy);
         invocation = (ActionInvocation) mockInvocation.proxy();
         interceptor = new ChainingInterceptor();
         container.inject(interceptor);

--- a/core/src/test/java/com/opensymphony/xwork2/spring/ActionsFromSpringTest.java
+++ b/core/src/test/java/com/opensymphony/xwork2/spring/ActionsFromSpringTest.java
@@ -77,4 +77,20 @@ public class ActionsFromSpringTest extends XWorkTestCase {
     	        assertTrue(springResult.isInitialize());
     	        assertNotNull(springResult.getStringParameter());
     }
+
+    public void testChainingAOPedActions() throws Exception {
+        ActionProxy proxy = actionProxyFactory.createActionProxy(null, "chainedAOPedTestBeanAction", null, null);
+
+        proxy.execute();
+
+        TestSubBean chaintoAOPedAction = (TestSubBean) appContext.getBean("pointcutted-test-sub-bean");
+        TestSubBean aspectState = (TestSubBean) appContext.getBean("aspected-test-sub-bean");
+
+        assertEquals(1, chaintoAOPedAction.getCount()); //check if chain
+        assertEquals("WW-4105", chaintoAOPedAction.getName());
+        assertNotNull(aspectState.getIssueId());   //and AOP
+        assertNotNull(aspectState.getName());
+        assertEquals(aspectState.getName(), aspectState.getIssueId());
+        assertEquals("WW-4105", aspectState.getIssueId());   //work together without any problem
+    }
 }

--- a/core/src/test/java/com/opensymphony/xwork2/spring/SpringObjectFactoryTest.java
+++ b/core/src/test/java/com/opensymphony/xwork2/spring/SpringObjectFactoryTest.java
@@ -122,6 +122,19 @@ public class SpringObjectFactoryTest extends XWorkTestCase {
         assertEquals(SimpleAction.class, action.getClass());
     }
 
+    public void testObtainActionBySpringNameKeepConfigClass() throws Exception {
+        sac.registerSingleton("simple-action-kcc", SimpleAction.class, new MutablePropertyValues());
+        SimpleAction bean = (SimpleAction) sac.getBean("simple-action-kcc");
+
+        ActionConfig actionConfig = new ActionConfig.Builder("fs", "jim", SimpleAction.class.getName())
+                .beanName("simple-action-kcc")
+                .build();
+        Object action = objectFactory.buildAction("", "", actionConfig, null);
+
+        assertEquals(SimpleAction.class, action.getClass());
+        assertEquals(bean, action);
+    }
+
     public void testObtainInterceptorBySpringName() throws Exception {
         sac.registerSingleton("timer-interceptor", TimerInterceptor.class, new MutablePropertyValues());
 
@@ -220,6 +233,25 @@ public class SpringObjectFactoryTest extends XWorkTestCase {
 
         ActionConfig actionConfig = new ActionConfig.Builder("jim", "bob", "simple-action").build();
         SimpleAction simpleAction = (SimpleAction) objectFactory.buildBean(actionConfig.getClassName(), null);
+        objectFactory.autoWireBean(simpleAction);
+        assertEquals(simpleAction.getBean(), bean);
+    }
+
+    public void testSetAutowireStrategyKeepConfigClass() throws Exception {
+        assertEquals(objectFactory.getAutowireStrategy(), AutowireCapableBeanFactory.AUTOWIRE_BY_NAME);
+
+        objectFactory.setAutowireStrategy(AutowireCapableBeanFactory.AUTOWIRE_BY_TYPE);
+
+        sac.getBeanFactory().registerSingleton("bean", new TestBean());
+        TestBean bean = (TestBean) sac.getBean("bean");
+
+        sac.registerPrototype("simple-action", SimpleAction.class, new MutablePropertyValues());
+
+        ActionConfig actionConfig = new ActionConfig.Builder("jim", "bob", SimpleAction.class.getName())
+                .beanName("simple-action")
+                .build();
+        SimpleAction simpleAction = (SimpleAction) objectFactory.buildAction("", "", actionConfig,
+                null);
         objectFactory.autoWireBean(simpleAction);
         assertEquals(simpleAction.getBean(), bean);
     }

--- a/core/src/test/resources/com/opensymphony/xwork2/spring/actionContext-spring.xml
+++ b/core/src/test/resources/com/opensymphony/xwork2/spring/actionContext-spring.xml
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aop="http://www.springframework.org/schema/aop"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-          http://www.springframework.org/schema/beans/spring-beans.xsd">
+          http://www.springframework.org/schema/beans/spring-beans.xsd
+          http://www.springframework.org/schema/aop
+          http://www.springframework.org/schema/aop/spring-aop.xsd">
 
 	<bean id="simple-action" class="com.opensymphony.xwork2.SimpleAction" scope="prototype"/>
 
@@ -40,4 +43,25 @@
     <bean id="springResult" class="com.opensymphony.xwork2.spring.SpringResult" init-method="initialize">
 		<property name="stringParameter" value="my string"/>
 	</bean>
+
+    <bean id="pointcutted-test-bean" class="com.opensymphony.xwork2.TestBean">
+        <property name="name"><value>WW-4105</value></property>
+        <property name="count"><value>1</value></property>
+    </bean>
+    <bean id="pointcutted-test-sub-bean" class="com.opensymphony.xwork2.TestSubBean">
+        <property name="issueId"><value>WW-4105</value></property>
+    </bean>
+    <bean id="aspected-test-sub-bean" class="com.opensymphony.xwork2.TestSubBean" />
+    <aop:config>
+        <aop:aspect id="myAspect" ref="aspected-test-sub-bean">
+            <aop:pointcut id="testBeanGetName"
+                expression="execution(String com.opensymphony.xwork2.TestBean.getName()) and bean(pointcutted-test-bean)" />
+            <aop:after-returning pointcut-ref="testBeanGetName"
+                method="setIssueId" returning="issueId" />
+            <aop:pointcut id="testSubBeanGetIssueId"
+                expression="execution(String com.opensymphony.xwork2.TestSubBean.getIssueId()) and bean(pointcutted-test-sub-bean)" />
+            <aop:after-returning pointcut-ref="testSubBeanGetIssueId"
+                method="setName" returning="name" />
+        </aop:aspect>
+    </aop:config>
 </beans>

--- a/core/src/test/resources/com/opensymphony/xwork2/spring/actionContext-xwork.xml
+++ b/core/src/test/resources/com/opensymphony/xwork2/spring/actionContext-xwork.xml
@@ -1,4 +1,4 @@
-<!DOCTYPE xwork PUBLIC "-//Apache Struts//XWork 2.0//EN" "http://struts.apache.org/dtds/xwork-2.0.dtd">
+<!DOCTYPE xwork PUBLIC "-//Apache Struts//XWork 2.5//EN" "http://struts.apache.org/dtds/xwork-2.5.dtd">
 <xwork>
 	<bean type="com.opensymphony.xwork2.ObjectFactory" class="com.opensymphony.xwork2.spring.SpringObjectFactory" />
 	<constant name="applicationContextPath" value="com/opensymphony/xwork2/spring/actionContext-spring.xml" />
@@ -6,7 +6,14 @@
         <result-types>
             <result-type name="null" class="com.opensymphony.xwork2.mock.MockResult" default="true"/>
             <result-type name="springResult" class="springResult" />
+            <result-type name="chain"
+                class="com.opensymphony.xwork2.ActionChainResult" />
         </result-types>
+
+        <interceptors>
+            <interceptor name="chain"
+                class="com.opensymphony.xwork2.interceptor.ChainingInterceptor"></interceptor>
+        </interceptors>
 
 		<action name="simpleAction" class="simple-action"/>
 
@@ -19,5 +26,17 @@
         <action name="simpleActionSpringResult" class="simple-action">
 			<result name="error" type="springResult"/>
 		</action>
+
+        <action name="chainedAOPedTestBeanAction" class="com.opensymphony.xwork2.TestBean"
+                bean="pointcutted-test-bean" method="getName">
+            <result name="WW-4105" type="chain">
+                <param name="actionName">chaintoAOPedTestSubBeanAction</param>
+            </result>
+        </action>
+        <action name="chaintoAOPedTestSubBeanAction" class="com.opensymphony.xwork2.TestSubBean"
+                bean="pointcutted-test-sub-bean" method="getIssueId">
+            <interceptor-ref name="chain" />
+            <result name="WW-4105" type="null" />
+        </action>
     </package>
 </xwork>

--- a/plugins/convention/src/main/java/org/apache/struts2/convention/PackageBasedActionConfigBuilder.java
+++ b/plugins/convention/src/main/java/org/apache/struts2/convention/PackageBasedActionConfigBuilder.java
@@ -916,15 +916,20 @@ public class PackageBasedActionConfigBuilder implements ActionConfigBuilder {
     protected void createActionConfig(PackageConfig.Builder pkgCfg, Class<?> actionClass, String actionName,
                                       String actionMethod, Action annotation, Set<String> allowedMethods) {
     	String className = actionClass.getName();
+        String beanName = null;
         if (annotation != null) {
             actionName = annotation.value() != null && annotation.value().equals(Action.DEFAULT_VALUE) ? actionName : annotation.value();
             actionName = StringUtils.contains(actionName, "/") && !slashesInActionNames ? StringUtils.substringAfterLast(actionName, "/") : actionName;
             if(!Action.DEFAULT_VALUE.equals(annotation.className())){
             	className = annotation.className();
             }
+            if(!Action.DEFAULT_VALUE.equals(annotation.beanName())){
+                beanName = StringUtils.trimToNull(annotation.beanName());
+            }
         }
 
         ActionConfig.Builder actionConfig = new ActionConfig.Builder(pkgCfg.getName(), actionName, className);
+        actionConfig.beanName(beanName);
         actionConfig.methodName(actionMethod);
 
         if (pkgCfg.isStrictMethodInvocation()) {

--- a/plugins/convention/src/main/java/org/apache/struts2/convention/annotation/Action.java
+++ b/plugins/convention/src/main/java/org/apache/struts2/convention/annotation/Action.java
@@ -99,4 +99,11 @@ public @interface Action {
      * @return The class name for the action.
      */
     String className() default DEFAULT_VALUE;
+
+    /**
+     * Allows actions to specify bean name.
+     *
+     * @return The bean name for the action.
+     */
+    String beanName() default DEFAULT_VALUE;
 }

--- a/plugins/convention/src/test/java/org/apache/struts2/convention/PackageBasedActionConfigBuilderTest.java
+++ b/plugins/convention/src/test/java/org/apache/struts2/convention/PackageBasedActionConfigBuilderTest.java
@@ -374,7 +374,7 @@ public class PackageBasedActionConfigBuilderTest extends TestCase {
         verifyActionConfig(pkgConfig, "action1", ActionNameAction.class, "run1", pkgConfig.getName());
         verifyActionConfig(pkgConfig, "action2", ActionNameAction.class, "run2", pkgConfig.getName());
         verifyMissingActionConfig(pkgConfig, "foo", DontFindMeAction.class, "foo", pkgConfig.getName());
-        verifyActionConfig(pkgConfig, "action3", "someClassName", "run1", pkgConfig.getName());
+        verifyActionConfig(pkgConfig, "action3", "someClassName", "someBeanName", "run1", pkgConfig.getName());
         verifyActionConfig(pkgConfig, "actions1", ActionNamesAction.class, "run", pkgConfig.getName());
         verifyActionConfig(pkgConfig, "actions2", ActionNamesAction.class, "run", pkgConfig.getName());
         verifyActionConfig(pkgConfig, "action", SingleActionNameAction.class, "run", pkgConfig.getName());
@@ -661,10 +661,12 @@ public class PackageBasedActionConfigBuilderTest extends TestCase {
         assertNull(ac);
     }
 
-    private void verifyActionConfig(PackageConfig pkgConfig, String actionName, String actionClass, String methodName, String packageName) {
+    private void verifyActionConfig(PackageConfig pkgConfig, String actionName, String actionClass, String actionBean,
+                                    String methodName, String packageName) {
         ActionConfig ac = pkgConfig.getAllActionConfigs().get(actionName);
         assertNotNull(ac);
         assertEquals(actionClass, ac.getClassName());
+        assertEquals(actionBean, ac.getBeanName());
         assertEquals(methodName, ac.getMethodName());
         assertEquals(packageName, ac.getPackageName());
     }

--- a/plugins/convention/src/test/java/org/apache/struts2/convention/actions/action/ClassNameAction.java
+++ b/plugins/convention/src/test/java/org/apache/struts2/convention/actions/action/ClassNameAction.java
@@ -29,7 +29,7 @@ import org.apache.struts2.convention.annotation.Action;
  */
 public class ClassNameAction {
 
-    @Action(value = "action3", className = "someClassName")
+    @Action(value = "action3", className = "someClassName", beanName = "someBeanName")
     public String run1() {
         return null;
     }


### PR DESCRIPTION
I think it is `ready for merge` and does not break backward compatibility. The added `bean` attribute is and should be optional always.

If you agree and merged this, then [784bb23](https://github.com/yasserzamani/struts/commit/784bb235e2ffcfcd7a5f2f47965ca0183e952ddd) will be a base for other possible enhancements like:

- Considering config time class of the action in parameters interceptor enhances S2 security (details already have been submitted to `security@struts.apache.org`).
- Considering config time class of the action in json result has similar impacts (prevents action information to be leaked to attacker).

What do you think?

# Documentation
Mainly, this is about how to deal when run time class of the action is not same as the config time, e.g. when action is proxified with a 3rd party technology or when the creation of action is with object factory. At this point, operating S2 inside that technology or object factory makes problems or potential security issues. So S2 always needs to know config time class of the action to operate in it's own borders only.

Currently S2 uses `class` attribute for both config time class or bean name of the action inside object factory. When the user uses `class` attribute as a bean name, S2 looses this information, config time class of the action. This PR gives it back to S2 by [784bb23](https://github.com/yasserzamani/struts/commit/784bb235e2ffcfcd7a5f2f47965ca0183e952ddd) and presents a resolution for [WW-4105](https://issues.apache.org/jira/browse/WW-4105) as an example which shows how to consider config time class of the action in sensitive places by [e95224f](https://github.com/apache/struts/pull/133/commits/e95224f26aa17dad6ad490473b4aeab1d2ceaf79).