### PR TITLE
WW-4835: Configurable handlers

### DIFF
--- a/plugins/rest/src/main/java/org/apache/struts2/rest/ContentTypeHandlerManager.java
+++ b/plugins/rest/src/main/java/org/apache/struts2/rest/ContentTypeHandlerManager.java
@@ -21,6 +21,7 @@
 
 package org.apache.struts2.rest;
 
+import com.opensymphony.xwork2.ActionInvocation;
 import org.apache.struts2.rest.handler.ContentTypeHandler;
 
 import javax.servlet.http.HttpServletRequest;
@@ -59,10 +60,16 @@ public interface ContentTypeHandlerManager {
      * @param target The object to return, usually the action object
      * @return The new result code to process
      * @throws IOException If unable to write to the response
+     *
+     * @deprecated use version which requires {@link ActionInvocation}
      */
+    @Deprecated
     String handleResult(ActionConfig actionConfig, Object methodResult, Object target)
             throws IOException;
     
+    String handleResult(ActionInvocation actionInvocation, Object methodResult, Object target)
+            throws IOException;
+
     /**
      * Finds the extension in the url
      * 

--- a/plugins/rest/src/main/java/org/apache/struts2/rest/ContentTypeInterceptor.java
+++ b/plugins/rest/src/main/java/org/apache/struts2/rest/ContentTypeInterceptor.java
@@ -57,7 +57,7 @@ public class ContentTypeInterceptor extends AbstractInterceptor {
         if (request.getContentLength() > 0) {
             InputStream is = request.getInputStream();
             InputStreamReader reader = new InputStreamReader(is);
-            handler.toObject(reader, target);
+            handler.toObject(invocation, reader, target);
         }
         return invocation.invoke();
     }

--- a/plugins/rest/src/main/java/org/apache/struts2/rest/DefaultContentTypeHandlerManager.java
+++ b/plugins/rest/src/main/java/org/apache/struts2/rest/DefaultContentTypeHandlerManager.java
@@ -21,9 +21,12 @@
 
 package org.apache.struts2.rest;
 
+import com.opensymphony.xwork2.ActionInvocation;
 import com.opensymphony.xwork2.config.entities.ActionConfig;
 import com.opensymphony.xwork2.inject.Container;
 import com.opensymphony.xwork2.inject.Inject;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.struts2.ServletActionContext;
 import org.apache.struts2.rest.handler.ContentTypeHandler;
 
@@ -40,6 +43,8 @@ import java.util.Set;
  * process results
  */
 public class DefaultContentTypeHandlerManager implements ContentTypeHandlerManager {
+
+    private static final Logger LOG = LogManager.getLogger(DefaultContentTypeHandlerManager.class);
 
     /** ContentTypeHandlers keyed by the extension */
     Map<String, ContentTypeHandler> handlersByExtension = new HashMap<String, ContentTypeHandler>();
@@ -115,7 +120,7 @@ public class DefaultContentTypeHandlerManager implements ContentTypeHandlerManag
 
     /**
      * Gets the handler for the response by looking at the extension of the request
-     * @param req The request
+     * @param request The request
      * @return The appropriate handler
      *
      * WW-4588: modified to get a handler for the response side and auto generate the response type
@@ -153,20 +158,28 @@ public class DefaultContentTypeHandlerManager implements ContentTypeHandlerManag
         return handler;
     }
 
+    @Override
+    public String handleResult(ActionConfig actionConfig, Object methodResult, Object target) throws IOException {
+        LOG.warn("This method is deprecated!");
+        return readResultCode(methodResult);
+    }
+
     /**
      * Handles the result using handlers to generate content type-specific content
      * 
-     * @param actionConfig The action config for the current request
+     * @param invocation The action invocation for the current request
      * @param methodResult The object returned from the action method
      * @param target The object to return, usually the action object
      * @return The new result code to process
      * @throws IOException If unable to write to the response
      */
-    public String handleResult(ActionConfig actionConfig, Object methodResult, Object target) throws IOException {
+    public String handleResult(ActionInvocation invocation, Object methodResult, Object target) throws IOException {
         String resultCode = readResultCode(methodResult);
         Integer statusCode = readStatusCode(methodResult);
         HttpServletRequest req = ServletActionContext.getRequest();
         HttpServletResponse res = ServletActionContext.getResponse();
+        ActionConfig actionConfig = invocation.getProxy().getConfig();
+
         if(statusCode != null) {
             res.setStatus(statusCode);
         }
@@ -178,7 +191,7 @@ public class DefaultContentTypeHandlerManager implements ContentTypeHandlerManag
                 resultCode = extCode;
             } else {
                 StringWriter writer = new StringWriter();
-                resultCode = handler.fromObject(target, resultCode, writer);
+                resultCode = handler.fromObject(invocation, target, resultCode, writer);
                 String text = writer.toString();
                 if (text.length() > 0) {
                     byte[] data = text.getBytes("UTF-8");

--- a/plugins/rest/src/main/java/org/apache/struts2/rest/RestActionInvocation.java
+++ b/plugins/rest/src/main/java/org/apache/struts2/rest/RestActionInvocation.java
@@ -224,7 +224,7 @@ public class RestActionInvocation extends DefaultActionInvocation {
         if (handler != null && !(handler instanceof HtmlHandler)) {
 
             // Specific representation (json, xml...)
-            resultCode = handlerSelector.handleResult(this.getProxy().getConfig(), httpHeaders, target);
+            resultCode = handlerSelector.handleResult(this, httpHeaders, target);
         } else {
             // Normal struts execution (html o other struts result)
             findResult();

--- a/plugins/rest/src/main/java/org/apache/struts2/rest/RestWorkflowInterceptor.java
+++ b/plugins/rest/src/main/java/org/apache/struts2/rest/RestWorkflowInterceptor.java
@@ -221,7 +221,7 @@ public class RestWorkflowInterceptor extends MethodFilterInterceptor {
             	
             	errors.put("actionErrors", validationAwareAction.getActionErrors());
             	errors.put("fieldErrors", validationAwareAction.getFieldErrors());
-            	return manager.handleResult(invocation.getProxy().getConfig(), info, errors);
+            	return manager.handleResult(invocation, info, errors);
             }
         }
 

--- a/plugins/rest/src/main/java/org/apache/struts2/rest/handler/AbstractContentTypeHandler.java
+++ b/plugins/rest/src/main/java/org/apache/struts2/rest/handler/AbstractContentTypeHandler.java
@@ -1,6 +1,4 @@
 /*
- * $Id$
- *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -21,40 +19,26 @@
 
 package org.apache.struts2.rest.handler;
 
-import com.opensymphony.xwork2.ActionInvocation;
-import com.thoughtworks.xstream.XStream;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
 import java.io.Reader;
 import java.io.Writer;
 
-/**
- * Handles XML content
- */
-public class XStreamHandler extends AbstractContentTypeHandler {
+abstract public class AbstractContentTypeHandler implements ContentTypeHandler {
 
-    public String fromObject(ActionInvocation invocation, Object obj, String resultCode, Writer out) throws IOException {
-        if (obj != null) {
-            XStream xstream = createXStream();
-            xstream.toXML(obj, out);
-        }
+    private static final Logger LOG = LogManager.getLogger(AbstractContentTypeHandler.class);
+
+    @Override
+    public void toObject(Reader in, Object target) throws IOException {
+        LOG.warn("This method is deprecated!");
+    }
+
+    @Override
+    public String fromObject(Object obj, String resultCode, Writer stream) throws IOException {
+        LOG.warn("This method is deprecated!");
         return null;
     }
 
-    public void toObject(ActionInvocation invocation, Reader in, Object target) {
-        XStream xstream = createXStream();
-        xstream.fromXML(in, target);
-    }
-    
-    protected XStream createXStream() {
-        return new XStream();
-    }
-
-    public String getContentType() {
-        return "application/xml";
-    }
-
-    public String getExtension() {
-        return "xml";
-    }
 }

--- a/plugins/rest/src/main/java/org/apache/struts2/rest/handler/ContentTypeHandler.java
+++ b/plugins/rest/src/main/java/org/apache/struts2/rest/handler/ContentTypeHandler.java
@@ -21,6 +21,8 @@
 
 package org.apache.struts2.rest.handler;
 
+import com.opensymphony.xwork2.ActionInvocation;
+
 import java.io.IOException;
 import java.io.Reader;
 import java.io.Writer;
@@ -35,9 +37,14 @@ public interface ContentTypeHandler {
      * @param in The input stream, usually the body of the request
      * @param target The target, usually the action class
      * @throws IOException If unable to write to the output stream
+     *
+     * @deprecated use version which requires {@link ActionInvocation}
      */
+    @Deprecated
     void toObject(Reader in, Object target) throws IOException;
-    
+
+    void toObject(ActionInvocation invocation, Reader in, Object target) throws IOException;
+
     /**
      * Writes content to the stream
      * 
@@ -46,9 +53,14 @@ public interface ContentTypeHandler {
      * @param stream The output stream, usually the response
      * @return The new result code
      * @throws IOException If unable to write to the output stream
+     *
+     * @deprecated use version which requires {@link ActionInvocation}
      */
+    @Deprecated
     String fromObject(Object obj, String resultCode, Writer stream) throws IOException;
-    
+
+    String fromObject(ActionInvocation invocation, Object obj, String resultCode, Writer stream) throws IOException;
+
     /**
      * Gets the content type for this handler
      * 

--- a/plugins/rest/src/main/java/org/apache/struts2/rest/handler/FormUrlEncodedHandler.java
+++ b/plugins/rest/src/main/java/org/apache/struts2/rest/handler/FormUrlEncodedHandler.java
@@ -20,6 +20,8 @@
  */
 package org.apache.struts2.rest.handler;
 
+import com.opensymphony.xwork2.ActionInvocation;
+
 import java.io.Writer;
 import java.io.IOException;
 import java.io.Reader;
@@ -34,11 +36,11 @@ import java.io.Reader;
  * @see <a href="http://www.w3.org/TR/html401/interact/forms.html#h-17.13.4">http://www.w3.org/TR/html401/interact/forms.html#h-17.13.4</a>
  *
  */
-public class FormUrlEncodedHandler implements ContentTypeHandler {
+public class FormUrlEncodedHandler extends  AbstractContentTypeHandler {
 
     public static final String CONTENT_TYPE = "application/x-www-form-urlencoded";
 
-    public String fromObject(Object obj, String resultCode, Writer out) throws IOException {
+    public String fromObject(ActionInvocation invocation, Object obj, String resultCode, Writer out) throws IOException {
         throw new IOException("Conversion from Object to '"+getContentType()+"' is not supported");
     }
 
@@ -48,7 +50,7 @@ public class FormUrlEncodedHandler implements ContentTypeHandler {
      * @param in The input stream, usually the body of the request
      * @param target The target, usually the action class
      */
-    public void toObject(Reader in, Object target) {
+    public void toObject(ActionInvocation invocation, Reader in, Object target) {
     }
 
     /**

--- a/plugins/rest/src/main/java/org/apache/struts2/rest/handler/HtmlHandler.java
+++ b/plugins/rest/src/main/java/org/apache/struts2/rest/handler/HtmlHandler.java
@@ -21,6 +21,8 @@
 
 package org.apache.struts2.rest.handler;
 
+import com.opensymphony.xwork2.ActionInvocation;
+
 import java.io.IOException;
 import java.io.Reader;
 import java.io.Writer;
@@ -28,13 +30,13 @@ import java.io.Writer;
 /**
  * Handles HTML content, usually just a simple passthrough to the framework
  */
-public class HtmlHandler implements ContentTypeHandler {
+public class HtmlHandler extends AbstractContentTypeHandler {
 
-    public String fromObject(Object obj, String resultCode, Writer out) throws IOException {
+    public String fromObject(ActionInvocation invocation, Object obj, String resultCode, Writer out) throws IOException {
         return resultCode;
     }
 
-    public void toObject(Reader in, Object target) {
+    public void toObject(ActionInvocation invocation, Reader in, Object target) {
     }
 
     public String getExtension() {

--- a/plugins/rest/src/main/java/org/apache/struts2/rest/handler/JacksonLibHandler.java
+++ b/plugins/rest/src/main/java/org/apache/struts2/rest/handler/JacksonLibHandler.java
@@ -24,6 +24,7 @@ package org.apache.struts2.rest.handler;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.opensymphony.xwork2.ActionInvocation;
 import com.opensymphony.xwork2.inject.Inject;
 import org.apache.struts2.StrutsConstants;
 
@@ -34,19 +35,19 @@ import java.io.Writer;
 /**
  * Handles JSON content using jackson-lib
  */
-public class JacksonLibHandler implements ContentTypeHandler {
+public class JacksonLibHandler extends AbstractContentTypeHandler {
 
     private static final String DEFAULT_CONTENT_TYPE = "application/json";
     private String defaultEncoding = "ISO-8859-1";
     private ObjectMapper mapper = new ObjectMapper();
 
-    public void toObject(Reader in, Object target) throws IOException {
+    public void toObject(ActionInvocation invocation, Reader in, Object target) throws IOException {
         mapper.configure(SerializationFeature.WRITE_NULL_MAP_VALUES, false);
         ObjectReader or = mapper.readerForUpdating(target);
         or.readValue(in);
     }
 
-    public String fromObject(Object obj, String resultCode, Writer stream) throws IOException {
+    public String fromObject(ActionInvocation invocation, Object obj, String resultCode, Writer stream) throws IOException {
         mapper.configure(SerializationFeature.WRITE_NULL_MAP_VALUES, false);
         mapper.writeValue(stream, obj);
         return null;

--- a/plugins/rest/src/main/java/org/apache/struts2/rest/handler/JsonLibHandler.java
+++ b/plugins/rest/src/main/java/org/apache/struts2/rest/handler/JsonLibHandler.java
@@ -26,6 +26,7 @@ import java.io.Reader;
 import java.io.Writer;
 import java.util.Collection;
 
+import com.opensymphony.xwork2.ActionInvocation;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 import net.sf.json.JsonConfig;
@@ -37,12 +38,12 @@ import com.opensymphony.xwork2.inject.Inject;
 /**
  * Handles JSON content using json-lib
  */
-public class JsonLibHandler implements ContentTypeHandler {
+public class JsonLibHandler extends AbstractContentTypeHandler {
 
     private static final String DEFAULT_CONTENT_TYPE = "application/json";
     private String defaultEncoding = "ISO-8859-1";
 
-    public void toObject(Reader in, Object target) throws IOException {
+    public void toObject(ActionInvocation invocation, Reader in, Object target) throws IOException {
         StringBuilder sb = new StringBuilder();
         char[] buffer = new char[1024];
         int len = 0;
@@ -63,7 +64,7 @@ public class JsonLibHandler implements ContentTypeHandler {
         }
     }
 
-    public String fromObject(Object obj, String resultCode, Writer stream) throws IOException {
+    public String fromObject(ActionInvocation invocation, Object obj, String resultCode, Writer stream) throws IOException {
         if (obj != null) {
             if (isArray(obj)) {
                 JSONArray jsonArray = JSONArray.fromObject(obj);

--- a/plugins/rest/src/main/java/org/apache/struts2/rest/handler/MultipartFormDataHandler.java
+++ b/plugins/rest/src/main/java/org/apache/struts2/rest/handler/MultipartFormDataHandler.java
@@ -20,6 +20,8 @@
  */
 package org.apache.struts2.rest.handler;
 
+import com.opensymphony.xwork2.ActionInvocation;
+
 import java.io.Writer;
 import java.io.IOException;
 import java.io.Reader;
@@ -34,11 +36,11 @@ import java.io.Reader;
  *
  * @see <a href="http://www.w3.org/TR/html401/interact/forms.html#h-17.13.4">http://www.w3.org/TR/html401/interact/forms.html#h-17.13.4</a>
  */
-public class MultipartFormDataHandler implements ContentTypeHandler {
+public class MultipartFormDataHandler extends AbstractContentTypeHandler {
 
     public static final String CONTENT_TYPE = "multipart/form-data";
 
-    public String fromObject(Object obj, String resultCode, Writer out) throws IOException {
+    public String fromObject(ActionInvocation invocation, Object obj, String resultCode, Writer out) throws IOException {
         throw new IOException("Conversion from Object to '"+getContentType()+"' is not supported");
     }
 
@@ -48,7 +50,7 @@ public class MultipartFormDataHandler implements ContentTypeHandler {
      * @param in The input stream, usually the body of the request
      * @param target The target, usually the action class
      */
-    public void toObject(Reader in, Object target) {
+    public void toObject(ActionInvocation invocation, Reader in, Object target) {
     }
 
     /**

--- a/plugins/rest/src/test/java/org/apache/struts2/rest/DefaultContentTypeHandlerManagerTest.java
+++ b/plugins/rest/src/test/java/org/apache/struts2/rest/DefaultContentTypeHandlerManagerTest.java
@@ -1,8 +1,10 @@
 package org.apache.struts2.rest;
 
+import com.opensymphony.xwork2.ActionInvocation;
 import com.opensymphony.xwork2.XWorkTestCase;
 import com.opensymphony.xwork2.inject.Container;
 import com.opensymphony.xwork2.inject.Scope;
+import org.apache.struts2.rest.handler.AbstractContentTypeHandler;
 import org.apache.struts2.rest.handler.ContentTypeHandler;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -113,13 +115,13 @@ class DummyContainer implements Container {
     private ContentTypeHandler handler;
 
     DummyContainer(final String contentType, final String extension) {
-        handler = new ContentTypeHandler() {
+        handler = new AbstractContentTypeHandler() {
 
-            public void toObject(Reader in, Object target) throws IOException {
+            public void toObject(ActionInvocation invocation, Reader in, Object target) throws IOException {
 
             }
 
-            public String fromObject(Object obj, String resultCode, Writer stream) throws IOException {
+            public String fromObject(ActionInvocation invocation, Object obj, String resultCode, Writer stream) throws IOException {
                 return null;
             }
 

--- a/plugins/rest/src/test/java/org/apache/struts2/rest/RestWorkflowInterceptorTest.java
+++ b/plugins/rest/src/test/java/org/apache/struts2/rest/RestWorkflowInterceptorTest.java
@@ -44,7 +44,6 @@ public class RestWorkflowInterceptorTest extends TestCase {
         Mock mockActionInvocation = new Mock(ActionInvocation.class);
         Mock mockActionProxy = new Mock(ActionProxy.class);
         mockActionProxy.expectAndReturn("getConfig", null);
-        mockActionInvocation.expectAndReturn("getProxy", mockActionProxy.proxy());
         mockActionInvocation.expectAndReturn("getAction", action);
         Mock mockContentTypeHandlerManager = new Mock(ContentTypeHandlerManager.class);
         mockContentTypeHandlerManager.expectAndReturn("handleResult", new AnyConstraintMatcher() {

--- a/plugins/rest/src/test/java/org/apache/struts2/rest/handler/JacksonLibHandlerTest.java
+++ b/plugins/rest/src/test/java/org/apache/struts2/rest/handler/JacksonLibHandlerTest.java
@@ -21,6 +21,7 @@
 
 package org.apache.struts2.rest.handler;
 
+import com.opensymphony.xwork2.mock.MockActionInvocation;
 import junit.framework.TestCase;
 
 import java.io.IOException;
@@ -37,7 +38,7 @@ public class JacksonLibHandlerTest extends TestCase {
 
         StringWriter writer = new StringWriter();
         JacksonLibHandler handler = new JacksonLibHandler();
-        handler.fromObject(contact, "success", writer);
+        handler.fromObject(new MockActionInvocation(), contact, "success", writer);
         String data = writer.toString();
         assertTrue(data.startsWith("{"));
         assertTrue(data.contains("\"age\":44"));
@@ -50,7 +51,7 @@ public class JacksonLibHandlerTest extends TestCase {
 
         StringWriter writer = new StringWriter();
         JacksonLibHandler handler = new JacksonLibHandler();
-        handler.fromObject(Arrays.asList(contact), "success", writer);
+        handler.fromObject(new MockActionInvocation(), Arrays.asList(contact), "success", writer);
 
         String data = writer.toString();
         assertTrue(data.startsWith("[{"));
@@ -65,7 +66,7 @@ public class JacksonLibHandlerTest extends TestCase {
         Contact target = new Contact();
         StringReader reader = new StringReader("{\"age\":44,\"important\":true,\"name\":\"bob\"}");
         JacksonLibHandler handler = new JacksonLibHandler();
-        handler.toObject(reader, target);
+        handler.toObject(new MockActionInvocation(), reader, target);
         assertEquals(contact, target);
     }
 
@@ -78,7 +79,7 @@ public class JacksonLibHandlerTest extends TestCase {
         List<Contact> target = new ArrayList<Contact>();
         StringReader reader = new StringReader("[{\"age\":44,\"important\":true,\"name\":\"bob\"},{\"age\":33,\"important\":false,\"name\":\"john\"}]");
         JacksonLibHandler handler = new JacksonLibHandler();
-        handler.toObject(reader, target);
+        handler.toObject(new MockActionInvocation(), reader, target);
         assertEquals(source.size(), target.size());
     }
 

--- a/plugins/rest/src/test/java/org/apache/struts2/rest/handler/JsonLibHandlerTest.java
+++ b/plugins/rest/src/test/java/org/apache/struts2/rest/handler/JsonLibHandlerTest.java
@@ -26,6 +26,7 @@ import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.Arrays;
 
+import com.opensymphony.xwork2.mock.MockActionInvocation;
 import junit.framework.TestCase;
 
 public class JsonLibHandlerTest extends TestCase {
@@ -35,7 +36,7 @@ public class JsonLibHandlerTest extends TestCase {
 
         StringWriter writer = new StringWriter();
         JsonLibHandler handler = new JsonLibHandler();
-        handler.fromObject(contact, "success", writer);
+        handler.fromObject(new MockActionInvocation(), contact, "success", writer);
         String data = writer.toString();
         assertTrue(data.startsWith("{"));
         assertTrue(data.contains("\"age\":44"));
@@ -48,7 +49,7 @@ public class JsonLibHandlerTest extends TestCase {
 
         StringWriter writer = new StringWriter();
         JsonLibHandler handler = new JsonLibHandler();
-        handler.fromObject(Arrays.asList(contact), "success", writer);
+        handler.fromObject(new MockActionInvocation(), Arrays.asList(contact), "success", writer);
 
         String data = writer.toString();
         assertTrue(data.startsWith("[{"));
@@ -63,7 +64,7 @@ public class JsonLibHandlerTest extends TestCase {
         Contact target = new Contact();
         StringReader reader = new StringReader("{\"age\":44,\"important\":true,\"name\":\"bob\"}");
         JsonLibHandler handler = new JsonLibHandler();
-        handler.toObject(reader, target);
+        handler.toObject(new MockActionInvocation(), reader, target);
 
         assertEquals(contact, target);
     }


### PR DESCRIPTION
This PR changes API a bit to allow pass current `ActionInvocation` to the REST content type handlers to allow implement different behaviour based on a current action.

[WW-4835](https://issues.apache.org/jira/browse/WW-4835)