### PR TITLE
WW-4840 Build Fails Due to Unused com.sun Import

### DIFF
--- a/core/src/test/java/org/apache/struts2/views/jsp/ui/SelectTest.java
+++ b/core/src/test/java/org/apache/struts2/views/jsp/ui/SelectTest.java
@@ -26,7 +26,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import com.sun.xml.internal.bind.v2.util.StackRecorder;
 import org.apache.struts2.TestAction;
 import org.apache.struts2.views.jsp.AbstractUITagTest;
 


### PR DESCRIPTION
[WW-4840](https://issues.apache.org/jira/browse/WW-4840) Build Fails Due to Unused com.sun Import