### PR TITLE
Minor config fixes for the Showcase Application:

### DIFF
--- a/apps/showcase/src/main/resources/struts-token.xml
+++ b/apps/showcase/src/main/resources/struts-token.xml
@@ -48,7 +48,7 @@
             <interceptor-ref name="defaultStack"/>
             <interceptor-ref name="token"/>
             <result name="invalid.token">/WEB-INF/token/doublePost.jsp</result>
-            <result name="success" type="redirect">/WEB-INF/token/transferDone.jsp</result>
+            <result name="success">/WEB-INF/token/transferDone.jsp</result>
         </action>
 
 
@@ -62,7 +62,7 @@
             <interceptor-ref name="defaultStack"/>
             <interceptor-ref name="tokenSession"/>
             <result name="invalid.token">/WEB-INF/token/doublePost.jsp</result>
-            <result name="success" type="redirect">/WEB-INF/token/transferDone.jsp</result>
+            <result name="success">/WEB-INF/token/transferDone.jsp</result>
         </action>
 
 

--- a/apps/showcase/src/main/resources/struts-validation.xml
+++ b/apps/showcase/src/main/resources/struts-validation.xml
@@ -34,28 +34,28 @@
 
 	<package name="validation" extends="json-default" namespace="/validation">
         <action name="index">
-            <result>/WEB-INF/validation/index.jsp</result>
+            <result>index.jsp</result>
         </action>
 
 	    <action name="quizBasic" class="org.apache.struts2.showcase.validation.QuizAction">
-            <result name="input">quiz-basic.jsp</result>
-            <result>quiz-success.jsp</result>
+            <result name="input">/WEB-INF/validation/quiz-basic.jsp</result>
+            <result>/WEB-INF/validation/quiz-success.jsp</result>
         </action>
 
         <action name="quizClient" class="org.apache.struts2.showcase.validation.QuizAction">
-            <result name="input">quiz-client.jsp</result>
-            <result>quiz-success.jsp</result>
+            <result name="input">/WEB-INF/validation/quiz-client.jsp</result>
+            <result>/WEB-INF/validation/quiz-success.jsp</result>
         </action>
 
         <action name="quizClientCss" class="org.apache.struts2.showcase.validation.QuizAction">
-            <result name="input">quiz-client-css.jsp</result>
-            <result>quiz-success.jsp</result>
+            <result name="input">/WEB-INF/validation/quiz-client-css.jsp</result>
+            <result>/WEB-INF/validation/quiz-success.jsp</result>
         </action>
 
         <action name="quizAjax" class="org.apache.struts2.showcase.validation.QuizAction">
             <interceptor-ref name="jsonValidationWorkflowStack"/>
-            <result name="input">quiz-ajax.jsp</result>
-            <result>quiz-success.jsp</result>
+            <result name="input">/WEB-INF/validation/quiz-ajax.jsp</result>
+            <result>/WEB-INF/validation/quiz-success.jsp</result>
         </action>
 
 		<!-- =========================================== -->

--- a/apps/showcase/src/main/webapp/WEB-INF/token/example4.ftl
+++ b/apps/showcase/src/main/webapp/WEB-INF/token/example4.ftl
@@ -50,7 +50,7 @@
 
 		<@s.form action="transfer4">
 			<@s.token/>
-			<@s.textfield label="Amount" name="amount" required="true" value="400"/>
+			<@s.textfield label="Amount" name="amount" required=true value="400"/>
 			<@s.submit value="Transfer money" cssClass="btn btn-primary"/>
 		</@s.form>
 		</div>


### PR DESCRIPTION
1) Token examples. Examples 2 and 3 previously resulted in 403's upon submit (config issue).
2) Token examples. Example 4 resulted in error 500 when selected from the menu (FTL param type issue).
3) Validation examples.  Examples quizBasic, quizClient and quizClientCss resulted in 404's when selected from menu (config issue).