### PR TITLE
Update Struts 2.5.19 build with some newer (compatible) library versions

### DIFF
--- a/plugins/embeddedjsp/pom.xml
+++ b/plugins/embeddedjsp/pom.xml
@@ -101,7 +101,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.19.1</version>
                 <configuration>
                     <additionalClasspathElements>
                         <element>${project.build.testOutputDirectory}/jsps.jar</element>

--- a/plugins/oval/src/test/java/org/apache/struts2/oval/interceptor/OValValidationInterceptorTest.java
+++ b/plugins/oval/src/test/java/org/apache/struts2/oval/interceptor/OValValidationInterceptorTest.java
@@ -28,6 +28,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+import junit.framework.AssertionFailedError;
+
 public class OValValidationInterceptorTest extends XWorkTestCase {
     public void testSimpleFieldsXML() throws Exception {
         ActionProxy baseActionProxy = actionProxyFactory.createActionProxy("oval", "simpleFieldsXML", null, null);
@@ -283,7 +285,18 @@ public class OValValidationInterceptorTest extends XWorkTestCase {
         assertEquals(5, fieldErrors.size()); // 5: as there will be field errors for 'model' and 'address' themselves
         assertValue(fieldErrors, "name", Arrays.asList("name cannot be null"));
         assertValue(fieldErrors, "email", Arrays.asList("email cannot be null"));
-        assertValue(fieldErrors, "address.street", Arrays.asList("street cannot be smaller than 7 characters"));
+        try {
+            // Oval version <= 1.40 validation error for invalid data reports: "net.sf.oval.constraint.AssertValid.violated".
+            assertValue(fieldErrors, "address", Arrays.asList("net.sf.oval.constraint.AssertValid.violated"));
+            // Oval version <= 1.40 validation error for minimum length reports: "street cannot be smaller than 7 characters".
+            assertValue(fieldErrors, "address.street", Arrays.asList("street cannot be smaller than 7 characters"));
+        }
+        catch (AssertionFailedError afe) {
+            // Oval version >= 1.50 validation error for invalid data reports: "address is invalid".
+            assertValue(fieldErrors, "address", Arrays.asList("address is invalid"));
+            // Oval version >= 1.50 validation error for minimum length reports: "street cannot be shorter than 7 characters".
+            assertValue(fieldErrors, "address.street", Arrays.asList("street cannot be shorter than 7 characters"));
+        }
 
     }
 
@@ -300,7 +313,19 @@ public class OValValidationInterceptorTest extends XWorkTestCase {
     	assertEquals(5, fieldErrors.size()); // 5: as there will be field errors for 'person' and 'person.address' themselves
     	assertValue(fieldErrors, "person.name", Arrays.asList("name cannot be null"));
     	assertValue(fieldErrors, "person.email", Arrays.asList("email cannot be null"));
-    	assertValue(fieldErrors, "person.address.street", Arrays.asList("street cannot be smaller than 7 characters"));
+       try {
+           // Oval version <= 1.40 validation error for invalid data reports: "net.sf.oval.constraint.AssertValid.violated".
+           assertValue(fieldErrors, "person.address", Arrays.asList("net.sf.oval.constraint.AssertValid.violated"));
+           // Oval version <= 1.40 validation error for minimum length reports: "street cannot be smaller than 7 characters".
+           assertValue(fieldErrors, "person.address.street", Arrays.asList("street cannot be smaller than 7 characters"));
+       }
+       catch (AssertionFailedError afe) {
+           // Oval version >= 1.50 validation error for invalid data reports: "address is invalid".
+           assertValue(fieldErrors, "person.address", Arrays.asList("address is invalid"));
+           // Oval version >= 1.50 validation error for minimum length reports: "street cannot be shorter than 7 characters".
+           assertValue(fieldErrors, "person.address.street", Arrays.asList("street cannot be shorter than 7 characters"));
+       }
+
     }
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <connection>scm:git:https://gitbox.apache.org/repos/asf/struts.git</connection>
         <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/struts.git</developerConnection>
         <url>https://github.com/apache/struts/</url>
-        <tag>STRUTS_2_5_16</tag>
+        <tag>STRUTS_2_5_19</tag>
     </scm>
 
     <issueManagement>
@@ -97,16 +97,16 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <spring.platformVersion>4.3.13.RELEASE</spring.platformVersion>
-        <ognl.version>3.1.15</ognl.version>
+        <spring.platformVersion>4.3.20.RELEASE</spring.platformVersion>
+        <ognl.version>3.1.18</ognl.version>
         <asm.version>5.2</asm.version>
-        <tiles.version>3.0.7</tiles.version>
-        <tiles-request.version>1.0.6</tiles-request.version>
-        <log4j2.version>2.10.0</log4j2.version>
-        <jackson.version>2.9.5</jackson.version>
+        <tiles.version>3.0.8</tiles.version>
+        <tiles-request.version>1.0.7</tiles-request.version>
+        <log4j2.version>2.11.1</log4j2.version>
+        <jackson.version>2.9.7</jackson.version>
 
         <!-- Site generation -->
-        <fluido-skin.version>1.6</fluido-skin.version>
+        <fluido-skin.version>1.7</fluido-skin.version>
 
         <!-- Sonar -->
         <sonar.host.url>https://builds.apache.org/analysis/</sonar.host.url>
@@ -234,6 +234,13 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>2.20.1</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.apache.maven.surefire</groupId>
+                            <artifactId>surefire-junit47</artifactId>
+                            <version>2.20.1</version>
+                        </dependency>
+                    </dependencies>
                     <configuration>
                         <argLine>-Duser.language=en -Duser.region=US</argLine>
                         <includes>
@@ -242,6 +249,12 @@
                         <excludes>
                             <exclude>**/TestBean.java</exclude>
                         </excludes>
+                        <properties>
+                          <property>
+                            <name>junit</name>
+                            <value>false</value>
+                          </property>
+                        </properties>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -312,7 +325,7 @@
                 <plugin>
                     <groupId>org.owasp</groupId>
                     <artifactId>dependency-check-maven</artifactId>
-                    <version>3.1.1</version>
+                    <version>3.3.4</version>
                     <configuration>
                         <suppressionFiles>
                             <suppressionFile>src/etc/project-suppression.xml</suppressionFile>
@@ -373,12 +386,12 @@
                     <dependency>
                         <groupId>org.apache.maven.doxia</groupId>
                         <artifactId>doxia-core</artifactId>
-                        <version>1.7</version>
+                        <version>1.8</version>
                     </dependency>
                     <dependency>
                         <groupId>org.apache.maven.doxia</groupId>
                         <artifactId>doxia-module-markdown</artifactId>
-                        <version>1.3</version>
+                        <version>1.7</version>
                     </dependency>
                 </dependencies>
             </plugin>
@@ -445,7 +458,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>versions-maven-plugin</artifactId>
-                <version>2.5</version>
+                <version>2.7</version>
                 <reportSets>
                     <reportSet>
                         <reports>
@@ -607,13 +620,13 @@
             <dependency>
                 <groupId>org.freemarker</groupId>
                 <artifactId>freemarker</artifactId>
-                <version>2.3.26-incubating</version>
+                <version>2.3.28</version>
             </dependency>
 
             <dependency>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>org.apache.felix.main</artifactId>
-                <version>4.0.3</version>
+                <version>4.6.1</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.felix</groupId>
@@ -690,12 +703,13 @@
                 <groupId>cglib</groupId>
                 <artifactId>cglib-nodep</artifactId>
                 <version>2.1_3</version>
+                <!-- Recommended version for jmock-cglib 1.2.0 -->
             </dependency>
 
             <dependency>
                 <groupId>org.easymock</groupId>
                 <artifactId>easymock</artifactId>
-                <version>3.4</version>
+                <version>3.5.1</version>
                 <scope>test</scope>
             </dependency>
 
@@ -709,7 +723,7 @@
             <dependency>
                 <groupId>org.glassfish</groupId>
                 <artifactId>javax.el</artifactId>
-                <version>3.0.0</version>
+                <version>3.0.1-b10</version>
             </dependency>
 
             <dependency>
@@ -729,7 +743,7 @@
             <dependency>
                 <groupId>org.apache.tomcat</groupId>
                 <artifactId>jasper</artifactId>
-                <version>6.0.18</version>
+                <version>6.0.53</version>
                 <scope>provided</scope>
             </dependency>
 
@@ -813,19 +827,19 @@
             <dependency>
                 <groupId>org.apache.tomcat</groupId>
                 <artifactId>juli</artifactId>
-                <version>6.0.18</version>
+                <version>6.0.53</version>
             </dependency>
 
             <!-- Commons -->
             <dependency>
                 <groupId>commons-logging</groupId>
                 <artifactId>commons-logging</artifactId>
-                <version>1.1.3</version>
+                <version>1.2</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-collections4</artifactId>
-                <version>4.1</version>
+                <version>4.2</version>
             </dependency>
             <!-- it's a dependency of Velocity defined here to override the transitive one -->
             <dependency>
@@ -841,12 +855,12 @@
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>2.5</version>
+                <version>2.6</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.6</version>
+                <version>3.8.1</version>
             </dependency>
             <dependency>
                 <groupId>commons-digester</groupId>
@@ -867,12 +881,12 @@
             <dependency>
                 <groupId>commons-beanutils</groupId>
                 <artifactId>commons-beanutils</artifactId>
-                <version>1.9.2</version>
+                <version>1.9.3</version>
             </dependency>
             <dependency>
                 <groupId>commons-validator</groupId>
                 <artifactId>commons-validator</artifactId>
-                <version>1.5.1</version>
+                <version>1.6</version>
             </dependency>
 
             <!-- Mocks for unit testing (by Spring) -->
@@ -970,7 +984,7 @@
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-all</artifactId>
-                <version>1.9.5</version>
+                <version>1.10.19</version>
                 <scope>test</scope>
             </dependency>
 
@@ -984,12 +998,12 @@
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
-                <version>1.7.12</version>
+                <version>1.7.25</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-simple</artifactId>
-                <version>1.7.12</version>
+                <version>1.7.25</version>
             </dependency>
 
             <dependency>
@@ -1009,13 +1023,13 @@
             <dependency>
                 <groupId>net.sf.oval</groupId>
                 <artifactId>oval</artifactId>
-                <version>1.31</version>
+                <version>1.90</version>
             </dependency>
 
             <dependency>
                 <groupId>com.thoughtworks.xstream</groupId>
                 <artifactId>xstream</artifactId>
-                <version>1.4.10</version>
+                <version>1.4.11.1</version>
             </dependency>
 
             <dependency>
@@ -1027,12 +1041,12 @@
             <dependency>
                 <groupId>org.mortbay.jetty</groupId>
                 <artifactId>jetty</artifactId>
-                <version>6.1.9</version>
+                <version>6.1.26</version>
             </dependency>
             <dependency>
                 <groupId>org.mortbay.jetty</groupId>
                 <artifactId>jsp-2.1</artifactId>
-                <version>6.1.9</version>
+                <version>6.1.26</version>
             </dependency>
 
             <!-- Portlet -->
@@ -1075,13 +1089,13 @@
             <dependency>
                 <groupId>javax.enterprise</groupId>
                 <artifactId>cdi-api</artifactId>
-                <version>1.0-SP1</version>
+                <version>1.0-SP4</version>
             </dependency>
 
             <dependency>
                 <groupId>org.jboss.weld</groupId>
                 <artifactId>weld-core</artifactId>
-                <version>1.0.1-Final</version>
+                <version>1.0.1-SP4</version>
             </dependency>
 
             <dependency>
@@ -1093,7 +1107,7 @@
             <dependency>
                 <groupId>xerces</groupId>
                 <artifactId>xercesImpl</artifactId>
-                <version>2.10.0</version>
+                <version>2.12.0</version>
                 <scope>test</scope>
             </dependency>
 


### PR DESCRIPTION
Update Struts 2.5.19 build with some newer (compatible) library versions.

- Fix SCM tag entry typo in main pom.xml.
- Enhance main pom.xml maven-surefire-plugin configuration to avoid some test-ng related duplication failures:  "Cannot find JUnit method class junit.framework.TestSuite$1.warning".
- Remove unnecessary plugins/embeddedjsp/pom.xml (struts2-embeddedjsp-plugin) maven-surefire-plugin version override (noted with preceding change).
- Update Struts 2.5.19 build to use some newer (compatible) library versions.
  Change the main pom.xml library versions for the following:
  - spring.platformVersion 4.3.13.RELEASE -> 4.3.20.RELEASE
  - ognl 3.1.15 -> 3.1.18  (Note: newest version that passes unit tests)
  - oval 1.31 -> 1.90      (Note: required unit test fix for OValValidationInterceptorTest.java)
  - tiles 3.0.7 -> 3.0.8
  - tiles-request 1.0.6 -> 1.0.7
  - log4j 2.10.0 -> 2.11.1
  - jackson 2.9.5 -> 2.9.7
  - fluido-skin.version 1.6 -> 1.7
  - slf4j 1.7.12 -> 1.7.25
  - xtream 1.4.10 -> 1.4.11.1
  - jetty 6.1.9 -> 6.1.26 (last in 6.1.x line)
  - xerces 2.10.0 - > 2.12.0
  - org.owasp 3.1.1 -> 3.3.4
  - versions-maven-plugin 2.5 -> 2.7
  - doxia-core 1.7 -> 1.8
  - doxia-markdown 1.3 -> 1.7
  - freemarker 2.3.26-incubating -> 2.3.28
  - org.apache.felix.main 4.0.3 -> 4.6.1  (Note: most recent 4.x)
  - easymock 3.4 -> 3.5.1
  - javax.el 3.0 -> 3.0.1-b10
  - jasper 6.0.18 -> 6.0.53  (Note: most recent 6.0.x)
  - juli 6.0.18 -> 6.0.53    (Note: most recent 6.0.x)
  - commons-logging 1.1.3 -> 1.2
  - commons-collections4 4.1 -> 4.2
  - commons-io 2.5 -> 2.6
  - commons-lang 3.6 -> 3.8.1
  - commons-beanutils 1.9.2 -> 1.9.3
  - commons-validator 1.5.1 -> 1.6
  - mockito 1.9.5 -> 1.10.19            (Note: most recent 1.x)
  - cdi-api 1.0-SP1 -> 1.0-SP4          (Note: most recent 1.0.x)
  - weld-core 1.0.1-Final -> 1.0.1-SP4  (Note: most recent 1.0.x)
  Note for cglib-nodep:  Build succeeded with cglib-nodep 2.2.2 and 3.2.5.  Although
    cglib 3.2.5 matches ASM 5.2, jmock-cglib 1.2.0 identifies cglib-nodep 2.1_3 as its
    requirement (on the JMock http://jmock.org/download.html download page) so it should
    remain as long as JMock 1.2.0 is used.

Fixes [WW-4978](https://issues.apache.org/jira/browse/WW-4978)