### PR TITLE
remove an obsolete TODO comment

### DIFF
--- a/core/src/test/java/org/apache/struts2/views/freemarker/FreemarkerResultMockedTest.java
+++ b/core/src/test/java/org/apache/struts2/views/freemarker/FreemarkerResultMockedTest.java
@@ -100,7 +100,6 @@ public class FreemarkerResultMockedTest extends StrutsInternalTestCase {
         ActionMapping mapping = container.getInstance(ActionMapper.class).getMapping(request, configurationManager);
         dispatcher.serviceAction(request, response, mapping);
 
-        // TODO lukaszlenart: remove expectedJDK15 and if() after switching to Java 1.6
         String expectedJDK17 =
                 "<input type=\"text\" name=\"test\" value=\"\" id=\"test\" placeholder=\"input\" foo=\"bar\"/>"
                         + "<input type=\"text\" name=\"test\" value=\"\" id=\"test\" placeholder=\"input\" foo=\"bar\"/>"


### PR DESCRIPTION
At commit e262854e2a1b7548efa0a1eb50d350ecd215231b the project switch from JDK1.5 to JDK1.7 . At commit f0797388bc220b48c720e0fb29d42d4f58243757, line 104/109, expectedJDK{15,16} was changed to expectedJDK{17,18}. However, the corresponding TODO comment was not changed. 
We should remove this obsolete comment.