### PR TITLE
WW-4891 Debug tag should not display anything when not in dev mode

### DIFF
--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/tag/nonui/debugtag/DebugTagAction.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/tag/nonui/debugtag/DebugTagAction.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.struts2.showcase.tag.nonui.debugtag;
+
+import com.opensymphony.xwork2.ActionSupport;
+import org.apache.struts2.dispatcher.PrepareOperations;
+
+public class DebugTagAction extends ActionSupport {
+
+    public String execute() throws Exception {
+        PrepareOperations.overrideDevMode(true); // Just for Showcase, explicitly switch on for this action only
+        return SUCCESS;
+    }
+}

--- a/apps/showcase/src/main/resources/struts-tags-non-ui.xml
+++ b/apps/showcase/src/main/resources/struts-tags-non-ui.xml
@@ -151,7 +151,7 @@
         <action name="date">
             <result>/WEB-INF/tags/non-ui/date.jsp</result>
         </action>
-        <action name="debugTagDemo">
+		<action name="debugTagDemo" class="org.apache.struts2.showcase.tag.nonui.debugtag.DebugTagAction">
             <result>/WEB-INF/tags/non-ui/debug.jsp</result>
         </action>
     </package>

--- a/apps/showcase/src/main/webapp/WEB-INF/tags/non-ui/debug.jsp
+++ b/apps/showcase/src/main/webapp/WEB-INF/tags/non-ui/debug.jsp
@@ -42,7 +42,7 @@
 			<p>
 			    Just click on the Debug label to see the Struts ValueStack Debug information.
 		    <p/>
-		    <s:debug disabled="false" />
+		    <s:debug />
 		</div>
 	</div>
 </div>

--- a/apps/showcase/src/main/webapp/WEB-INF/tags/non-ui/debug.jsp
+++ b/apps/showcase/src/main/webapp/WEB-INF/tags/non-ui/debug.jsp
@@ -42,7 +42,7 @@
 			<p>
 			    Just click on the Debug label to see the Struts ValueStack Debug information.
 		    <p/>
-		    <s:debug />
+		    <s:debug disabled="false" />
 		</div>
 	</div>
 </div>

