### PR TITLE
WW-4937 Add SortedSet support to JSON plugin

### DIFF
--- a/plugins/json/src/main/java/org/apache/struts2/json/JSONPopulator.java
+++ b/plugins/json/src/main/java/org/apache/struts2/json/JSONPopulator.java
@@ -207,6 +207,8 @@ public class JSONPopulator {
                     newCollection = new TreeSet();
                 } else if (Set.class.isAssignableFrom(clazz)) {
                     newCollection = new HashSet();
+                } else if (Queue.class.isAssignableFrom(clazz)) {
+                    newCollection = new ArrayDeque();
                 } else {
                     newCollection = new ArrayList();
                 }

--- a/plugins/json/src/main/java/org/apache/struts2/json/JSONPopulator.java
+++ b/plugins/json/src/main/java/org/apache/struts2/json/JSONPopulator.java
@@ -203,7 +203,9 @@ public class JSONPopulator {
                 newCollection = (Collection) clazz.newInstance();
             } catch (InstantiationException ex) {
                 // fallback if clazz represents an interface or abstract class
-                if (Set.class.isAssignableFrom(clazz)) {
+                if (SortedSet.class.isAssignableFrom(clazz)) {
+                    newCollection = new TreeSet();
+                } else if (Set.class.isAssignableFrom(clazz)) {
                     newCollection = new HashSet();
                 } else {
                     newCollection = new ArrayList();

--- a/plugins/json/src/test/java/org/apache/struts2/json/JSONPopulatorTest.java
+++ b/plugins/json/src/test/java/org/apache/struts2/json/JSONPopulatorTest.java
@@ -112,6 +112,21 @@ public class JSONPopulatorTest extends TestCase {
         assertEquals(2, bean.getArrayMapField()[0].size());
         assertEquals(new Long(2073501), bean.getArrayMapField()[0].get("id1"));
         assertEquals(new Long(3), bean.getArrayMapField()[0].get("id2"));
+
+        assertEquals(3, bean.getSetField().size());
+        assertEquals(true, bean.getSetField().contains("A"));
+        assertEquals(true, bean.getSetField().contains("B"));
+        assertEquals(true, bean.getSetField().contains("C"));
+
+        assertEquals(3, bean.getSortedSetField().size());
+        assertEquals("A", bean.getSortedSetField().first());
+        assertEquals(true, bean.getSortedSetField().contains("B"));
+        assertEquals("C", bean.getSortedSetField().last());
+
+        assertEquals(3, bean.getNavigableSetField().size());
+        assertEquals("A", bean.getNavigableSetField().first());
+        assertEquals(true, bean.getNavigableSetField().contains("B"));
+        assertEquals("C", bean.getNavigableSetField().last());
     }
 
     public void testObjectBeanWithStrings() throws Exception {

--- a/plugins/json/src/test/java/org/apache/struts2/json/JSONPopulatorTest.java
+++ b/plugins/json/src/test/java/org/apache/struts2/json/JSONPopulatorTest.java
@@ -127,6 +127,16 @@ public class JSONPopulatorTest extends TestCase {
         assertEquals("A", bean.getNavigableSetField().first());
         assertEquals(true, bean.getNavigableSetField().contains("B"));
         assertEquals("C", bean.getNavigableSetField().last());
+
+        assertEquals(3, bean.getQueueField().size());
+        assertEquals("A", bean.getQueueField().poll());
+        assertEquals("B", bean.getQueueField().poll());
+        assertEquals("C", bean.getQueueField().poll());
+
+        assertEquals(3, bean.getDequeField().size());
+        assertEquals("A", bean.getDequeField().pollFirst());
+        assertEquals("B", bean.getDequeField().pollFirst());
+        assertEquals("C", bean.getDequeField().pollFirst());
     }
 
     public void testObjectBeanWithStrings() throws Exception {

--- a/plugins/json/src/test/java/org/apache/struts2/json/WrapperClassBean.java
+++ b/plugins/json/src/test/java/org/apache/struts2/json/WrapperClassBean.java
@@ -20,6 +20,9 @@ package org.apache.struts2.json;
 
 import java.util.List;
 import java.util.Map;
+import java.util.NavigableSet;
+import java.util.Set;
+import java.util.SortedSet;
 
 public class WrapperClassBean {
 
@@ -40,6 +43,9 @@ public class WrapperClassBean {
     private List<Map<String, Long>> listMapField;
     private Map<String, List<Long>> mapListField;
     private Map<String, Long>[] arrayMapField;
+    private Set<String> setField;
+    private SortedSet<String> sortedSetField;
+    private NavigableSet<String> navigableSetField;
 
     public List<SimpleValue> getListField() {
         return listField;
@@ -71,6 +77,30 @@ public class WrapperClassBean {
 
     public void setArrayMapField(Map<String, Long>[] arrayMapField) {
         this.arrayMapField = arrayMapField;
+    }
+
+    public Set<String> getSetField() {
+        return setField;
+    }
+
+    public void setSetField(Set<String> setField) {
+        this.setField = setField;
+    }
+
+    public SortedSet<String> getSortedSetField() {
+        return sortedSetField;
+    }
+
+    public void setSortedSetField(SortedSet<String> sortedSetField) {
+        this.sortedSetField = sortedSetField;
+    }
+
+    public NavigableSet<String> getNavigableSetField() {
+        return navigableSetField;
+    }
+
+    public void setNavigableSetField(NavigableSet<String> navigableSetField) {
+        this.navigableSetField = navigableSetField;
     }
 
     public Boolean getBooleanField() {

--- a/plugins/json/src/test/java/org/apache/struts2/json/WrapperClassBean.java
+++ b/plugins/json/src/test/java/org/apache/struts2/json/WrapperClassBean.java
@@ -18,9 +18,11 @@
  */
 package org.apache.struts2.json;
 
+import java.util.Deque;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableSet;
+import java.util.Queue;
 import java.util.Set;
 import java.util.SortedSet;
 
@@ -46,6 +48,8 @@ public class WrapperClassBean {
     private Set<String> setField;
     private SortedSet<String> sortedSetField;
     private NavigableSet<String> navigableSetField;
+    private Queue<String> queueField;
+    private Deque<String> dequeField;
 
     public List<SimpleValue> getListField() {
         return listField;
@@ -101,6 +105,22 @@ public class WrapperClassBean {
 
     public void setNavigableSetField(NavigableSet<String> navigableSetField) {
         this.navigableSetField = navigableSetField;
+    }
+
+    public Queue<String> getQueueField() {
+        return queueField;
+    }
+
+    public void setQueueField(Queue<String> queueField) {
+        this.queueField = queueField;
+    }
+
+    public Deque<String> getDequeField() {
+        return dequeField;
+    }
+
+    public void setDequeField(Deque<String> dequeField) {
+        this.dequeField = dequeField;
     }
 
     public Boolean getBooleanField() {

--- a/plugins/json/src/test/resources/org/apache/struts2/json/json-7.txt
+++ b/plugins/json/src/test/resources/org/apache/struts2/json/json-7.txt
@@ -19,5 +19,7 @@
         "arrayMapField": [{"id1":2073501,"id2":3}],
         "setField": ["A", "C", "B"],
         "sortedSetField": ["A", "C", "B"],
-        "navigableSetField": ["A", "B", "C"]
+        "navigableSetField": ["A", "B", "C"],
+        "queueField": ["A", "B", "C"],
+        "dequeField": ["A", "B", "C"]
 }

--- a/plugins/json/src/test/resources/org/apache/struts2/json/json-7.txt
+++ b/plugins/json/src/test/resources/org/apache/struts2/json/json-7.txt
@@ -16,5 +16,8 @@
         "listField": [{"value":"1"},{"value":"2"}],
         "listMapField": [{"id1":2073501,"id2":3}],
         "mapListField": {"id1":[1,2,3],"id2":[4,3,2,1]},
-        "arrayMapField": [{"id1":2073501,"id2":3}]
+        "arrayMapField": [{"id1":2073501,"id2":3}],
+        "setField": ["A", "C", "B"],
+        "sortedSetField": ["A", "C", "B"],
+        "navigableSetField": ["A", "B", "C"]
 }


### PR DESCRIPTION
Currently when I try to deserialize a bean that contains fields of type SortedSet, I get the following exception: `java.lang.IllegalArgumentException: argument type mismatch`. This is due to the fact that JSONPopulator does not distinguish between Set and SortedSet interface. 

I added this support by creating a TreeSet for SortedSet fields. I also added a couple of tests to show the issue and confirm that it's fixed. 

I tried to follow the local code style, but since it's my first contribution to Struts project, I might have made some mistakes. I would be very happy to hear any comments and make necessary changes to this pull request. I truly appreciate your hard work of maintaining this project.