### PR TITLE
 WW-4932 honor .properties file before the generic parametrics

### DIFF
--- a/core/src/main/java/com/opensymphony/xwork2/conversion/impl/DefaultObjectTypeDeterminer.java
+++ b/core/src/main/java/com/opensymphony/xwork2/conversion/impl/DefaultObjectTypeDeterminer.java
@@ -75,10 +75,10 @@ public class DefaultObjectTypeDeterminer implements ObjectTypeDeterminer {
 
     /**
      * Determines the key class by looking for the value of @Key annotation for the given class.
-     * If no annotation is found, the key class is determined by using the generic parametrics.
-     *
-     * As fallback, it determines the key class by looking for the value of Key_${property} in the properties
+     * If no annotation is found, it determines the key class by looking for the value of Key_${property} in the properties
      * file for the given class.
+     *
+     * As fallback, the key class is determined by using the generic parametrics.
      *
      * @param parentClass the Class which contains as a property the Map or Collection we are finding the key for.
      * @param property    the property of the Map or Collection for the given parent class
@@ -89,20 +89,20 @@ public class DefaultObjectTypeDeterminer implements ObjectTypeDeterminer {
         if (annotation != null) {
             return annotation.value();
         }
-        Class clazz = getClass(parentClass, property, false);
+        Class clazz = (Class) xworkConverter.getConverter(parentClass, KEY_PREFIX + property);
         if (clazz != null) {
             return clazz;
         }
-        return (Class) xworkConverter.getConverter(parentClass, KEY_PREFIX + property);
+        return getClass(parentClass, property, false);
     }
 
     /**
      * Determines the element class by looking for the value of @Element annotation for the given
      * class.
-     * If no annotation is found, the element class is determined by using the generic parametrics.
-     *
-     * As fallback, it determines the key class by looking for the value of Element_${property} in the properties
+     * If no annotation is found, it determines the key class by looking for the value of Element_${property} in the properties
      * file for the given class. Also looks for the deprecated Collection_${property}
+     *
+     * As fallback, the element class is determined by using the generic parametrics.
      *
      * @param parentClass the Class which contains as a property the Map or Collection we are finding the key for.
      * @param property    the property of the Map or Collection for the given parent class
@@ -113,17 +113,17 @@ public class DefaultObjectTypeDeterminer implements ObjectTypeDeterminer {
         if (annotation != null) {
             return annotation.value();
         }
-        Class clazz = getClass(parentClass, property, true);
-        if (clazz != null) {
-            return clazz;
-        }
-        clazz = (Class) xworkConverter.getConverter(parentClass, ELEMENT_PREFIX + property);
+        Class clazz = (Class) xworkConverter.getConverter(parentClass, ELEMENT_PREFIX + property);
         if (clazz == null) {
             clazz = (Class) xworkConverter.getConverter(parentClass, DEPRECATED_ELEMENT_PREFIX + property);
             if (clazz != null) {
                 LOG.info("The Collection_xxx pattern for collection type conversion is deprecated. Please use Element_xxx!");
             }
         }
+        if (clazz != null) {
+            return clazz;
+        }
+        clazz = getClass(parentClass, property, true);
         return clazz;
     }
 

--- a/core/src/test/java/com/opensymphony/xwork2/ognl/OgnlUtilTest.java
+++ b/core/src/test/java/com/opensymphony/xwork2/ognl/OgnlUtilTest.java
@@ -582,7 +582,7 @@ public class OgnlUtilTest extends XWorkTestCase {
         // just do some of the 15 tests
         Map beans = ognlUtil.getBeanMap(foo);
         assertNotNull(beans);
-        assertEquals(21, beans.size());
+        assertEquals(22, beans.size());
         assertEquals("Hello Santa", beans.get("title"));
         assertEquals(new Long("123"), beans.get("ALong"));
         assertEquals(new Integer("44"), beans.get("number"));

--- a/core/src/test/java/com/opensymphony/xwork2/ognl/OgnlValueStackTest.java
+++ b/core/src/test/java/com/opensymphony/xwork2/ognl/OgnlValueStackTest.java
@@ -733,6 +733,14 @@ public class OgnlValueStackTest extends XWorkTestCase {
         assertEquals("Cat One", ((Cat) foo.getCats().get(0)).getName());
         assertEquals("Cat Two", ((Cat) foo.getCats().get(1)).getName());
 
+        //test when both Key and Value types of Map are interfaces but concrete classes are defined in .properties file
+        vs.setValue("animalMap[3].name", "Cat Three by interface");
+        vs.setValue("animalMap[6].name", "Cat Six by interface");
+        assertNotNull(foo.getAnimalMap());
+        assertEquals(2, foo.getAnimalMap().size());
+        assertEquals("Cat Three by interface", foo.getAnimalMap().get(new Long(3)).getName());
+        assertEquals("Cat Six by interface", foo.getAnimalMap().get(new Long(6)).getName());
+
         vs.setValue("annotatedCats[0].name", "Cat One By Annotation");
         vs.setValue("annotatedCats[1].name", "Cat Two By Annotation");
         assertNotNull(foo.getAnnotatedCats());

--- a/core/src/test/java/com/opensymphony/xwork2/util/Animal.java
+++ b/core/src/test/java/com/opensymphony/xwork2/util/Animal.java
@@ -18,44 +18,6 @@
  */
 package com.opensymphony.xwork2.util;
 
-import java.util.List;
-
-
-/**
- * @author <a href="mailto:plightbo@cisco.com">Pat Lightbody</a>
- * @author $Author$
- * @version $Revision$
- */
-public class Cat implements Animal {
-
-    public static final String SCIENTIFIC_NAME = "Feline";
-
-    Foo foo;
-    List kittens;
-    String name;
-
-
-    public void setFoo(Foo foo) {
-        this.foo = foo;
-    }
-
-    public Foo getFoo() {
-        return foo;
-    }
-
-    public void setKittens(List kittens) {
-        this.kittens = kittens;
-    }
-
-    public List getKittens() {
-        return kittens;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public String getName() {
-        return name;
-    }
+public interface Animal {
+    String getName();
 }

--- a/core/src/test/java/com/opensymphony/xwork2/util/Foo.java
+++ b/core/src/test/java/com/opensymphony/xwork2/util/Foo.java
@@ -53,6 +53,7 @@ public class Foo {
     long aLong;
     Calendar calendar;
     BarJunior barJunior;
+    Map<MyNumber, Animal> animalMap;
 
     public BarJunior getBarJunior() {
         return barJunior;
@@ -242,5 +243,13 @@ public class Foo {
 
     public void setCalendar(Calendar calendar) {
         this.calendar = calendar;
-    }     
+    }
+
+    public Map<MyNumber, Animal> getAnimalMap() {
+        return animalMap;
+    }
+
+    public void setAnimalMap(Map<MyNumber, Animal> animalMap) {
+        this.animalMap = animalMap;
+    }
 }

--- a/core/src/test/java/com/opensymphony/xwork2/util/MyNumber.java
+++ b/core/src/test/java/com/opensymphony/xwork2/util/MyNumber.java
@@ -18,44 +18,5 @@
  */
 package com.opensymphony.xwork2.util;
 
-import java.util.List;
-
-
-/**
- * @author <a href="mailto:plightbo@cisco.com">Pat Lightbody</a>
- * @author $Author$
- * @version $Revision$
- */
-public class Cat implements Animal {
-
-    public static final String SCIENTIFIC_NAME = "Feline";
-
-    Foo foo;
-    List kittens;
-    String name;
-
-
-    public void setFoo(Foo foo) {
-        this.foo = foo;
-    }
-
-    public Foo getFoo() {
-        return foo;
-    }
-
-    public void setKittens(List kittens) {
-        this.kittens = kittens;
-    }
-
-    public List getKittens() {
-        return kittens;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public String getName() {
-        return name;
-    }
+abstract class MyNumber extends Number {
 }

--- a/core/src/test/resources/com/opensymphony/xwork2/util/Foo-conversion.properties
+++ b/core/src/test/resources/com/opensymphony/xwork2/util/Foo-conversion.properties
@@ -26,4 +26,5 @@ KeyProperty_barCollection=id
 Element_barCollection=com.opensymphony.xwork2.util.Bar
 KeyProperty_barList=id
 Element_barList=com.opensymphony.xwork2.util.Bar
-
+Key_animalMap=java.lang.Long
+Element_animalMap=com.opensymphony.xwork2.util.Cat


### PR DESCRIPTION
I think it's better to honor .properties file (where element class has been defined strictly by user) before the generic parametrics.