### PR TITLE
WW-4865: Add "requiredValue" parameter to Checkbox Struts Tag

### DIFF
--- a/core/src/main/java/org/apache/struts2/components/Checkbox.java
+++ b/core/src/main/java/org/apache/struts2/components/Checkbox.java
@@ -60,7 +60,7 @@ public class Checkbox extends UIBean {
     final public static String TEMPLATE = "checkbox";
 
     protected String fieldValue;
-    protected String requiredValue;
+    protected String submitUnchecked;
 
     public Checkbox(ValueStack stack, HttpServletRequest request, HttpServletResponse response) {
         super(stack, request, response);
@@ -76,10 +76,10 @@ public class Checkbox extends UIBean {
         } else {
             addParameter("fieldValue", "true");
         }
-        if (requiredValue != null) {
-            addParameter("requiredValue", findString(requiredValue));
+        if (submitUnchecked != null) {
+            addParameter("submitUnchecked", findString(submitUnchecked));
         } else {
-            addParameter("requiredValue", "true");
+            addParameter("submitUnchecked", "true");
         }
     }
 
@@ -93,7 +93,7 @@ public class Checkbox extends UIBean {
     }
 
     @StrutsTagAttribute(description="If set to false, unchecked elements will not be submitted with the form.", defaultValue="true")
-    public void setRequiredValue(String requiredValue) {
-        this.requiredValue = requiredValue;
+    public void setSubmitUnchecked(String submitUnchecked) {
+        this.submitUnchecked = submitUnchecked;
     }
 }

--- a/core/src/main/java/org/apache/struts2/components/Checkbox.java
+++ b/core/src/main/java/org/apache/struts2/components/Checkbox.java
@@ -60,6 +60,7 @@ public class Checkbox extends UIBean {
     final public static String TEMPLATE = "checkbox";
 
     protected String fieldValue;
+    protected String requiredValue;
 
     public Checkbox(ValueStack stack, HttpServletRequest request, HttpServletResponse response) {
         super(stack, request, response);
@@ -75,6 +76,11 @@ public class Checkbox extends UIBean {
         } else {
             addParameter("fieldValue", "true");
         }
+        if (requiredValue != null) {
+            addParameter("requiredValue", findString(requiredValue));
+        } else {
+            addParameter("requiredValue", "true");
+        }
     }
 
     protected Class getValueClassType() {
@@ -86,4 +92,8 @@ public class Checkbox extends UIBean {
         this.fieldValue = fieldValue;
     }
 
+    @StrutsTagAttribute(description="If set to false, unchecked elements will not be submitted with the form.", defaultValue="true")
+    public void setRequiredValue(String requiredValue) {
+        this.requiredValue = requiredValue;
+    }
 }

--- a/core/src/main/java/org/apache/struts2/components/Checkbox.java
+++ b/core/src/main/java/org/apache/struts2/components/Checkbox.java
@@ -79,7 +79,7 @@ public class Checkbox extends UIBean {
         if (submitUnchecked != null) {
             addParameter("submitUnchecked", findString(submitUnchecked));
         } else {
-            addParameter("submitUnchecked", "true");
+            addParameter("submitUnchecked", "false");
         }
     }
 
@@ -92,7 +92,7 @@ public class Checkbox extends UIBean {
         this.fieldValue = fieldValue;
     }
 
-    @StrutsTagAttribute(description="If set to false, unchecked elements will not be submitted with the form.", defaultValue="true")
+    @StrutsTagAttribute(description="If set to true, unchecked elements will be submitted with the form.", defaultValue="false")
     public void setSubmitUnchecked(String submitUnchecked) {
         this.submitUnchecked = submitUnchecked;
     }

--- a/core/src/main/java/org/apache/struts2/views/jsp/ui/CheckboxTag.java
+++ b/core/src/main/java/org/apache/struts2/views/jsp/ui/CheckboxTag.java
@@ -38,6 +38,7 @@ public class CheckboxTag extends AbstractUITag {
     private static final long serialVersionUID = -350752809266337636L;
 
     protected String fieldValue;
+    protected String requiredValue;
 
     public Component getBean(ValueStack stack, HttpServletRequest req, HttpServletResponse res) {
         return new Checkbox(stack, req, res);
@@ -47,9 +48,14 @@ public class CheckboxTag extends AbstractUITag {
         super.populateParams();
 
         ((Checkbox) component).setFieldValue(fieldValue);
+        ((Checkbox) component).setRequiredValue(requiredValue);
     }
 
     public void setFieldValue(String aValue) {
         this.fieldValue = aValue;
+    }
+
+    public void setRequiredValue(String aValue) {
+        this.requiredValue = aValue;
     }
 }

--- a/core/src/main/java/org/apache/struts2/views/jsp/ui/CheckboxTag.java
+++ b/core/src/main/java/org/apache/struts2/views/jsp/ui/CheckboxTag.java
@@ -38,7 +38,7 @@ public class CheckboxTag extends AbstractUITag {
     private static final long serialVersionUID = -350752809266337636L;
 
     protected String fieldValue;
-    protected String requiredValue;
+    protected String submitUnchecked;
 
     public Component getBean(ValueStack stack, HttpServletRequest req, HttpServletResponse res) {
         return new Checkbox(stack, req, res);
@@ -48,14 +48,14 @@ public class CheckboxTag extends AbstractUITag {
         super.populateParams();
 
         ((Checkbox) component).setFieldValue(fieldValue);
-        ((Checkbox) component).setRequiredValue(requiredValue);
+        ((Checkbox) component).setSubmitUnchecked(submitUnchecked);
     }
 
     public void setFieldValue(String aValue) {
         this.fieldValue = aValue;
     }
 
-    public void setRequiredValue(String aValue) {
-        this.requiredValue = aValue;
+    public void setSubmitUnchecked(String aValue) {
+        this.submitUnchecked = aValue;
     }
 }

--- a/core/src/main/resources/template/simple/checkbox.ftl
+++ b/core/src/main/resources/template/simple/checkbox.ftl
@@ -41,7 +41,7 @@
 <#include "/${parameters.templateDir}/${parameters.expandTheme}/common-attributes.ftl" />
 <#include "/${parameters.templateDir}/${parameters.expandTheme}/dynamic-attributes.ftl" />
 />
-<#if (parameters.requiredValue?boolean)!true>
+<#if (parameters.submitUnchecked?boolean)!true>
 <input type="hidden" id="__checkbox_${parameters.id?html}" name="__checkbox_${parameters.name?html}" value="${parameters.fieldValue?html}"<#rt/>
 <#if parameters.disabled!false>
  disabled="disabled"<#rt/>

--- a/core/src/main/resources/template/simple/checkbox.ftl
+++ b/core/src/main/resources/template/simple/checkbox.ftl
@@ -40,8 +40,11 @@
 <#include "/${parameters.templateDir}/${parameters.expandTheme}/scripting-events.ftl" />
 <#include "/${parameters.templateDir}/${parameters.expandTheme}/common-attributes.ftl" />
 <#include "/${parameters.templateDir}/${parameters.expandTheme}/dynamic-attributes.ftl" />
-/><input type="hidden" id="__checkbox_${parameters.id?html}" name="__checkbox_${parameters.name?html}" value="${parameters.fieldValue?html}"<#rt/>
+/>
+<#if (parameters.requiredValue?boolean)!true>
+<input type="hidden" id="__checkbox_${parameters.id?html}" name="__checkbox_${parameters.name?html}" value="${parameters.fieldValue?html}"<#rt/>
 <#if parameters.disabled!false>
  disabled="disabled"<#rt/>
 </#if>
  />
+</#if>

--- a/core/src/main/resources/template/simple/checkbox.ftl
+++ b/core/src/main/resources/template/simple/checkbox.ftl
@@ -41,7 +41,7 @@
 <#include "/${parameters.templateDir}/${parameters.expandTheme}/common-attributes.ftl" />
 <#include "/${parameters.templateDir}/${parameters.expandTheme}/dynamic-attributes.ftl" />
 />
-<#if (parameters.submitUnchecked?boolean)!true>
+<#if (parameters.submitUnchecked?boolean)!false>
 <input type="hidden" id="__checkbox_${parameters.id?html}" name="__checkbox_${parameters.name?html}" value="${parameters.fieldValue?html}"<#rt/>
 <#if parameters.disabled!false>
  disabled="disabled"<#rt/>

--- a/core/src/site/resources/tags/checkbox.html
+++ b/core/src/site/resources/tags/checkbox.html
@@ -300,10 +300,10 @@ Please do not edit it directly.
 				<tr>
 					<td align="left" valign="top">submitUnchecked</td>
 					<td align="left" valign="top">false</td>
-					<td align="left" valign="top">true</td>
+					<td align="left" valign="top">false</td>
 					<td align="left" valign="top">false</td>
 					<td align="left" valign="top">String</td>
-					<td align="left" valign="top">If set to false, unchecked elements will not be submitted with the form.</td>
+					<td align="left" valign="top">If set to true, unchecked elements will be submitted with the form.</td>
 				</tr>
 				<tr>
 					<td align="left" valign="top">tabindex</td>

--- a/core/src/site/resources/tags/checkbox.html
+++ b/core/src/site/resources/tags/checkbox.html
@@ -290,6 +290,14 @@ Please do not edit it directly.
 					<td align="left" valign="top">Define required position of required form element (left|right)</td>
 				</tr>
 				<tr>
+					<td align="left" valign="top">requiredValue</td>
+					<td align="left" valign="top">false</td>
+					<td align="left" valign="top">true</td>
+					<td align="left" valign="top">false</td>
+					<td align="left" valign="top">String</td>
+					<td align="left" valign="top">If set to true, unchecked elements will be submitted with the form.</td>
+				</tr>
+				<tr>
 					<td align="left" valign="top">style</td>
 					<td align="left" valign="top">false</td>
 					<td align="left" valign="top"></td>

--- a/core/src/site/resources/tags/checkbox.html
+++ b/core/src/site/resources/tags/checkbox.html
@@ -290,20 +290,20 @@ Please do not edit it directly.
 					<td align="left" valign="top">Define required position of required form element (left|right)</td>
 				</tr>
 				<tr>
-					<td align="left" valign="top">requiredValue</td>
-					<td align="left" valign="top">false</td>
-					<td align="left" valign="top">true</td>
-					<td align="left" valign="top">false</td>
-					<td align="left" valign="top">String</td>
-					<td align="left" valign="top">If set to true, unchecked elements will be submitted with the form.</td>
-				</tr>
-				<tr>
 					<td align="left" valign="top">style</td>
 					<td align="left" valign="top">false</td>
 					<td align="left" valign="top"></td>
 					<td align="left" valign="top">false</td>
 					<td align="left" valign="top">String</td>
 					<td align="left" valign="top">The css style definitions for element to use - it's an alias of cssStyle attribute.</td>
+				</tr>
+				<tr>
+					<td align="left" valign="top">submitUnchecked</td>
+					<td align="left" valign="top">false</td>
+					<td align="left" valign="top">true</td>
+					<td align="left" valign="top">false</td>
+					<td align="left" valign="top">String</td>
+					<td align="left" valign="top">If set to false, unchecked elements will not be submitted with the form.</td>
 				</tr>
 				<tr>
 					<td align="left" valign="top">tabindex</td>

--- a/core/src/test/java/org/apache/struts2/views/jsp/ui/CheckboxTest.java
+++ b/core/src/test/java/org/apache/struts2/views/jsp/ui/CheckboxTest.java
@@ -198,7 +198,7 @@ public class CheckboxTest extends AbstractUITagTest {
         verify(CheckboxTag.class.getResource("Checkbox-6.txt"));
     }
 
-    public void testRequiredValue() throws Exception {
+    public void testSubmitUnchecked() throws Exception {
         TestAction testAction = (TestAction) action;
         testAction.setFoo("true");
 
@@ -207,7 +207,7 @@ public class CheckboxTest extends AbstractUITagTest {
         tag.setLabel("mylabel");
         tag.setName("foo");
         tag.setFieldValue("baz");
-        tag.setRequiredValue("false");
+        tag.setSubmitUnchecked("false");
         tag.setTitle("mytitle");
         tag.setDisabled("true");
 

--- a/core/src/test/java/org/apache/struts2/views/jsp/ui/CheckboxTest.java
+++ b/core/src/test/java/org/apache/struts2/views/jsp/ui/CheckboxTest.java
@@ -198,7 +198,7 @@ public class CheckboxTest extends AbstractUITagTest {
         verify(CheckboxTag.class.getResource("Checkbox-6.txt"));
     }
 
-    public void testSubmitUnchecked() throws Exception {
+    public void testSubmitUncheckedAsFalse() throws Exception {
         TestAction testAction = (TestAction) action;
         testAction.setFoo("true");
 
@@ -207,7 +207,7 @@ public class CheckboxTest extends AbstractUITagTest {
         tag.setLabel("mylabel");
         tag.setName("foo");
         tag.setFieldValue("baz");
-        tag.setSubmitUnchecked("false");
+        //tag.setSubmitUnchecked("false");        // Test default value
         tag.setTitle("mytitle");
         tag.setDisabled("true");
 
@@ -215,5 +215,30 @@ public class CheckboxTest extends AbstractUITagTest {
         tag.doEndTag();
 
         verify(CheckboxTag.class.getResource("Checkbox-7.txt"));
+
+        // Test value set
+        tag.setSubmitUnchecked("false");
+        verify(CheckboxTag.class.getResource("Checkbox-7.txt"));
+
     }
+
+    public void testSubmitUncheckedAsTrue() throws Exception {
+        TestAction testAction = (TestAction) action;
+        testAction.setFoo("true");
+
+        CheckboxTag tag = new CheckboxTag();
+        tag.setPageContext(pageContext);
+        tag.setLabel("mylabel");
+        tag.setName("foo");
+        tag.setFieldValue("baz");
+        tag.setSubmitUnchecked("true");
+        tag.setTitle("mytitle");
+        tag.setDisabled("true");
+
+        tag.doStartTag();
+        tag.doEndTag();
+
+        verify(CheckboxTag.class.getResource("Checkbox-8.txt"));
+    }
+
 }

--- a/core/src/test/java/org/apache/struts2/views/jsp/ui/CheckboxTest.java
+++ b/core/src/test/java/org/apache/struts2/views/jsp/ui/CheckboxTest.java
@@ -197,4 +197,23 @@ public class CheckboxTest extends AbstractUITagTest {
 
         verify(CheckboxTag.class.getResource("Checkbox-6.txt"));
     }
+
+    public void testRequiredValue() throws Exception {
+        TestAction testAction = (TestAction) action;
+        testAction.setFoo("true");
+
+        CheckboxTag tag = new CheckboxTag();
+        tag.setPageContext(pageContext);
+        tag.setLabel("mylabel");
+        tag.setName("foo");
+        tag.setFieldValue("baz");
+        tag.setRequiredValue("false");
+        tag.setTitle("mytitle");
+        tag.setDisabled("true");
+
+        tag.doStartTag();
+        tag.doEndTag();
+
+        verify(CheckboxTag.class.getResource("Checkbox-7.txt"));
+    }
 }

--- a/core/src/test/resources/org/apache/struts2/views/jsp/ui/Checkbox-1.txt
+++ b/core/src/test/resources/org/apache/struts2/views/jsp/ui/Checkbox-1.txt
@@ -3,7 +3,6 @@
 	</td>
     <td class="tdCheckboxInput">
 		<input type="checkbox" name="foo" value="baz" checked="checked" id="someId" title="mytitle" onfocus="test();"/>
-		<input type="hidden" id="__checkbox_someId" name="__checkbox_foo" value="baz"/>
         <label for="someId" class="checkboxLabel">mylabel</label>
     </td>
 </tr>

--- a/core/src/test/resources/org/apache/struts2/views/jsp/ui/Checkbox-2.txt
+++ b/core/src/test/resources/org/apache/struts2/views/jsp/ui/Checkbox-2.txt
@@ -3,7 +3,6 @@
 	</td>
     <td class="tdCheckboxInput">
         <input type="checkbox" name="foo" value="baz" id="foo" title="mytitle"/>
-        <input type="hidden" id="__checkbox_foo" name="__checkbox_foo" value="baz"/>
         <label for="foo" class="checkboxLabel">mylabel</label>
     </td>
 </tr>

--- a/core/src/test/resources/org/apache/struts2/views/jsp/ui/Checkbox-3.txt
+++ b/core/src/test/resources/org/apache/struts2/views/jsp/ui/Checkbox-3.txt
@@ -10,7 +10,6 @@
 	</td>
     <td class="tdCheckboxInput">
           <input type="checkbox" name="foo" value="baz" checked="checked" id="foo" class="myErrorClass" title="mytitle" onclick="test();" ondblclick="test();"/>
-          <input type="hidden" id="__checkbox_foo" name="__checkbox_foo" value="baz"/>
           <label for="foo" class="checkboxErrorLabel">mylabel</label>
     </td>
 </tr>

--- a/core/src/test/resources/org/apache/struts2/views/jsp/ui/Checkbox-33.txt
+++ b/core/src/test/resources/org/apache/struts2/views/jsp/ui/Checkbox-33.txt
@@ -10,7 +10,6 @@
 	</td>
     <td class="tdCheckboxInput">
           <input type="checkbox" name="foo" value="baz" checked="checked" id="foo" style="color:red" title="mytitle" onclick="test();" ondblclick="test();"/>
-          <input type="hidden" id="__checkbox_foo" name="__checkbox_foo" value="baz"/>
           <label for="foo" class="checkboxErrorLabel">mylabel</label>
     </td>
 </tr>

--- a/core/src/test/resources/org/apache/struts2/views/jsp/ui/Checkbox-4.txt
+++ b/core/src/test/resources/org/apache/struts2/views/jsp/ui/Checkbox-4.txt
@@ -6,6 +6,5 @@
 <tr>
     <td colspan="2">
 		<input type="checkbox" name="foo" value="baz" checked="checked" id="someId" title="mytitle" onfocus="test();"/>
-		<input type="hidden" id="__checkbox_someId" name="__checkbox_foo" value="baz"/>
     </td>
 </tr>

--- a/core/src/test/resources/org/apache/struts2/views/jsp/ui/Checkbox-5.txt
+++ b/core/src/test/resources/org/apache/struts2/views/jsp/ui/Checkbox-5.txt
@@ -4,6 +4,5 @@
 	</td>
     <td class="tdCheckboxInput">
 		<input type="checkbox" name="foo" value="baz" checked="checked" id="someId" title="mytitle" onfocus="test();"/>
-		<input type="hidden" id="__checkbox_someId" name="__checkbox_foo" value="baz"/>
     </td>
 </tr>

--- a/core/src/test/resources/org/apache/struts2/views/jsp/ui/Checkbox-6.txt
+++ b/core/src/test/resources/org/apache/struts2/views/jsp/ui/Checkbox-6.txt
@@ -3,7 +3,6 @@
 	</td>
     <td class="tdCheckboxInput">
 		<input type="checkbox" name="foo" value="baz" checked="checked" disabled="disabled" id="foo" title="mytitle" />
-		<input type="hidden" id="__checkbox_foo" name="__checkbox_foo" value="baz" disabled="disabled"/>
 		<label for="foo" class="checkboxLabel">mylabel</label>
     </td>
 </tr>

--- a/core/src/test/resources/org/apache/struts2/views/jsp/ui/Checkbox-7.txt
+++ b/core/src/test/resources/org/apache/struts2/views/jsp/ui/Checkbox-7.txt
@@ -1,0 +1,8 @@
+<tr>
+	<td class="tdCheckboxLabel">
+	</td>
+    <td class="tdCheckboxInput">
+		<input type="checkbox" name="foo" value="baz" checked="checked" disabled="disabled" id="foo" title="mytitle" />
+		<label for="foo" class="checkboxLabel">mylabel</label>
+    </td>
+</tr>

--- a/core/src/test/resources/org/apache/struts2/views/jsp/ui/Checkbox-8.txt
+++ b/core/src/test/resources/org/apache/struts2/views/jsp/ui/Checkbox-8.txt
@@ -1,8 +1,9 @@
 <tr>
 	<td class="tdCheckboxLabel">
 	</td>
-    <td class="tdCheckboxInput">
+	<td class="tdCheckboxInput">
 		<input type="checkbox" name="foo" value="baz" checked="checked" disabled="disabled" id="foo" title="mytitle"/>
+		<input type="hidden" id="__checkbox_foo" name="__checkbox_foo" value="baz" disabled="disabled"/>
 		<label for="foo" class="checkboxLabel">mylabel</label>
-    </td>
+	</td>
 </tr>


### PR DESCRIPTION
Added requiredValue to Checkbox Struts Tag as a parameter to give developer flexibility to use/not use "submit unchecked values" design pattern.  When requiredValue set to "false", unchecked checkbox elements will not be submitted with the form (i.e. no hidden input html elements will be created for the checkbox).  Default value is true for backwards compatibility.

[WW-4865](https://issues.apache.org/jira/browse/WW-4865)