--- a/core/src/main/java/org/apache/struts2/components/Debug.java
+++ b/core/src/main/java/org/apache/struts2/components/Debug.java
@@ -34,13 +34,12 @@ import org.apache.struts2.views.annotations.StrutsTag;
 import org.apache.struts2.StrutsException;
 
 @StrutsTag(name="debug", tldTagClass="org.apache.struts2.views.jsp.ui.DebugTag",
-        description="Prints debugging information")
+        description="Prints debugging information (Only if 'struts.devMode' enabled or disable tag is set 'false')")
 public class Debug extends UIBean {
     public static final String TEMPLATE = "debug";
-    
+
     protected ReflectionProvider reflectionProvider;
 
-    
 
     public Debug(ValueStack stack, HttpServletRequest request, HttpServletResponse response) {
         super(stack, request, response);
@@ -50,7 +49,7 @@ public class Debug extends UIBean {
     public void setReflectionProvider(ReflectionProvider prov) {
         this.reflectionProvider = prov;
     }
-    
+
     protected String getDefaultTemplate() {
         return TEMPLATE;
     }
@@ -58,23 +57,38 @@ public class Debug extends UIBean {
     public boolean start(Writer writer) {
         boolean result = super.start(writer);
 
-        ValueStack stack = getStack();
-        Iterator iter = stack.getRoot().iterator();
-        List stackValues = new ArrayList(stack.getRoot().size());
-        while (iter.hasNext()) {
-            Object o = iter.next();
-            Map values;
-            try {
-                values = reflectionProvider.getBeanMap(o);
-            } catch (Exception e) {
-                throw new StrutsException("Caught an exception while getting the property values of " + o, e);
+        if (showDebug()) {
+            ValueStack stack = getStack();
+            Iterator iter = stack.getRoot().iterator();
+            List stackValues = new ArrayList(stack.getRoot().size());
+            while (iter.hasNext()) {
+                Object o = iter.next();
+                Map values;
+                try {
+                    values = reflectionProvider.getBeanMap(o);
+                } catch (Exception e) {
+                    throw new StrutsException("Caught an exception while getting the property values of " + o, e);
+                }
+                stackValues.add(new DebugMapEntry(o.getClass().getName(), values));
             }
-            stackValues.add(new DebugMapEntry(o.getClass().getName(), values));
+
+            addParameter("stackValues", stackValues);
         }
-
-        addParameter("stackValues", stackValues);
-
         return result;
+    }
+
+    @Override
+    public boolean end(Writer writer, String body) {
+        if (showDebug()) {
+            return super.end(writer, body);
+        } else {
+            popComponentStack();
+            return false;
+        }
+    }
+
+    protected boolean showDebug() {
+        return (devMode || "false".equalsIgnoreCase(disabled));
     }
 
     private static class DebugMapEntry implements Map.Entry {

--- a/core/src/main/java/org/apache/struts2/components/Debug.java
+++ b/core/src/main/java/org/apache/struts2/components/Debug.java
@@ -30,11 +30,12 @@ import java.util.Map;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.struts2.dispatcher.PrepareOperations;
 import org.apache.struts2.views.annotations.StrutsTag;
 import org.apache.struts2.StrutsException;
 
 @StrutsTag(name="debug", tldTagClass="org.apache.struts2.views.jsp.ui.DebugTag",
-        description="Prints debugging information (Only if 'struts.devMode' enabled or disable tag is set 'false')")
+        description="Prints debugging information (Only if 'struts.devMode' is enabled)")
 public class Debug extends UIBean {
     public static final String TEMPLATE = "debug";
 
@@ -88,7 +89,7 @@ public class Debug extends UIBean {
     }
 
     protected boolean showDebug() {
-        return (devMode || "false".equalsIgnoreCase(disabled));
+        return (devMode || Boolean.TRUE == PrepareOperations.getDevModeOverride());
     }
 
     private static class DebugMapEntry implements Map.Entry {

--- a/core/src/test/java/org/apache/struts2/views/jsp/ui/DebugTagTest.java
+++ b/core/src/test/java/org/apache/struts2/views/jsp/ui/DebugTagTest.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.struts2.views.jsp.ui;
+
+import com.opensymphony.xwork2.ActionContext;
+import com.opensymphony.xwork2.config.ConfigurationException;
+import com.opensymphony.xwork2.inject.ContainerBuilder;
+import com.opensymphony.xwork2.test.StubConfigurationProvider;
+import com.opensymphony.xwork2.util.location.LocatableProperties;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.struts2.StrutsConstants;
+import org.apache.struts2.views.jsp.AbstractUITagTest;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Test case for {@link org.apache.struts2.components.Debug}.
+ */
+public class DebugTagTest extends AbstractUITagTest {
+
+    private DebugTag tag;
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        tag = new DebugTag();
+        tag.setPageContext(pageContext);
+        context.put("checkStackProperty", "Hello World");
+    }
+
+    public void testDevModeEnabled() throws Exception {
+        setDevMode(true);
+
+        tag.doStartTag();
+        tag.doEndTag();
+        String result = writer.toString();
+        assertTrue(StringUtils.isNotEmpty(result));
+        assertTrue("Property 'checkStackProperty' should be in Debug Tag output", StringUtils.contains(result, "<td>checkStackProperty</td>"));
+    }
+
+    public void testDevModeDisabled() throws Exception {
+        setDevMode(false);
+
+        tag.doStartTag();
+        tag.doEndTag();
+        assertTrue("nothing to see here, devMode=false", StringUtils.isEmpty(writer.toString()));
+    }
+
+    public void testTagAttributeDisableEmpty() throws Exception {
+        setDevMode(false);
+
+        tag.doStartTag();
+        tag.doEndTag();
+        assertTrue("nothing to see here, devMode=false and Tag<disable> not set", StringUtils.isEmpty(writer.toString()));
+    }
+
+    public void testTagAttributeDisableFalse() throws Exception {
+        setDevMode(false);
+
+        tag.setDisabled("false");
+        tag.doStartTag();
+        tag.doEndTag();
+        String result = writer.toString();
+        assertTrue("devMode=false but Tag<disable> is set 'false'", StringUtils.isNotEmpty(result));
+        assertTrue("Property 'checkStackProperty' should be in Debug Tag output", StringUtils.contains(result, "<td>checkStackProperty</td>"));
+    }
+
+    public void testTagAttributeDisableTrue() throws Exception {
+        setDevMode(false);
+
+        tag.setDisabled("true");
+        tag.doStartTag();
+        tag.doEndTag();
+        assertTrue("nothing to see here, devMode=false and Tag<disable> is set 'true", StringUtils.isEmpty(writer.toString()));
+    }
+
+    public void testTagAttributeDisableAny() throws Exception {
+        setDevMode(false);
+
+        tag.setDisabled("rubbish");
+        tag.doStartTag();
+        tag.doEndTag();
+        assertTrue("nothing to see here, devMode=false and Tag<disable> is set 'rubbish", StringUtils.isEmpty(writer.toString()));
+    }
+
+
+    private void setDevMode(final boolean devMode) {
+        setStrutsConstant(new HashMap<String, String>() {{
+            put(StrutsConstants.STRUTS_DEVMODE, Boolean.toString(devMode));
+        }});
+    }
+
+    /**
+     * Overwrite the Struts Constant and reload container
+     */
+    private void setStrutsConstant(final Map<String, String> overwritePropeties) {
+        configurationManager.addContainerProvider(new StubConfigurationProvider() {
+            @Override
+            public boolean needsReload() {
+                return true;
+            }
+
+            @Override
+            public void register(ContainerBuilder builder, LocatableProperties props) throws ConfigurationException {
+                for (Map.Entry<String, String> stringStringEntry : overwritePropeties.entrySet()) {
+                    props.setProperty(stringStringEntry.getKey(), stringStringEntry.getValue(), null);
+                }
+            }
+        });
+
+        configurationManager.reload();
+        container = configurationManager.getConfiguration().getContainer();
+        stack.getContext().put(ActionContext.CONTAINER, container);
+    }
+}

--- a/core/src/test/java/org/apache/struts2/views/jsp/ui/DebugTagTest.java
+++ b/core/src/test/java/org/apache/struts2/views/jsp/ui/DebugTagTest.java
@@ -25,6 +25,7 @@ import com.opensymphony.xwork2.test.StubConfigurationProvider;
 import com.opensymphony.xwork2.util.location.LocatableProperties;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.struts2.StrutsConstants;
+import org.apache.struts2.dispatcher.PrepareOperations;
 import org.apache.struts2.views.jsp.AbstractUITagTest;
 
 import java.util.HashMap;
@@ -63,43 +64,25 @@ public class DebugTagTest extends AbstractUITagTest {
         assertTrue("nothing to see here, devMode=false", StringUtils.isEmpty(writer.toString()));
     }
 
-    public void testTagAttributeDisableEmpty() throws Exception {
+    public void testTagAttributeOverrideDevModeTrue() throws Exception {
         setDevMode(false);
 
-        tag.doStartTag();
-        tag.doEndTag();
-        assertTrue("nothing to see here, devMode=false and Tag<disable> not set", StringUtils.isEmpty(writer.toString()));
-    }
-
-    public void testTagAttributeDisableFalse() throws Exception {
-        setDevMode(false);
-
-        tag.setDisabled("false");
+        PrepareOperations.overrideDevMode(true);
         tag.doStartTag();
         tag.doEndTag();
         String result = writer.toString();
-        assertTrue("devMode=false but Tag<disable> is set 'false'", StringUtils.isNotEmpty(result));
+        assertTrue(StringUtils.isNotEmpty(result));
         assertTrue("Property 'checkStackProperty' should be in Debug Tag output", StringUtils.contains(result, "<td>checkStackProperty</td>"));
     }
 
-    public void testTagAttributeDisableTrue() throws Exception {
+    public void testTagAttributeOverrideDevModeFalse() throws Exception {
         setDevMode(false);
 
-        tag.setDisabled("true");
+        PrepareOperations.overrideDevMode(false);
         tag.doStartTag();
         tag.doEndTag();
-        assertTrue("nothing to see here, devMode=false and Tag<disable> is set 'true", StringUtils.isEmpty(writer.toString()));
+        assertTrue("nothing to see here, devMode=false and overrideDevMode=false", StringUtils.isEmpty(writer.toString()));
     }
-
-    public void testTagAttributeDisableAny() throws Exception {
-        setDevMode(false);
-
-        tag.setDisabled("rubbish");
-        tag.doStartTag();
-        tag.doEndTag();
-        assertTrue("nothing to see here, devMode=false and Tag<disable> is set 'rubbish", StringUtils.isEmpty(writer.toString()));
-    }
-
 
     private void setDevMode(final boolean devMode) {
         setStrutsConstant(new HashMap<String, String>() {{


### PR DESCRIPTION
one solution
if a user really wants to show the Debug Flag on his production release, he can use  `<s:debug disabled="false"/>`


got another solution 17b598433db28681344b65d10436ccac5f1fff54
this will solve the problem with client/server side control