### PR TITLE
WW-4713 Drop searchValueStack attribute from tag <s:text/>

### DIFF
--- a/core/src/main/java/org/apache/struts2/components/Text.java
+++ b/core/src/main/java/org/apache/struts2/components/Text.java
@@ -49,9 +49,8 @@ import java.util.List;
  *
  * <p>
  * If the named message is not found in a property file, then the body of the
- * tag will be used as default message. If no body is used, then the stack can
- * be searched, and if a value is returned, it will written to the output.
- * If no value is found on the stack, the key of the message will be written out.
+ * tag will be used as default message. If no value is found, the key of the 
+ * message will be written out.
  * </p>
  * <!-- END SNIPPET: javadoc -->
  *
@@ -123,7 +122,6 @@ public class Text extends ContextBean implements Param.UnnamedParametric {
     protected List<Object> values = Collections.emptyList();
     protected String actualName;
     protected String name;
-    protected String searchStack;
     private boolean escapeHtml = false;
     private boolean escapeJavaScript = false;
     private boolean escapeXml = false;
@@ -136,11 +134,6 @@ public class Text extends ContextBean implements Param.UnnamedParametric {
     @StrutsTagAttribute(description = "Name of resource property to fetch", required = true)
     public void setName(String name) {
         this.name = name;
-    }
-
-    @StrutsTagAttribute(description="Search the stack if property is not found on resources", type = "Boolean", defaultValue = "false")
-    public void setSearchValueStack(String searchStack) {
-        this.searchStack = searchStack;
     }
 
     @StrutsTagAttribute(description="Whether to escape HTML", type="Boolean", defaultValue="false")
@@ -179,13 +172,7 @@ public class Text extends ContextBean implements Param.UnnamedParametric {
             defaultMessage = actualName;
         }
 
-        Boolean doSearchStack = false;
-        if (searchStack != null) {
-            Object value = findValue(searchStack, Boolean.class);
-            doSearchStack = value != null ? (Boolean) value : false;
-        }
-
-        String msg = TextProviderHelper.getText(actualName, defaultMessage, values, getStack(), doSearchStack);
+        String msg = TextProviderHelper.getText(actualName, defaultMessage, values, getStack());
 
         if (msg != null) {
             try {

--- a/core/src/main/java/org/apache/struts2/views/jsp/TextTag.java
+++ b/core/src/main/java/org/apache/struts2/views/jsp/TextTag.java
@@ -34,7 +34,6 @@ public class TextTag extends ContextBeanTag {
     private static final long serialVersionUID = -3075088084198264581L;
 
     protected String name;
-    protected String searchValueStack;
     private boolean escapeHtml = false;
     private boolean escapeJavaScript = false;
     private boolean escapeXml = false;
@@ -49,7 +48,6 @@ public class TextTag extends ContextBeanTag {
 
         Text text = (Text) component;
         text.setName(name);
-        text.setSearchValueStack(searchValueStack);
         text.setEscapeHtml(escapeHtml);
         text.setEscapeJavaScript(escapeJavaScript);
         text.setEscapeXml(escapeXml);
@@ -58,10 +56,6 @@ public class TextTag extends ContextBeanTag {
 
     public void setName(String name) {
         this.name = name;
-    }
-
-    public void setSearchValueStack(String searchStack) {
-        this.searchValueStack = searchStack;
     }
 
     public void setEscapeHtml(boolean escapeHtml) {

--- a/core/src/site/resources/tags/text.html
+++ b/core/src/site/resources/tags/text.html
@@ -74,14 +74,6 @@ Please do not edit it directly.
 					<td align="left" valign="top">Name of resource property to fetch</td>
 				</tr>
 				<tr>
-					<td align="left" valign="top">searchValueStack</td>
-					<td align="left" valign="top">false</td>
-					<td align="left" valign="top">false</td>
-					<td align="left" valign="top">false</td>
-					<td align="left" valign="top">Boolean</td>
-					<td align="left" valign="top">Search the stack if property is not found on resources</td>
-				</tr>
-				<tr>
 					<td align="left" valign="top">var</td>
 					<td align="left" valign="top">false</td>
 					<td align="left" valign="top"></td>

--- a/core/src/test/java/org/apache/struts2/views/jsp/TextTagTest.java
+++ b/core/src/test/java/org/apache/struts2/views/jsp/TextTagTest.java
@@ -215,47 +215,6 @@ public class TextTagTest extends AbstractTagTest {
         assertEquals(value_int, writer.toString());
     }
 
-     public void testTextTagCanSearchStackToFindValue() throws JspException {
-        String key = "result";
-
-        tag.setName(key);
-        tag.setSearchValueStack("true");
-        final StringBuffer buffer = writer.getBuffer();
-        buffer.delete(0, buffer.length());
-        ValueStack newStack = container.getInstance(ValueStackFactory.class).createValueStack();
-        newStack.getContext().put(ActionContext.CONTAINER, container);
-        TestAction testAction = new TestAction();
-        container.inject(testAction);
-        testAction.setResult("bar");
-        newStack.push(testAction);
-        request.setAttribute(ServletActionContext.STRUTS_VALUESTACK_KEY, newStack);
-
-
-        tag.doStartTag();
-        tag.doEndTag();
-        assertEquals("bar", writer.toString());
-    }
-
-    public void testTextTagDoNotSearchStackByDefault() throws JspException {
-        String key = "result";
-
-        tag.setName(key);
-        final StringBuffer buffer = writer.getBuffer();
-        buffer.delete(0, buffer.length());
-        ValueStack newStack = container.getInstance(ValueStackFactory.class).createValueStack();
-        newStack.getContext().put(ActionContext.CONTAINER, container);
-        TestAction testAction = new TestAction();
-        container.inject(testAction);
-        testAction.setResult("bar");
-        newStack.push(testAction);
-        request.setAttribute(ServletActionContext.STRUTS_VALUESTACK_KEY, newStack);
-
-
-        tag.doStartTag();
-        tag.doEndTag();
-        assertEquals("result", writer.toString());
-    }
-
     public void testWithNoMessageAndBodyIsNotEmptyBodyIsReturned() throws Exception {
         final String key = "key.does.not.exist";
         final String bodyText = "body text";


### PR DESCRIPTION
Should the method in the TextProviderHelper class also be removed?
It does not seem to have any remaining references in this project.

https://github.com/apache/struts/blob/6e96f11debc4fa52c65a12b28fea82b514b96abd/core/src/main/java/org/apache/struts2/util/TextProviderHelper.java#L66