### PR TITLE
return request HTTP method to fix problem for portlets with multipart validation

### DIFF
--- a/plugins/portlet/src/main/java/org/apache/struts2/portlet/servlet/PortletServletRequest.java
+++ b/plugins/portlet/src/main/java/org/apache/struts2/portlet/servlet/PortletServletRequest.java
@@ -31,6 +31,7 @@ import java.util.Locale;
 import java.util.Map;
 
 import javax.portlet.ActionRequest;
+import javax.portlet.ClientDataRequest;
 import javax.portlet.PortletContext;
 import javax.portlet.PortletRequest;
 import javax.portlet.PortletRequestDispatcher;
@@ -161,7 +162,12 @@ public class PortletServletRequest implements HttpServletRequest {
 	 * @see javax.servlet.http.HttpServletRequest#getMethod()
 	 */
 	public String getMethod() {
-		return null;
+		if (portletRequest instanceof ClientDataRequest) {
+			return ((ClientDataRequest) portletRequest).getMethod();
+		}
+		else {
+			return null;
+		}
 	}
 
 	/*


### PR DESCRIPTION
multipart validation added to Dispatcher in WW-4768 and JakartaMultiPartRequest in WW-4767 can't be passed within a portlet since PortletServletRequest.getMethod() only returns null 