### PR TITLE
WW-4915 Replace deprecated commons-lang3 classes

### DIFF
--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/model/Skill.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/model/Skill.java
@@ -20,7 +20,7 @@
  */
 package org.apache.struts2.showcase.model;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 
 import java.io.Serializable;
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -263,6 +263,10 @@
             <artifactId>commons-lang3</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-core</artifactId>
             <optional>true</optional>

--- a/core/src/main/java/com/opensymphony/xwork2/DefaultActionProxy.java
+++ b/core/src/main/java/com/opensymphony/xwork2/DefaultActionProxy.java
@@ -23,7 +23,7 @@ import com.opensymphony.xwork2.config.ConfigurationException;
 import com.opensymphony.xwork2.config.entities.ActionConfig;
 import com.opensymphony.xwork2.inject.Inject;
 import com.opensymphony.xwork2.util.profiling.UtilTimerStack;
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/core/src/main/java/com/opensymphony/xwork2/config/providers/EnvsValueSubstitutor.java
+++ b/core/src/main/java/com/opensymphony/xwork2/config/providers/EnvsValueSubstitutor.java
@@ -18,7 +18,7 @@
  */
 package com.opensymphony.xwork2.config.providers;
 
-import org.apache.commons.lang3.text.StrSubstitutor;
+import org.apache.commons.text.StrSubstitutor;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 

--- a/core/src/main/java/com/opensymphony/xwork2/interceptor/ConversionErrorInterceptor.java
+++ b/core/src/main/java/com/opensymphony/xwork2/interceptor/ConversionErrorInterceptor.java
@@ -22,7 +22,7 @@ import com.opensymphony.xwork2.ActionContext;
 import com.opensymphony.xwork2.ActionInvocation;
 import com.opensymphony.xwork2.conversion.impl.XWorkConverter;
 import com.opensymphony.xwork2.util.ValueStack;
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/core/src/main/java/com/opensymphony/xwork2/validator/validators/RepopulateConversionErrorFieldValidatorSupport.java
+++ b/core/src/main/java/com/opensymphony/xwork2/validator/validators/RepopulateConversionErrorFieldValidatorSupport.java
@@ -23,7 +23,7 @@ import com.opensymphony.xwork2.ActionInvocation;
 import com.opensymphony.xwork2.interceptor.PreResultListener;
 import com.opensymphony.xwork2.util.ValueStack;
 import com.opensymphony.xwork2.validator.ValidationException;
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 

