### PR TITLE
WW-4907 support JSR 303 Validation Groups in BeanValidation-Plugin

### DIFF
--- a/plugins/bean-validation/src/main/java/org/apache/struts/beanvalidation/constraints/ValidateGroup.java
+++ b/plugins/bean-validation/src/main/java/org/apache/struts/beanvalidation/constraints/ValidateGroup.java
@@ -16,24 +16,35 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.struts.beanvalidation.models;
+package org.apache.struts.beanvalidation.constraints;
 
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Size;
-import javax.validation.groups.Default;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-public class Address {
+/**
+ * Validation with Group Constrains on execution method (Action)
+ * <p>
+ * Example, Validate with on special group
+ * </p>
+ * <pre>
+ *
+ *  {@literal @}ValidateGroup(CarChecks.class)
+ *  {@literal @}Action...
+ * </pre>
+ * <p>
+ * <p>
+ * Example, Validate with severals special group
+ * </p>
+ * <pre>
+ *  {@literal @}ValidateGroup(Default.class, CarChecks.class, DriverChecks.class)
+ *  {@literal @}Action...
+ * </pre>
+ */
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidateGroup {
 
-    @NotNull(message = "streetNotNull", groups = {Default.class, Person.StreetChecks.class, Person.NameAndStreetChecks.class})
-    @Size(min = 3, max = 64, message = "streetSize", groups = {Default.class, Person.StreetChecks.class, Person.NameAndStreetChecks.class})
-    private String street;
-
-    public void setStreet(String street) {
-        this.street = street;
-    }
-
-    public String getStreet() {
-        return street;
-    }
-
+    Class<?>[] value() default {};
 }

--- a/plugins/bean-validation/src/main/java/org/apache/struts/beanvalidation/constraints/ValidationGroup.java
+++ b/plugins/bean-validation/src/main/java/org/apache/struts/beanvalidation/constraints/ValidationGroup.java
@@ -30,7 +30,7 @@ import java.lang.annotation.Target;
  * </p>
  * <pre>
  *
- *  {@literal @}ValidateGroup(CarChecks.class)
+ *  {@literal @}ValidationGroup(CarChecks.class)
  *  {@literal @}Action...
  * </pre>
  * <p>
@@ -38,13 +38,13 @@ import java.lang.annotation.Target;
  * Example, Validate with severals special group
  * </p>
  * <pre>
- *  {@literal @}ValidateGroup(Default.class, CarChecks.class, DriverChecks.class)
+ *  {@literal @}ValidationGroup(Default.class, CarChecks.class, DriverChecks.class)
  *  {@literal @}Action...
  * </pre>
  */
 @Target({ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
-public @interface ValidateGroup {
+public @interface ValidationGroup {
 
     Class<?>[] value() default {};
 }

--- a/plugins/bean-validation/src/main/java/org/apache/struts/beanvalidation/constraints/ValidationGroup.java
+++ b/plugins/bean-validation/src/main/java/org/apache/struts/beanvalidation/constraints/ValidationGroup.java
@@ -18,6 +18,7 @@
  */
 package org.apache.struts.beanvalidation.constraints;
 
+import javax.validation.groups.Default;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -46,5 +47,5 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ValidationGroup {
 
-    Class<?>[] value() default {};
+    Class<?>[] value() default {Default.class};
 }

--- a/plugins/bean-validation/src/main/java/org/apache/struts/beanvalidation/validation/interceptor/BeanValidationInterceptor.java
+++ b/plugins/bean-validation/src/main/java/org/apache/struts/beanvalidation/validation/interceptor/BeanValidationInterceptor.java
@@ -27,16 +27,18 @@ import com.opensymphony.xwork2.interceptor.MethodFilterInterceptor;
 import com.opensymphony.xwork2.validator.DelegatingValidatorContext;
 import com.opensymphony.xwork2.validator.ValidatorContext;
 import org.apache.commons.lang3.BooleanUtils;
-import org.apache.commons.lang3.reflect.MethodUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.reflect.MethodUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.struts.beanvalidation.constraints.ValidateGroup;
 import org.apache.struts.beanvalidation.validation.constant.ValidatorConstants;
 import org.apache.struts2.interceptor.validation.SkipValidation;
 
 import javax.validation.ConstraintViolation;
 import javax.validation.Validator;
 import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.Set;
 
 /**
@@ -95,36 +97,42 @@ public class BeanValidationInterceptor extends MethodFilterInterceptor {
         if (LOG.isDebugEnabled()) {
             LOG.debug("Validating [{}/{}] with method [{}]", invocation.getProxy().getNamespace(), invocation.getProxy().getActionName(), methodName);
         }
+        Class<?>[] validationGroup = getValidationGroups(action, methodName);
 
         if (null == MethodUtils.getAnnotation(getActionMethod(action.getClass(), methodName), SkipValidation.class,
                 true, true)) {
             // performing bean validation on action
-            performBeanValidation(action, validator);
+            performBeanValidation(action, validator, validationGroup);
         }
 
         return invocation.invoke();
     }
 
-    protected void performBeanValidation(Object action, Validator validator) {
+    protected Class<?>[] getValidationGroups(Object action, String methodName) throws NoSuchMethodException {
+        ValidateGroup validateGroup = MethodUtils.getAnnotation(getActionMethod(action.getClass(), methodName), ValidateGroup.class, true, true);
+        return validateGroup == null ? new Class[]{} : validateGroup.value();
+    }
 
-        LOG.trace("Initiating bean validation..");
+    protected void performBeanValidation(Object action, Validator validator, Class<?>[] groups) {
+
+        LOG.trace("Initiating bean validation.. with groups [{}]", Arrays.toString(groups));
 
         Set<ConstraintViolation<Object>> constraintViolations;
 
         if (action instanceof ModelDriven) {
             LOG.trace("Performing validation on model..");
             Object model = (Object)((ModelDriven<?>) action).getModel();
-            constraintViolations = validator.validate(model);
+            constraintViolations = validator.validate(model, groups);
         } else {
             LOG.trace("Performing validation on action..");
-            constraintViolations = validator.validate(action);
+            constraintViolations = validator.validate(action, groups);
         }
 
         addBeanValidationErrors(constraintViolations, action);
     }
 
     @SuppressWarnings("nls")
-    private void addBeanValidationErrors(Set<ConstraintViolation<Object>> constraintViolations, Object action) {
+    protected void addBeanValidationErrors(Set<ConstraintViolation<Object>> constraintViolations, Object action) {
         if (constraintViolations != null) {
             ValidatorContext validatorContext = new DelegatingValidatorContext(action, textProviderFactory);
             for (ConstraintViolation<Object> constraintViolation : constraintViolations) {

--- a/plugins/bean-validation/src/main/java/org/apache/struts/beanvalidation/validation/interceptor/BeanValidationInterceptor.java
+++ b/plugins/bean-validation/src/main/java/org/apache/struts/beanvalidation/validation/interceptor/BeanValidationInterceptor.java
@@ -31,7 +31,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.reflect.MethodUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.struts.beanvalidation.constraints.ValidateGroup;
+import org.apache.struts.beanvalidation.constraints.ValidationGroup;
 import org.apache.struts.beanvalidation.validation.constant.ValidatorConstants;
 import org.apache.struts2.interceptor.validation.SkipValidation;
 
@@ -109,8 +109,8 @@ public class BeanValidationInterceptor extends MethodFilterInterceptor {
     }
 
     protected Class<?>[] getValidationGroups(Object action, String methodName) throws NoSuchMethodException {
-        ValidateGroup validateGroup = MethodUtils.getAnnotation(getActionMethod(action.getClass(), methodName), ValidateGroup.class, true, true);
-        return validateGroup == null ? new Class[]{} : validateGroup.value();
+        ValidationGroup validationGroup = MethodUtils.getAnnotation(getActionMethod(action.getClass(), methodName), ValidationGroup.class, true, true);
+        return validationGroup == null ? new Class[]{} : validationGroup.value();
     }
 
     protected void performBeanValidation(Object action, Validator validator, Class<?>[] groups) {

--- a/plugins/bean-validation/src/main/java/org/apache/struts/beanvalidation/validation/interceptor/BeanValidationInterceptor.java
+++ b/plugins/bean-validation/src/main/java/org/apache/struts/beanvalidation/validation/interceptor/BeanValidationInterceptor.java
@@ -37,6 +37,7 @@ import org.apache.struts2.interceptor.validation.SkipValidation;
 
 import javax.validation.ConstraintViolation;
 import javax.validation.Validator;
+import javax.validation.groups.Default;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Set;
@@ -108,7 +109,7 @@ public class BeanValidationInterceptor extends MethodFilterInterceptor {
 
     protected Class<?>[] getValidationGroups(Object action, String methodName) throws NoSuchMethodException {
         ValidationGroup validationGroup = MethodUtils.getAnnotation(getActionMethod(action.getClass(), methodName), ValidationGroup.class, true, true);
-        return validationGroup == null ? new Class[]{} : validationGroup.value();
+        return validationGroup == null ? new Class[]{Default.class} : validationGroup.value();
     }
 
     protected void performBeanValidation(Object action, Validator validator, Class<?>[] groups) {

--- a/plugins/bean-validation/src/main/java/org/apache/struts/beanvalidation/validation/interceptor/BeanValidationInterceptor.java
+++ b/plugins/bean-validation/src/main/java/org/apache/struts/beanvalidation/validation/interceptor/BeanValidationInterceptor.java
@@ -94,13 +94,11 @@ public class BeanValidationInterceptor extends MethodFilterInterceptor {
         ActionProxy actionProxy = invocation.getProxy();
         String methodName = actionProxy.getMethod();
 
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Validating [{}/{}] with method [{}]", invocation.getProxy().getNamespace(), invocation.getProxy().getActionName(), methodName);
-        }
         Class<?>[] validationGroup = getValidationGroups(action, methodName);
 
         if (null == MethodUtils.getAnnotation(getActionMethod(action.getClass(), methodName), SkipValidation.class,
                 true, true)) {
+            LOG.debug("Validating [{}/{}] with method [{}] and groups [{}]", invocation.getProxy().getNamespace(), invocation.getProxy().getActionName(), methodName, Arrays.toString(validationGroup));
             // performing bean validation on action
             performBeanValidation(action, validator, validationGroup);
         }
@@ -115,7 +113,7 @@ public class BeanValidationInterceptor extends MethodFilterInterceptor {
 
     protected void performBeanValidation(Object action, Validator validator, Class<?>[] groups) {
 
-        LOG.trace("Initiating bean validation.. with groups [{}]", Arrays.toString(groups));
+        LOG.trace("Initiating bean validation..");
 
         Set<ConstraintViolation<Object>> constraintViolations;
 
@@ -156,9 +154,7 @@ public class BeanValidationInterceptor extends MethodFilterInterceptor {
                     if (action instanceof ModelDriven && fieldName.startsWith(ValidatorConstants.MODELDRIVEN_PREFIX)) {
                         fieldName = fieldName.replace("model.", ValidatorConstants.EMPTY_SPACE);
                     }
-                    if (LOG.isDebugEnabled()) {
-                        LOG.debug("Adding field error [{}] with message [{}]", fieldName, validationError.getMessage());
-                    }
+                    LOG.debug("Adding field error [{}] with message [{}]", fieldName, validationError.getMessage());
                     validatorContext.addFieldError(fieldName, validationError.getMessage());
                 }
             }

--- a/plugins/bean-validation/src/main/java/org/apache/struts/beanvalidation/validation/interceptor/BeanValidationInterceptor.java
+++ b/plugins/bean-validation/src/main/java/org/apache/struts/beanvalidation/validation/interceptor/BeanValidationInterceptor.java
@@ -94,11 +94,13 @@ public class BeanValidationInterceptor extends MethodFilterInterceptor {
         ActionProxy actionProxy = invocation.getProxy();
         String methodName = actionProxy.getMethod();
 
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Validating [{}/{}] with method [{}]", invocation.getProxy().getNamespace(), invocation.getProxy().getActionName(), methodName);
+        }
         Class<?>[] validationGroup = getValidationGroups(action, methodName);
 
         if (null == MethodUtils.getAnnotation(getActionMethod(action.getClass(), methodName), SkipValidation.class,
                 true, true)) {
-            LOG.debug("Validating [{}/{}] with method [{}] and groups [{}]", invocation.getProxy().getNamespace(), invocation.getProxy().getActionName(), methodName, Arrays.toString(validationGroup));
             // performing bean validation on action
             performBeanValidation(action, validator, validationGroup);
         }
@@ -113,7 +115,7 @@ public class BeanValidationInterceptor extends MethodFilterInterceptor {
 
     protected void performBeanValidation(Object action, Validator validator, Class<?>[] groups) {
 
-        LOG.trace("Initiating bean validation..");
+        LOG.trace("Initiating bean validation.. with groups [{}]", Arrays.toString(groups));
 
         Set<ConstraintViolation<Object>> constraintViolations;
 
@@ -154,7 +156,9 @@ public class BeanValidationInterceptor extends MethodFilterInterceptor {
                     if (action instanceof ModelDriven && fieldName.startsWith(ValidatorConstants.MODELDRIVEN_PREFIX)) {
                         fieldName = fieldName.replace("model.", ValidatorConstants.EMPTY_SPACE);
                     }
-                    LOG.debug("Adding field error [{}] with message [{}]", fieldName, validationError.getMessage());
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("Adding field error [{}] with message [{}]", fieldName, validationError.getMessage());
+                    }
                     validatorContext.addFieldError(fieldName, validationError.getMessage());
                 }
             }

--- a/plugins/bean-validation/src/main/java/org/apache/struts/beanvalidation/validation/interceptor/BeanValidationInterceptor.java
+++ b/plugins/bean-validation/src/main/java/org/apache/struts/beanvalidation/validation/interceptor/BeanValidationInterceptor.java
@@ -94,13 +94,11 @@ public class BeanValidationInterceptor extends MethodFilterInterceptor {
         ActionProxy actionProxy = invocation.getProxy();
         String methodName = actionProxy.getMethod();
 
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Validating [{}/{}] with method [{}]", invocation.getProxy().getNamespace(), invocation.getProxy().getActionName(), methodName);
-        }
-        Class<?>[] validationGroup = getValidationGroups(action, methodName);
+        LOG.debug("Validating [{}/{}] with method [{}]", invocation.getProxy().getNamespace(), invocation.getProxy().getActionName(), methodName);
 
         if (null == MethodUtils.getAnnotation(getActionMethod(action.getClass(), methodName), SkipValidation.class,
                 true, true)) {
+            Class<?>[] validationGroup = getValidationGroups(action, methodName);
             // performing bean validation on action
             performBeanValidation(action, validator, validationGroup);
         }
@@ -156,9 +154,7 @@ public class BeanValidationInterceptor extends MethodFilterInterceptor {
                     if (action instanceof ModelDriven && fieldName.startsWith(ValidatorConstants.MODELDRIVEN_PREFIX)) {
                         fieldName = fieldName.replace("model.", ValidatorConstants.EMPTY_SPACE);
                     }
-                    if (LOG.isDebugEnabled()) {
-                        LOG.debug("Adding field error [{}] with message [{}]", fieldName, validationError.getMessage());
-                    }
+                    LOG.debug("Adding field error [{}] with message [{}]", fieldName, validationError.getMessage());
                     validatorContext.addFieldError(fieldName, validationError.getMessage());
                 }
             }

--- a/plugins/bean-validation/src/test/java/org/apache/struts/beanvalidation/actions/ValidateGroupAction.java
+++ b/plugins/bean-validation/src/test/java/org/apache/struts/beanvalidation/actions/ValidateGroupAction.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.struts.beanvalidation.actions;
+
+import com.opensymphony.xwork2.ActionSupport;
+import com.opensymphony.xwork2.ModelDriven;
+import org.apache.struts.beanvalidation.constraints.ValidateGroup;
+import org.apache.struts.beanvalidation.models.Person;
+
+import javax.validation.Valid;
+
+public class ValidateGroupAction extends ActionSupport implements ModelDriven<Person> {
+
+    @Valid
+    private Person model = new Person();
+
+    public Person getModel() {
+        return model;
+    }
+
+    public String actionStandard() {
+        return SUCCESS;
+    }
+
+    @ValidateGroup
+    public String actionDefault() {
+        return SUCCESS;
+    }
+
+    @ValidateGroup(Person.NameChecks.class)
+    public String actionNameChecks() {
+        return SUCCESS;
+    }
+
+    @ValidateGroup(Person.StreetChecks.class)
+    public String actionStreetChecks() {
+        return SUCCESS;
+    }
+
+    @ValidateGroup(Person.NameAndStreetChecks.class)
+    public String actionNameAndStreetChecks() {
+        return SUCCESS;
+    }
+
+    @ValidateGroup({Person.NameChecks.class, Person.FirstNameChecks.class})
+    public String actionMultiGroupsChecks() {
+        return SUCCESS;
+    }
+
+    @ValidateGroup({Person.LongNameChecks.class})
+    public String actionLongNameChecks() {
+        return SUCCESS;
+    }
+}

--- a/plugins/bean-validation/src/test/java/org/apache/struts/beanvalidation/actions/ValidateGroupAction.java
+++ b/plugins/bean-validation/src/test/java/org/apache/struts/beanvalidation/actions/ValidateGroupAction.java
@@ -20,7 +20,7 @@ package org.apache.struts.beanvalidation.actions;
 
 import com.opensymphony.xwork2.ActionSupport;
 import com.opensymphony.xwork2.ModelDriven;
-import org.apache.struts.beanvalidation.constraints.ValidateGroup;
+import org.apache.struts.beanvalidation.constraints.ValidationGroup;
 import org.apache.struts.beanvalidation.models.Person;
 
 import javax.validation.Valid;
@@ -38,32 +38,32 @@ public class ValidateGroupAction extends ActionSupport implements ModelDriven<Pe
         return SUCCESS;
     }
 
-    @ValidateGroup
+    @ValidationGroup
     public String actionDefault() {
         return SUCCESS;
     }
 
-    @ValidateGroup(Person.NameChecks.class)
+    @ValidationGroup(Person.NameChecks.class)
     public String actionNameChecks() {
         return SUCCESS;
     }
 
-    @ValidateGroup(Person.StreetChecks.class)
+    @ValidationGroup(Person.StreetChecks.class)
     public String actionStreetChecks() {
         return SUCCESS;
     }
 
-    @ValidateGroup(Person.NameAndStreetChecks.class)
+    @ValidationGroup(Person.NameAndStreetChecks.class)
     public String actionNameAndStreetChecks() {
         return SUCCESS;
     }
 
-    @ValidateGroup({Person.NameChecks.class, Person.FirstNameChecks.class})
+    @ValidationGroup({Person.NameChecks.class, Person.FirstNameChecks.class})
     public String actionMultiGroupsChecks() {
         return SUCCESS;
     }
 
-    @ValidateGroup({Person.LongNameChecks.class})
+    @ValidationGroup({Person.LongNameChecks.class})
     public String actionLongNameChecks() {
         return SUCCESS;
     }

--- a/plugins/bean-validation/src/test/java/org/apache/struts/beanvalidation/models/Person.java
+++ b/plugins/bean-validation/src/test/java/org/apache/struts/beanvalidation/models/Person.java
@@ -19,16 +19,40 @@
 package org.apache.struts.beanvalidation.models;
 
 import org.hibernate.validator.constraints.Email;
+import org.hibernate.validator.constraints.NotBlank;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
+import javax.validation.groups.Default;
 
 public class Person {
 
-    @NotNull(message = "nameNotNull")
-    @Size(min = 2, max = 64, message = "nameSize")
+    public interface NameChecks {
+    }
+
+    public interface FirstNameChecks {
+    }
+
+    public interface StreetChecks {
+    }
+
+    public interface NameAndStreetChecks extends NameChecks, StreetChecks {
+    }
+
+    public interface LongNameChecks extends Default {
+    }
+
+    @NotNull(message = "nameNotNull", groups = {Default.class, NameChecks.class, NameAndStreetChecks.class})
+    @Size.List({
+            @Size(min = 4, max = 64, message = "nameSize", groups = {Default.class, NameChecks.class, NameAndStreetChecks.class}),
+            @Size(min = 20, max = 64, message = "nameSize20", groups = {LongNameChecks.class})
+
+    })
     private String name;
+
+    @NotBlank(message = "firstNameNotBlank", groups = FirstNameChecks.class)
+    private String firstName;
 
     @NotNull(message = "emailNotNull")
     @Email(message = "emailNotValid")
@@ -51,6 +75,14 @@ public class Person {
 
     public String getName() {
         return name;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
     }
 
     public void setAddress(Address address) {

--- a/plugins/bean-validation/src/test/resources/bean-validation-test.xml
+++ b/plugins/bean-validation/src/test/resources/bean-validation-test.xml
@@ -20,8 +20,8 @@
  */
 -->
 <!DOCTYPE xwork PUBLIC
-        "-//Apache Struts//XWork 2.0//EN"
-        "http://struts.apache.org/dtds/xwork-2.0.dtd"
+        "-//Apache Struts//XWork 2.5//EN"
+        "http://struts.apache.org/dtds/xwork-2.5.dtd"
         >
 
 <xwork>
@@ -63,6 +63,12 @@
         <action name="fieldActionDoExecute" class="org.apache.struts.beanvalidation.actions.FieldActionDoExecute">
             <interceptor-ref name="beanValidation"/>
             <result type="void"/>
+        </action>
+
+        <action name="validateGroupActions" class="org.apache.struts.beanvalidation.actions.ValidateGroupAction">
+            <interceptor-ref name="beanValidation"/>
+            <result type="void"/>
+            <allowed-methods>actionStandard, actionDefault, actionNameChecks, actionStreetChecks, actionNameAndStreetChecks, actionMultiGroupsChecks, actionLongNameChecks</allowed-methods>
         </action>
 
     </package>


### PR DESCRIPTION
it would be nice Feature if BeanValidation-Plugin would support 'Grouping Constraints'

https://docs.jboss.org/hibernate/validator/5.1/reference/en-US/html/chapter-groups.html

Hedju Hor
 
Implements [WW-4907](https://issues.apache.org/jira/browse/WW-4907)