### PR TITLE
WW-4888 add escaping possibilities to text-tag

### DIFF
--- a/core/src/main/java/org/apache/struts2/components/Text.java
+++ b/core/src/main/java/org/apache/struts2/components/Text.java
@@ -19,6 +19,7 @@
 package org.apache.struts2.components;
 
 import com.opensymphony.xwork2.util.ValueStack;
+import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -58,6 +59,10 @@ import java.util.List;
  *
  * <ul>
  *      <li>name* (String) - the i18n message key</li>
+ *      <li>escapeHtml (Boolean) - Escape HTML. Defaults to false</li>
+ *      <li>escapeJavaScript (Boolean) - Escape JavaScript. Defaults to false</li>
+ *      <li>escapeXml (Boolean) - Escape XML. Defaults to false</li>
+ *      <li>escapeCsv (Boolean) - Escape CSV. Defaults to false</li>
  * </ul>
  *
  * <!-- END SNIPPET: params -->
@@ -119,6 +124,10 @@ public class Text extends ContextBean implements Param.UnnamedParametric {
     protected String actualName;
     protected String name;
     protected String searchStack;
+    private boolean escapeHtml = false;
+    private boolean escapeJavaScript = false;
+    private boolean escapeXml = false;
+    private boolean escapeCsv = false;
 
     public Text(ValueStack stack) {
         super(stack);
@@ -132,6 +141,26 @@ public class Text extends ContextBean implements Param.UnnamedParametric {
     @StrutsTagAttribute(description="Search the stack if property is not found on resources", type = "Boolean", defaultValue = "false")
     public void setSearchValueStack(String searchStack) {
         this.searchStack = searchStack;
+    }
+
+    @StrutsTagAttribute(description="Whether to escape HTML", type="Boolean", defaultValue="false")
+    public void setEscapeHtml(boolean escape) {
+        this.escapeHtml = escape;
+    }
+    
+    @StrutsTagAttribute(description="Whether to escape Javascript", type="Boolean", defaultValue="false")
+    public void setEscapeJavaScript(boolean escapeJavaScript) {
+        this.escapeJavaScript = escapeJavaScript;
+    }
+
+    @StrutsTagAttribute(description="Whether to escape XML", type="Boolean", defaultValue="false")
+    public void setEscapeXml(boolean escapeXml) {
+        this.escapeXml = escapeXml;
+    }
+
+    @StrutsTagAttribute(description="Whether to escape CSV (useful to escape a value for a column)", type="Boolean", defaultValue="false")
+    public void setEscapeCsv(boolean escapeCsv) {
+        this.escapeCsv = escapeCsv;
     }
 
     public boolean usesBody() {
@@ -161,7 +190,7 @@ public class Text extends ContextBean implements Param.UnnamedParametric {
         if (msg != null) {
             try {
                 if (getVar() == null) {
-                    writer.write(msg);
+                    writer.write(prepare(msg));
                 } else {
                     putInContext(msg);
                 }
@@ -183,5 +212,23 @@ public class Text extends ContextBean implements Param.UnnamedParametric {
         }
 
         values.add(value);
+    }
+
+    private String prepare(String value) {
+        String result = value;
+        if (escapeHtml) {
+            result = StringEscapeUtils.escapeHtml4(result);
+        }
+        if (escapeJavaScript) {
+            result = StringEscapeUtils.escapeEcmaScript(result);
+        }
+        if (escapeXml) {
+            result = StringEscapeUtils.escapeXml(result);
+        }
+        if (escapeCsv) {
+            result = StringEscapeUtils.escapeCsv(result);
+        }
+
+        return result;
     }
 }

--- a/core/src/main/java/org/apache/struts2/views/jsp/PropertyTag.java
+++ b/core/src/main/java/org/apache/struts2/views/jsp/PropertyTag.java
@@ -35,7 +35,7 @@ public class PropertyTag extends ComponentTagSupport {
 
     private String defaultValue;
     private String value;
-    private boolean escapeHtml = false;
+    private boolean escapeHtml = true;
     private boolean escapeJavaScript = false;
     private boolean escapeXml = false;
     private boolean escapeCsv = false;

--- a/core/src/main/java/org/apache/struts2/views/jsp/PropertyTag.java
+++ b/core/src/main/java/org/apache/struts2/views/jsp/PropertyTag.java
@@ -35,7 +35,7 @@ public class PropertyTag extends ComponentTagSupport {
 
     private String defaultValue;
     private String value;
-    private boolean escapeHtml = true;
+    private boolean escapeHtml = false;
     private boolean escapeJavaScript = false;
     private boolean escapeXml = false;
     private boolean escapeCsv = false;

--- a/core/src/main/java/org/apache/struts2/views/jsp/TextTag.java
+++ b/core/src/main/java/org/apache/struts2/views/jsp/TextTag.java
@@ -35,6 +35,10 @@ public class TextTag extends ContextBeanTag {
 
     protected String name;
     protected String searchValueStack;
+    private boolean escapeHtml = false;
+    private boolean escapeJavaScript = false;
+    private boolean escapeXml = false;
+    private boolean escapeCsv = false;
 
     public Component getBean(ValueStack stack, HttpServletRequest req, HttpServletResponse res) {
         return new Text(stack);
@@ -46,6 +50,10 @@ public class TextTag extends ContextBeanTag {
         Text text = (Text) component;
         text.setName(name);
         text.setSearchValueStack(searchValueStack);
+        text.setEscapeHtml(escapeHtml);
+        text.setEscapeJavaScript(escapeJavaScript);
+        text.setEscapeXml(escapeXml);
+        text.setEscapeCsv(escapeCsv);
     }
 
     public void setName(String name) {
@@ -55,4 +63,21 @@ public class TextTag extends ContextBeanTag {
     public void setSearchValueStack(String searchStack) {
         this.searchValueStack = searchStack;
     }
+
+    public void setEscapeHtml(boolean escapeHtml) {
+        this.escapeHtml = escapeHtml;
+    }
+
+    public void setEscapeJavaScript(boolean escapeJavaScript) {
+        this.escapeJavaScript = escapeJavaScript;
+    }
+    
+    public void setEscapeXml(boolean escapeXml) {
+        this.escapeXml = escapeXml;
+    }
+
+    public void setEscapeCsv(boolean escapeCsv) {
+        this.escapeCsv = escapeCsv;
+    }
+
 }

--- a/core/src/site/resources/tags/text.html
+++ b/core/src/site/resources/tags/text.html
@@ -34,6 +34,38 @@ Please do not edit it directly.
 				<th align="left" valign="top"><h4>Description</h4></th>
 			</tr>
 				<tr>
+					<td align="left" valign="top">escapeCsv</td>
+					<td align="left" valign="top">false</td>
+					<td align="left" valign="top">false</td>
+					<td align="left" valign="top">false</td>
+					<td align="left" valign="top">Boolean</td>
+					<td align="left" valign="top">Whether to escape CSV (useful to escape a value for a column)</td>
+				</tr>
+				<tr>
+					<td align="left" valign="top">escapeHtml</td>
+					<td align="left" valign="top">false</td>
+					<td align="left" valign="top">false</td>
+					<td align="left" valign="top">false</td>
+					<td align="left" valign="top">Boolean</td>
+					<td align="left" valign="top">Whether to escape HTML</td>
+				</tr>
+				<tr>
+					<td align="left" valign="top">escapeJavaScript</td>
+					<td align="left" valign="top">false</td>
+					<td align="left" valign="top">false</td>
+					<td align="left" valign="top">false</td>
+					<td align="left" valign="top">Boolean</td>
+					<td align="left" valign="top">Whether to escape Javascript</td>
+				</tr>
+				<tr>
+					<td align="left" valign="top">escapeXml</td>
+					<td align="left" valign="top">false</td>
+					<td align="left" valign="top">false</td>
+					<td align="left" valign="top">false</td>
+					<td align="left" valign="top">Boolean</td>
+					<td align="left" valign="top">Whether to escape XML</td>
+				</tr>
+				<tr>
 					<td align="left" valign="top">name</td>
 					<td align="left" valign="top"><strong>true</strong></td>
 					<td align="left" valign="top"></td>

--- a/core/src/test/java/org/apache/struts2/views/jsp/TextTagTest.java
+++ b/core/src/test/java/org/apache/struts2/views/jsp/TextTagTest.java
@@ -305,6 +305,46 @@ public class TextTagTest extends AbstractTagTest {
         assertEquals("No foo here", stack.findString("myId")); // is in stack now
     }
 
+    public void testEscapeHtml() throws Exception {
+        final String key = "foo.escape.html";
+        final String value = "1 &lt; 2";
+        tag.setName(key);
+        tag.setEscapeHtml(true);
+        tag.doStartTag();
+        tag.doEndTag();
+        assertEquals(value, writer.toString());
+    }
+
+    public void testEscapeXml() throws Exception {
+        final String key = "foo.escape.xml";
+        final String value = "&lt;&gt;&apos;&quot;&amp;";
+        tag.setName(key);
+        tag.setEscapeXml(true);
+        tag.doStartTag();
+        tag.doEndTag();
+        assertEquals(value, writer.toString());
+    }
+
+    public void testEscapeJavaScript() throws Exception {
+        final String key = "foo.escape.javascript";
+        final String value = "\\t\\b\\n\\f\\r\\\"\\\'\\/\\\\";
+        tag.setName(key);
+        tag.setEscapeJavaScript(true);
+        tag.doStartTag();
+        tag.doEndTag();
+        assertEquals(value, writer.toString());
+    }
+
+    public void testEscapeCsv() throws Exception {
+        final String key = "foo.escape.csv";
+        final String value = "\"something,\"\",\"\"\"";
+        tag.setName(key);
+        tag.setEscapeCsv(true);
+        tag.doStartTag();
+        tag.doEndTag();
+        assertEquals(value, writer.toString());
+    }
+
     /**
      * todo remove ActionContext set after LocalizedTextUtil is fixed to not use ThreadLocal
      *

--- a/core/src/test/resources/org/apache/struts2/TestAction.properties
+++ b/core/src/test/resources/org/apache/struts2/TestAction.properties
@@ -22,3 +22,7 @@ messageFormatKey=Params are {0} {1} {2}
 foo.bar.baz=This should start with foo
 bar.baz=No foo here
 some.image.from.properties=some.gif
+foo.escape.html=1 < 2
+foo.escape.xml=<>''\"&
+foo.escape.javascript=\u0009\u0008\n\u000C\u000D\"''/\u005C
+foo.escape.csv=something,","


### PR DESCRIPTION
Added the option of escaping the result of an `<s:text>` tag.

Defaults set to not escaping in order not to break current behavior.


possible improvement:
* now holds duplicate prepare method from the `Property` class