### PR TITLE
Initial test dedicated for the DefaultUnknownHandlerManager

### DIFF
--- a/core/src/test/java/com/opensymphony/xwork2/DefaultUnknownHandlerManagerTest.java
+++ b/core/src/test/java/com/opensymphony/xwork2/DefaultUnknownHandlerManagerTest.java
@@ -1,0 +1,69 @@
+package com.opensymphony.xwork2;
+
+import com.opensymphony.xwork2.config.entities.ActionConfig;
+import com.opensymphony.xwork2.config.providers.SomeUnknownHandler;
+
+import java.util.ArrayList;
+
+/**
+ * Partial test to the DefaultUnknownHandlerManager to understand the relationship between Manager and Handlers.
+ *
+ * @author Ziyad Alsaeed
+ */
+public class DefaultUnknownHandlerManagerTest extends XWorkTestCase {
+
+    ActionConfig.Builder actionConfigBuilder = new ActionConfig.Builder( "com", "someAction", "someClass");
+    ActionConfig actionConfig = actionConfigBuilder.build();
+    SomeUnknownHandler someUnknownHandler = new SomeUnknownHandler();
+
+    /**
+     * Relationshsip when UnknownAction method is called.
+     *
+     * @author Ziyad Alsaeed
+     */
+    public void testHandleUnknownAction() {
+
+        DefaultUnknownHandlerManager defaultUnknownHandlerManager = new DefaultUnknownHandlerManager();
+        defaultUnknownHandlerManager.unknownHandlers = new ArrayList<>();
+        defaultUnknownHandlerManager.unknownHandlers.add(someUnknownHandler);
+
+        ActionConfig newActionConfig = defaultUnknownHandlerManager.handleUnknownAction("arbitraryNameSpace", "arbitraryActionName");
+
+        assertEquals(newActionConfig, actionConfig);
+    }
+
+    /**
+     * Relationship when UnknownActionMethod method called.
+     *
+     * @author Ziyad Alsaeed
+     */
+    public void testHandelUnknownActionMethod() throws Exception {
+        DefaultUnknownHandlerManager defaultUnknownHandlerManager = new DefaultUnknownHandlerManager();
+        defaultUnknownHandlerManager.unknownHandlers = new ArrayList<>();
+        defaultUnknownHandlerManager.unknownHandlers.add(someUnknownHandler);
+
+        String result = null;
+
+        for (int i = 0; i < 10 ; i++) {
+            result = (String) defaultUnknownHandlerManager.handleUnknownMethod(this, "someMethodName");
+            assertEquals(result, "specialActionMethod");
+        }
+
+    }
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+
+        // Make sure we are using the actionConfig we initialized.
+        someUnknownHandler.setActionConfig(actionConfig);
+        someUnknownHandler.setActionMethodResult("specialActionMethod");
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        super.tearDown();
+
+    }
+
+}

--- a/core/src/test/java/com/opensymphony/xwork2/DefaultUnknownHandlerManagerTest.java
+++ b/core/src/test/java/com/opensymphony/xwork2/DefaultUnknownHandlerManagerTest.java
@@ -29,9 +29,8 @@ import java.util.ArrayList;
  */
 public class DefaultUnknownHandlerManagerTest extends XWorkTestCase {
 
-    ActionConfig.Builder actionConfigBuilder = new ActionConfig.Builder( "com", "someAction", "someClass");
-    ActionConfig actionConfig = actionConfigBuilder.build();
-    SomeUnknownHandler someUnknownHandler = new SomeUnknownHandler();
+    ActionConfig actionConfig;
+    SomeUnknownHandler someUnknownHandler;
 
     /**
      * Relationshsip when UnknownAction method is called.
@@ -71,6 +70,10 @@ public class DefaultUnknownHandlerManagerTest extends XWorkTestCase {
         super.setUp();
 
         // Make sure we are using the actionConfig we initialized.
+        ActionConfig.Builder actionConfigBuilder = new ActionConfig.Builder( "com", "someAction", "someClass");
+        actionConfig = actionConfigBuilder.build();
+        someUnknownHandler = new SomeUnknownHandler();
+
         someUnknownHandler.setActionConfig(actionConfig);
         someUnknownHandler.setActionMethodResult("specialActionMethod");
     }

--- a/core/src/test/java/com/opensymphony/xwork2/DefaultUnknownHandlerManagerTest.java
+++ b/core/src/test/java/com/opensymphony/xwork2/DefaultUnknownHandlerManagerTest.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package com.opensymphony.xwork2;
 
 import com.opensymphony.xwork2.config.entities.ActionConfig;
@@ -8,7 +26,6 @@ import java.util.ArrayList;
 /**
  * Partial test to the DefaultUnknownHandlerManager to understand the relationship between Manager and Handlers.
  *
- * @author Ziyad Alsaeed
  */
 public class DefaultUnknownHandlerManagerTest extends XWorkTestCase {
 
@@ -19,7 +36,6 @@ public class DefaultUnknownHandlerManagerTest extends XWorkTestCase {
     /**
      * Relationshsip when UnknownAction method is called.
      *
-     * @author Ziyad Alsaeed
      */
     public void testHandleUnknownAction() {
 
@@ -35,7 +51,6 @@ public class DefaultUnknownHandlerManagerTest extends XWorkTestCase {
     /**
      * Relationship when UnknownActionMethod method called.
      *
-     * @author Ziyad Alsaeed
      */
     public void testHandelUnknownActionMethod() throws Exception {
         DefaultUnknownHandlerManager defaultUnknownHandlerManager = new DefaultUnknownHandlerManager();

--- a/core/src/test/java/com/opensymphony/xwork2/DefaultUnknownHandlerManagerTest.java
+++ b/core/src/test/java/com/opensymphony/xwork2/DefaultUnknownHandlerManagerTest.java
@@ -21,13 +21,15 @@ package com.opensymphony.xwork2;
 import com.opensymphony.xwork2.config.entities.ActionConfig;
 import com.opensymphony.xwork2.config.providers.SomeUnknownHandler;
 
+import junit.framework.TestCase;
+
 import java.util.ArrayList;
 
 /**
  * Partial test to the DefaultUnknownHandlerManager to understand the relationship between Manager and Handlers.
  *
  */
-public class DefaultUnknownHandlerManagerTest extends XWorkTestCase {
+public class DefaultUnknownHandlerManagerTest extends TestCase {
 
     ActionConfig actionConfig;
     SomeUnknownHandler someUnknownHandler;
@@ -76,12 +78,6 @@ public class DefaultUnknownHandlerManagerTest extends XWorkTestCase {
 
         someUnknownHandler.setActionConfig(actionConfig);
         someUnknownHandler.setActionMethodResult("specialActionMethod");
-    }
-
-    @Override
-    protected void tearDown() throws Exception {
-        super.tearDown();
-
     }
 
 }


### PR DESCRIPTION
This is a very trivial test dedicated for the DefaultUnknownHandlerManager. 

I'm doing some research that includes Apache Struts as an example. Most of the classes I'm interested in have sufficient tests. However, even though DefaultUnknownHandlerManager is tested through other tests created for other classes, those tests are not sufficient enough for my purpose. I'm pushing the given test for DefaultUnknownHandlerManager to confirm that it is acceptable by you. 