### PR TITLE
[WW-4977] Fixing flaky test in Jsr168DispatcherTest and Jsr286DispatcherTest.

### DIFF
--- a/plugins/portlet/src/test/java/org/apache/struts2/portlet/dispatcher/Jsr168DispatcherTest.java
+++ b/plugins/portlet/src/test/java/org/apache/struts2/portlet/dispatcher/Jsr168DispatcherTest.java
@@ -261,6 +261,7 @@ public class Jsr168DispatcherTest extends MockObjectTestCase {
         Map<String, String> initParams = new HashMap<String, String>();
         initParams.put("viewNamespace", "/view");
         initParams.put("editNamespace", "/edit");
+        initParams.put(StrutsConstants.STRUTS_ALWAYS_SELECT_FULL_NAMESPACE, "true");
 
         initPortletConfig(initParams, new HashMap<String, Object>());
         initRequest(requestParams, new HashMap<String, Object>(), sessionMap, mode, WindowState.NORMAL, false, null);

--- a/plugins/portlet/src/test/java/org/apache/struts2/portlet/dispatcher/Jsr286DispatcherTest.java
+++ b/plugins/portlet/src/test/java/org/apache/struts2/portlet/dispatcher/Jsr286DispatcherTest.java
@@ -142,6 +142,7 @@ public class Jsr286DispatcherTest extends MockObjectTestCase {
 		Map<String, String> initParams = new HashMap<String, String>();
 		initParams.put("viewNamespace", "/view");
 		initParams.put("editNamespace", "/edit");
+		initParams.put(StrutsConstants.STRUTS_ALWAYS_SELECT_FULL_NAMESPACE, "true");
 
 		initPortletConfig(initParams, new HashMap<String, Object>());
 		initRequest(requestParams, new HashMap<String, Object>(), sessionMap,


### PR DESCRIPTION
Issue link: https://issues.apache.org/jira/browse/WW-4977

testRender_ok and testProcessAction_ok in Jsr168DispatcherTest have test-order dependencies and fail when they are run after testModeChangeUsingPortletWidgets. Similarly, testRender_ok and testProcessAction_ok in Jsr286DispatcherTest also have this problem.

These tests can be fixed by adding the entry {STRUTS_ALWAYS_SELECT_FULL_NAMESPACE=“true”} to initParams in testModeChangeUsingPortletWidgets. The fix will enable the tests in these classes to now pass in any order. Let me know if you want to discuss more.