--- a/core/src/main/java/org/apache/struts2/components/Property.java
+++ b/core/src/main/java/org/apache/struts2/components/Property.java
@@ -19,7 +19,7 @@
 package org.apache.struts2.components;
 
 import com.opensymphony.xwork2.util.ValueStack;
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.struts2.views.annotations.StrutsTag;
@@ -162,15 +162,15 @@ public class Property extends Component {
     }
 
     private String prepare(String value) {
-    	String result = value;
+        String result = value;
         if (escapeHtml) {
-        	result = StringEscapeUtils.escapeHtml4(result);
+            result = StringEscapeUtils.escapeHtml4(result);
         }
         if (escapeJavaScript) {
-        	result = StringEscapeUtils.escapeEcmaScript(result);
+            result = StringEscapeUtils.escapeEcmaScript(result);
         }
         if (escapeXml) {
-        	result = StringEscapeUtils.escapeXml(result);
+            result = StringEscapeUtils.escapeXml10(result);
         }
         if (escapeCsv) {
             result = StringEscapeUtils.escapeCsv(result);

--- a/core/src/main/java/org/apache/struts2/components/Text.java
+++ b/core/src/main/java/org/apache/struts2/components/Text.java
@@ -19,7 +19,7 @@
 package org.apache.struts2.components;
 
 import com.opensymphony.xwork2.util.ValueStack;
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -225,7 +225,7 @@ public class Text extends ContextBean implements Param.UnnamedParametric {
             result = StringEscapeUtils.escapeEcmaScript(result);
         }
         if (escapeXml) {
-            result = StringEscapeUtils.escapeXml(result);
+            result = StringEscapeUtils.escapeXml10(result);
         }
         if (escapeCsv) {
             result = StringEscapeUtils.escapeCsv(result);

--- a/core/src/main/java/org/apache/struts2/dispatcher/Parameter.java
+++ b/core/src/main/java/org/apache/struts2/dispatcher/Parameter.java
@@ -20,7 +20,7 @@ package org.apache.struts2.dispatcher;
 
 import java.util.Objects;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 

--- a/core/src/main/java/org/apache/struts2/util/TextProviderHelper.java
+++ b/core/src/main/java/org/apache/struts2/util/TextProviderHelper.java
@@ -20,7 +20,7 @@ package org.apache.struts2.util;
 
 import com.opensymphony.xwork2.TextProvider;
 import com.opensymphony.xwork2.util.ValueStack;
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 

--- a/core/src/main/java/org/apache/struts2/views/util/DefaultUrlHelper.java
+++ b/core/src/main/java/org/apache/struts2/views/util/DefaultUrlHelper.java
@@ -30,7 +30,7 @@ import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/plugins/config-browser/src/main/java/org/apache/struts2/config_browser/ActionNamesAction.java
+++ b/plugins/config-browser/src/main/java/org/apache/struts2/config_browser/ActionNamesAction.java
@@ -21,7 +21,7 @@ package org.apache.struts2.config_browser;
 import com.opensymphony.xwork2.ActionSupport;
 import com.opensymphony.xwork2.config.entities.ActionConfig;
 import com.opensymphony.xwork2.inject.Inject;
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.struts2.StrutsConstants;
 
 import java.util.Set;

--- a/plugins/config-browser/src/main/java/org/apache/struts2/config_browser/ShowConfigAction.java
+++ b/plugins/config-browser/src/main/java/org/apache/struts2/config_browser/ShowConfigAction.java
@@ -24,7 +24,7 @@ import com.opensymphony.xwork2.inject.Inject;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 import com.opensymphony.xwork2.util.reflection.ReflectionProvider;
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 
 import java.beans.PropertyDescriptor;
 import java.util.Set;

--- a/plugins/javatemplates/pom.xml
+++ b/plugins/javatemplates/pom.xml
@@ -38,6 +38,10 @@
             <artifactId>commons-lang3</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.easymock</groupId>
             <artifactId>easymock</artifactId>
             <scope>test</scope>

--- a/plugins/javatemplates/src/main/java/org/apache/struts2/views/java/Attributes.java
+++ b/plugins/javatemplates/src/main/java/org/apache/struts2/views/java/Attributes.java
@@ -18,7 +18,7 @@
  */
 package org.apache.struts2.views.java;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.LinkedHashMap;

--- a/plugins/javatemplates/src/main/java/org/apache/struts2/views/java/XHTMLTagSerializer.java
+++ b/plugins/javatemplates/src/main/java/org/apache/struts2/views/java/XHTMLTagSerializer.java
@@ -20,7 +20,7 @@ package org.apache.struts2.views.java;
 
 import org.apache.struts2.components.template.TemplateRenderingContext;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 
 import java.io.IOException;
 import java.io.Writer;

--- a/plugins/javatemplates/src/main/java/org/apache/struts2/views/java/simple/CheckboxHandler.java
+++ b/plugins/javatemplates/src/main/java/org/apache/struts2/views/java/simple/CheckboxHandler.java
@@ -21,7 +21,7 @@ package org.apache.struts2.views.java.simple;
 import org.apache.struts2.views.java.Attributes;
 import org.apache.struts2.views.java.TagGenerator;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 
 import java.io.IOException;
 import java.util.Map;

--- a/plugins/javatemplates/src/main/java/org/apache/struts2/views/java/simple/CheckboxListHandler.java
+++ b/plugins/javatemplates/src/main/java/org/apache/struts2/views/java/simple/CheckboxListHandler.java
@@ -20,7 +20,7 @@ package org.apache.struts2.views.java.simple;
 
 import com.opensymphony.xwork2.util.ValueStack;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.struts2.util.MakeIterator;
 import org.apache.struts2.views.java.Attributes;

--- a/plugins/json/pom.xml
+++ b/plugins/json/pom.xml
@@ -60,6 +60,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>jsp-api</artifactId>
             <scope>provided</scope>

--- a/plugins/json/src/main/java/org/apache/struts2/json/JSONValidationInterceptor.java
+++ b/plugins/json/src/main/java/org/apache/struts2/json/JSONValidationInterceptor.java
@@ -25,7 +25,7 @@ import com.opensymphony.xwork2.interceptor.ValidationAware;
 import com.opensymphony.xwork2.interceptor.MethodFilterInterceptor;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.struts2.ServletActionContext;
 
 import javax.servlet.http.HttpServletRequest;

--- a/pom.xml
+++ b/pom.xml
@@ -848,6 +848,11 @@
                 <version>3.6</version>
             </dependency>
             <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-text</artifactId>
+                <version>1.2</version>
+            </dependency>
+            <dependency>
                 <groupId>commons-digester</groupId>
                 <artifactId>commons-digester</artifactId>
                 <version>2.1</version>


### PR DESCRIPTION
`org.apache.commons.lang3.StringEscapeUtils.escapeXml` was replaced with `org.apache.commons.text.StringEscapeUtils.escapeXml10` which escapes more characters and potentially can break some things.
@apache/struts-committers 