### PR TITLE
WW-4849 Restore ObjectFactory no-arg constructor for compatibility

### DIFF
--- a/core/src/main/java/com/opensymphony/xwork2/ObjectFactory.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ObjectFactory.java
@@ -49,7 +49,7 @@ public class ObjectFactory implements Serializable {
     private static final Logger LOG = LogManager.getLogger(ObjectFactory.class);
 
     private transient ClassLoader ccl;
-    private final Container container;
+    private Container container;
 
     private ActionFactory actionFactory;
     private ResultFactory resultFactory;
@@ -57,6 +57,8 @@ public class ObjectFactory implements Serializable {
     private ValidatorFactory validatorFactory;
     private ConverterFactory converterFactory;
     private UnknownHandlerFactory unknownHandlerFactory;
+
+    public ObjectFactory() {}
 
     @Inject
     public ObjectFactory(Container container) {
@@ -66,6 +68,16 @@ public class ObjectFactory implements Serializable {
     @Inject(value="objectFactory.classloader", required=false)
     public void setClassLoader(ClassLoader cl) {
         this.ccl = cl;
+    }
+
+    @Inject
+    public void setContainer(Container container) {
+        if (this.container == null) {
+            LOG.debug("Populating Container via setter injection");
+            this.container = container;
+        } else if (this.container != container) {
+            LOG.warn("Attempted to replace existing container; ignoring");
+        }
     }
 
     @Inject

--- a/core/src/test/java/com/opensymphony/xwork2/ObjectFactoryTest.java
+++ b/core/src/test/java/com/opensymphony/xwork2/ObjectFactoryTest.java
@@ -1,0 +1,84 @@
+package com.opensymphony.xwork2;
+
+import com.opensymphony.xwork2.inject.Container;
+
+import org.easymock.EasyMock;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+/**
+ * Regression-test the ObjectFactory API.
+ */
+public class ObjectFactoryTest {
+
+    private Container container1;
+    private Container container2;
+
+    @BeforeMethod
+    public void setUp() {
+        container1 = EasyMock.createMock(Container.class);
+        container2 = EasyMock.createMock(Container.class);
+    }
+
+    @Test
+    public void shouldInjectContainerByConstructor() {
+        ObjectFactory factory = new StubObjectFactory(container1);
+
+        verifyContainer1Injected(factory);
+    }
+
+    @Test
+    public void shouldInjectContainerBySetterWhenMissing() {
+        ObjectFactory factory = new StubObjectFactory();
+        factory.setContainer(container1);
+
+        verifyContainer1Injected(factory);
+    }
+
+    @Test
+    public void shouldIgnoreDifferentContainerWhenInjectedByConstructor() {
+        ObjectFactory factory = new StubObjectFactory(container1);
+        factory.setContainer(container2);
+
+        verifyContainer1Injected(factory);
+    }
+
+    @Test
+    public void shouldIgnoreDifferentContainerWhenInjectedBySetterTwice() {
+        ObjectFactory factory = new StubObjectFactory();
+        factory.setContainer(container1);
+        factory.setContainer(container2);
+
+        verifyContainer1Injected(factory);
+    }
+
+    @Test
+    public void shouldIgnoreInjectingNullContainerBySetter() {
+        ObjectFactory factory = new StubObjectFactory(container1);
+        factory.setContainer(null);
+
+        verifyContainer1Injected(factory);
+    }
+
+    private void verifyContainer1Injected(ObjectFactory factory) {
+        Object obj = new Object();
+        container1.inject(obj);
+        EasyMock.expectLastCall();
+        EasyMock.replay(container1, container2);
+
+        factory.injectInternalBeans(obj);
+    }
+
+    static class StubObjectFactory extends ObjectFactory {
+
+        StubObjectFactory() {}
+
+        StubObjectFactory(Container container) {
+            super(container);
+        }
+
+    }
+
+}


### PR DESCRIPTION
As per [documentation](https://struts.apache.org/docs/objectfactory.html), extending classes are supposed to use no-arg constructors themselves, so how are they supposed to have immediate access to a Container to pass to the superclass constructor?