### PR TITLE
WW-4930 Add constant to enable smi inheritance

### DIFF
--- a/plugins/convention/src/main/java/org/apache/struts2/convention/ConventionConstants.java
+++ b/plugins/convention/src/main/java/org/apache/struts2/convention/ConventionConstants.java
@@ -49,4 +49,6 @@ public class ConventionConstants {
     public static final String CONVENTION_ACTION_MAP_ALL_MATCHES = "struts.convention.action.mapAllMatches";
     public static final String CONVENTION_ACTION_EAGER_LOADING = "struts.convention.action.eagerLoading";
     public static final String CONVENTION_RESULT_FLAT_LAYOUT = "struts.convention.result.flatLayout";
+    /** Enables the inheritance of the SMI value from a parent package config to its children */
+    public static final String CONVENTION_ENABLE_SMI_INHERITANCE = "struts.convention.enable.smi.inheritance";
 }

--- a/plugins/convention/src/main/java/org/apache/struts2/convention/config/entities/ConventionConstantConfig.java
+++ b/plugins/convention/src/main/java/org/apache/struts2/convention/config/entities/ConventionConstantConfig.java
@@ -56,6 +56,7 @@ public class ConventionConstantConfig extends ConstantConfig {
     private Boolean conventionActionMapAllMatches;
     private Boolean conventionActionEagerLoading;
     private Boolean conventionResultFlatLayout;
+    private Boolean conventionEnableSmiInheritance;
 
     @Override
     public Map<String, String> getAllAsStringsMap() {
@@ -88,6 +89,7 @@ public class ConventionConstantConfig extends ConstantConfig {
         map.put(ConventionConstants.CONVENTION_ACTION_MAP_ALL_MATCHES, Objects.toString(conventionActionMapAllMatches, null));
         map.put(ConventionConstants.CONVENTION_ACTION_EAGER_LOADING, Objects.toString(conventionActionEagerLoading, null));
         map.put(ConventionConstants.CONVENTION_RESULT_FLAT_LAYOUT, Objects.toString(conventionResultFlatLayout, null));
+        map.put(ConventionConstants.CONVENTION_ENABLE_SMI_INHERITANCE, Objects.toString(conventionEnableSmiInheritance, null));
 
         return map;
     }
@@ -326,5 +328,13 @@ public class ConventionConstantConfig extends ConstantConfig {
 
     public void setConventionResultFlatLayout(Boolean conventionResultFlatLayout) {
         this.conventionResultFlatLayout = conventionResultFlatLayout;
+    }
+
+    public Boolean getConventionEnableSmiInheritance() {
+        return conventionEnableSmiInheritance;
+    }
+
+    public void setConventionEnableSmiInheritance(Boolean conventionEnableSmiInheritance) {
+        this.conventionEnableSmiInheritance = conventionEnableSmiInheritance;
     }
 }

--- a/plugins/convention/src/main/resources/struts-plugin.xml
+++ b/plugins/convention/src/main/resources/struts-plugin.xml
@@ -66,6 +66,8 @@
 
   <constant name="struts.convention.exclude.parentClassLoader" value="true" />
 
+  <constant name="struts.convention.enable.smi.inheritance" value="false" />
+
   <package name="convention-default" extends="struts-default">
   </package>
 </struts>

--- a/plugins/convention/src/test/java/org/apache/struts2/convention/PackageBasedActionConfigBuilderTest.java
+++ b/plugins/convention/src/test/java/org/apache/struts2/convention/PackageBasedActionConfigBuilderTest.java
@@ -347,7 +347,7 @@ public class PackageBasedActionConfigBuilderTest extends TestCase {
         mockContainer.setResultMapBuilder(resultMapBuilder);
         mockContainer.setConventionsService(new ConventionsServiceImpl(""));
 
-        PackageBasedActionConfigBuilder builder = new PackageBasedActionConfigBuilder(configuration, mockContainer ,of, "false", "struts-default");
+        PackageBasedActionConfigBuilder builder = new PackageBasedActionConfigBuilder(configuration, mockContainer ,of, "false", "struts-default", "false");
         builder.setFileProtocols("jar");
         if (actionPackages != null) {
             builder.setActionPackages(actionPackages);

--- a/plugins/convention/src/test/java/org/apache/struts2/convention/PackageBasedActionConfigBuilderTest.java
+++ b/plugins/convention/src/test/java/org/apache/struts2/convention/PackageBasedActionConfigBuilderTest.java
@@ -32,6 +32,8 @@ import com.opensymphony.xwork2.util.fs.DefaultFileManager;
 import com.opensymphony.xwork2.util.fs.DefaultFileManagerFactory;
 import com.opensymphony.xwork2.util.reflection.ReflectionException;
 import junit.framework.TestCase;
+
+import org.apache.commons.lang3.StringUtils;
 import org.apache.struts2.convention.actions.DefaultResultPathAction;
 import org.apache.struts2.convention.actions.NoAnnotationAction;
 import org.apache.struts2.convention.actions.Skip;
@@ -108,7 +110,18 @@ public class PackageBasedActionConfigBuilderTest extends TestCase {
         run("org.apache.struts2.convention.actions", null, "org.apache.struts2.convention.actions.exclude");
     }
 
+    public void testSmiInheritanceEnabled() throws MalformedURLException {
+        run("org.apache.struts2.convention.actions", null, null, "true");
+    }
+
+    public void testSmiInheritanceDisabled() throws MalformedURLException {
+        run("org.apache.struts2.convention.actions", null, null, "false");
+    }
+
     private void run(String actionPackages, String packageLocators, String excludePackages) throws MalformedURLException {
+        run(actionPackages, packageLocators, excludePackages, "");
+    }
+    private void run(String actionPackages, String packageLocators, String excludePackages, String enableSmiInheritance) throws MalformedURLException {
         //setup interceptors
         List<InterceptorConfig> defaultInterceptors = new ArrayList<>();
         defaultInterceptors.add(makeInterceptorConfig("interceptor-1"));
@@ -121,6 +134,19 @@ public class PackageBasedActionConfigBuilderTest extends TestCase {
         InterceptorMapping interceptor2 = new InterceptorMapping("interceptor-2", new TestInterceptor());
         defaultInterceptorStacks.add(makeInterceptorStackConfig("stack-1", interceptor1, interceptor2));
 
+        //setup strict MethodInvocation
+        boolean strictMethodInvocation = true;
+        boolean isSmiInheritanceEnabled = false;
+        // Sets the SMI value to false so we can test that the created package configs adopt the SMI value of their parent.
+        // If enableSmiInheritance is set to false it is expected that the generated package configs have their SMI value set to true (the default)
+        // even when the SMI of their parent is set to false.
+        if (StringUtils.equals(enableSmiInheritance, "true")) {
+            strictMethodInvocation = false;
+            isSmiInheritanceEnabled = true;
+        } else if (StringUtils.equals(enableSmiInheritance, "false")) {
+            strictMethodInvocation = false;
+        }
+
         //setup results
         ResultTypeConfig[] defaultResults = new ResultTypeConfig[]{new ResultTypeConfig.Builder("dispatcher",
                 ServletDispatcherResult.class.getName()).defaultResultParam("location").build(),
@@ -130,8 +156,7 @@ public class PackageBasedActionConfigBuilderTest extends TestCase {
         Set<String> globalAllowedMethods = TextParseUtil.commaDelimitedStringToSet("execute,browse,cancel,input");
 
         PackageConfig strutsDefault = makePackageConfig("struts-default", null, null, "dispatcher",
-                defaultResults, defaultInterceptors, defaultInterceptorStacks, globalAllowedMethods);
-
+                defaultResults, defaultInterceptors, defaultInterceptorStacks, globalAllowedMethods, strictMethodInvocation);
         PackageConfig packageLevelParentPkg = makePackageConfig("package-level", null, null, null);
         PackageConfig classLevelParentPkg = makePackageConfig("class-level", null, null, null);
 
@@ -347,7 +372,7 @@ public class PackageBasedActionConfigBuilderTest extends TestCase {
         mockContainer.setResultMapBuilder(resultMapBuilder);
         mockContainer.setConventionsService(new ConventionsServiceImpl(""));
 
-        PackageBasedActionConfigBuilder builder = new PackageBasedActionConfigBuilder(configuration, mockContainer ,of, "false", "struts-default", "false");
+        PackageBasedActionConfigBuilder builder = new PackageBasedActionConfigBuilder(configuration, mockContainer , of, "false", "struts-default", enableSmiInheritance);
         builder.setFileProtocols("jar");
         if (actionPackages != null) {
             builder.setActionPackages(actionPackages);
@@ -369,6 +394,7 @@ public class PackageBasedActionConfigBuilderTest extends TestCase {
         /* org.apache.struts2.convention.actions.action */
         PackageConfig pkgConfig = configuration.getPackageConfig("org.apache.struts2.convention.actions.action#struts-default#/action");
         assertNotNull(pkgConfig);
+        checkSmiValue(pkgConfig, strutsDefault, isSmiInheritanceEnabled);
         assertEquals(14, pkgConfig.getActionConfigs().size());
         verifyActionConfig(pkgConfig, "action1", ActionNameAction.class, "run1", pkgConfig.getName());
         verifyActionConfig(pkgConfig, "action2", ActionNameAction.class, "run2", pkgConfig.getName());
@@ -392,12 +418,14 @@ public class PackageBasedActionConfigBuilderTest extends TestCase {
         //action on namespace1 (action level)
         pkgConfig = configuration.getPackageConfig("org.apache.struts2.convention.actions.namespace3#struts-default#/namespaces1");
         assertNotNull(pkgConfig);
+        checkSmiValue(pkgConfig, strutsDefault, isSmiInheritanceEnabled);
         assertEquals(1, pkgConfig.getActionConfigs().size());
         verifyActionConfig(pkgConfig, "action-level-namespaces", ActionLevelNamespacesAction.class, "execute", pkgConfig.getName());
 
         //action on namespace2 (action level)
         pkgConfig = configuration.getPackageConfig("org.apache.struts2.convention.actions.namespace3#struts-default#/namespaces2");
         assertNotNull(pkgConfig);
+        checkSmiValue(pkgConfig, strutsDefault, isSmiInheritanceEnabled);
         assertEquals(1, pkgConfig.getActionConfigs().size());
         verifyActionConfig(pkgConfig, "action-level-namespaces", ActionLevelNamespacesAction.class, "execute", pkgConfig.getName());
 
@@ -405,12 +433,14 @@ public class PackageBasedActionConfigBuilderTest extends TestCase {
         //action on namespace3 (action level)
         pkgConfig = configuration.getPackageConfig("org.apache.struts2.convention.actions.namespace4#struts-default#/namespaces3");
         assertNotNull(pkgConfig);
+        checkSmiValue(pkgConfig, strutsDefault, isSmiInheritanceEnabled);
         assertEquals(1, pkgConfig.getActionConfigs().size());
         verifyActionConfig(pkgConfig, "action-and-package-level-namespaces", ActionAndPackageLevelNamespacesAction.class, "execute", pkgConfig.getName());
 
         //action on namespace4 (package level)
         pkgConfig = configuration.getPackageConfig("org.apache.struts2.convention.actions.namespace4#struts-default#/namespaces4");
         assertNotNull(pkgConfig);
+        checkSmiValue(pkgConfig, strutsDefault, isSmiInheritanceEnabled);
         assertEquals(1, pkgConfig.getActionConfigs().size());
         verifyActionConfig(pkgConfig, "action-and-package-level-namespaces", ActionAndPackageLevelNamespacesAction.class, "execute", pkgConfig.getName());
 
@@ -419,6 +449,7 @@ public class PackageBasedActionConfigBuilderTest extends TestCase {
         /* org.apache.struts2.convention.actions.params */
         pkgConfig = configuration.getPackageConfig("org.apache.struts2.convention.actions.params#struts-default#/params");
         assertNotNull(pkgConfig);
+        checkSmiValue(pkgConfig, strutsDefault, isSmiInheritanceEnabled);
         assertEquals(1, pkgConfig.getActionConfigs().size());
         ActionConfig ac = pkgConfig.getAllActionConfigs().get("actionParam1");
         assertNotNull(ac);
@@ -431,6 +462,7 @@ public class PackageBasedActionConfigBuilderTest extends TestCase {
         /* org.apache.struts2.convention.actions.params */
         pkgConfig = configuration.getPackageConfig("org.apache.struts2.convention.actions.exception#struts-default#/exception");
         assertNotNull(pkgConfig);
+        checkSmiValue(pkgConfig, strutsDefault, isSmiInheritanceEnabled);
         assertEquals(2, pkgConfig.getActionConfigs().size());
 
         ac = pkgConfig.getAllActionConfigs().get("exception1");
@@ -468,6 +500,7 @@ public class PackageBasedActionConfigBuilderTest extends TestCase {
         /* org.apache.struts2.convention.actions.idx */
         pkgConfig = configuration.getPackageConfig("org.apache.struts2.convention.actions.idx#struts-default#/idx");
         assertNotNull(pkgConfig);
+        checkSmiValue(pkgConfig, strutsDefault, isSmiInheritanceEnabled);
         assertEquals(3, pkgConfig.getActionConfigs().size());
         verifyActionConfig(pkgConfig, "", org.apache.struts2.convention.actions.idx.Index.class, "execute", pkgConfig.getName());
         verifyActionConfig(pkgConfig, "index", org.apache.struts2.convention.actions.idx.Index.class, "execute", pkgConfig.getName());
@@ -477,11 +510,13 @@ public class PackageBasedActionConfigBuilderTest extends TestCase {
         /* org.apache.struts2.convention.actions.defaultinterceptor */
         pkgConfig = configuration.getPackageConfig("org.apache.struts2.convention.actions.defaultinterceptor#struts-default#/defaultinterceptor");
         assertNotNull(pkgConfig);
+        checkSmiValue(pkgConfig, strutsDefault, isSmiInheritanceEnabled);
         assertEquals("validationWorkflowStack", pkgConfig.getDefaultInterceptorRef());
 
         /* org.apache.struts2.convention.actions.idx.idx2 */
         pkgConfig = configuration.getPackageConfig("org.apache.struts2.convention.actions.idx.idx2#struts-default#/idx/idx2");
         assertNotNull(pkgConfig);
+        checkSmiValue(pkgConfig, strutsDefault, isSmiInheritanceEnabled);
         assertEquals(2, pkgConfig.getActionConfigs().size());
         verifyActionConfig(pkgConfig, "", org.apache.struts2.convention.actions.idx.idx2.Index.class, "execute", pkgConfig.getName());
         verifyActionConfig(pkgConfig, "index", org.apache.struts2.convention.actions.idx.idx2.Index.class, "execute", pkgConfig.getName());
@@ -489,24 +524,28 @@ public class PackageBasedActionConfigBuilderTest extends TestCase {
         /* org.apache.struts2.convention.actions.namespace action level */
         pkgConfig = configuration.getPackageConfig("org.apache.struts2.convention.actions.namespace#struts-default#/action-level");
         assertNotNull(pkgConfig);
+        checkSmiValue(pkgConfig, strutsDefault, isSmiInheritanceEnabled);
         assertEquals(1, pkgConfig.getActionConfigs().size());
         verifyActionConfig(pkgConfig, "action", ActionLevelNamespaceAction.class, "execute", pkgConfig.getName());
 
         /* org.apache.struts2.convention.actions.namespace class level */
         pkgConfig = configuration.getPackageConfig("org.apache.struts2.convention.actions.namespace#struts-default#/class-level");
         assertNotNull(pkgConfig);
+        checkSmiValue(pkgConfig, strutsDefault, isSmiInheritanceEnabled);
         assertEquals(1, pkgConfig.getActionConfigs().size());
         verifyActionConfig(pkgConfig, "class-level-namespace", ClassLevelNamespaceAction.class, "execute", pkgConfig.getName());
 
         /* org.apache.struts2.convention.actions.namespace package level */
         pkgConfig = configuration.getPackageConfig("org.apache.struts2.convention.actions.namespace#struts-default#/package-level");
         assertNotNull(pkgConfig);
+        checkSmiValue(pkgConfig, strutsDefault, isSmiInheritanceEnabled);
         assertEquals(1, pkgConfig.getActionConfigs().size());
         verifyActionConfig(pkgConfig, "package-level-namespace", PackageLevelNamespaceAction.class, "execute", pkgConfig.getName());
 
         /* org.apache.struts2.convention.actions.namespace2 */
         pkgConfig = configuration.getPackageConfig("org.apache.struts2.convention.actions.namespace2#struts-default#/namespace2");
         assertNotNull(pkgConfig);
+        checkSmiValue(pkgConfig, strutsDefault, isSmiInheritanceEnabled);
         assertEquals(1, pkgConfig.getActionConfigs().size());
         verifyActionConfig(pkgConfig, "default-namespace", DefaultNamespaceAction.class, "execute", pkgConfig.getName());
 
@@ -539,37 +578,52 @@ public class PackageBasedActionConfigBuilderTest extends TestCase {
         /* org.apache.struts2.convention.actions.allowedmethods class level */
         pkgConfig = configuration.getPackageConfig("org.apache.struts2.convention.actions.allowedmethods#struts-default#/allowedmethods");
         assertNotNull(pkgConfig);
+        checkSmiValue(pkgConfig, strutsDefault, isSmiInheritanceEnabled);
         assertEquals(2, pkgConfig.getActionConfigs().size());
         verifyActionConfig(pkgConfig, "class-level-allowed-methods", ClassLevelAllowedMethodsAction.class, "execute", pkgConfig.getName());
         assertEquals("struts-default", pkgConfig.getParents().get(0).getName());
 
         ActionConfig actionConfig = pkgConfig.getActionConfigs().get("class-level-allowed-methods");
-        assertEquals(7, actionConfig.getAllowedMethods().size());
         assertTrue(actionConfig.getAllowedMethods().contains("execute"));
-        assertTrue(actionConfig.getAllowedMethods().contains("end"));
-        assertTrue(actionConfig.getAllowedMethods().contains("input"));
-        assertTrue(actionConfig.getAllowedMethods().contains("cancel"));
-        assertTrue(actionConfig.getAllowedMethods().contains("start"));
-        assertTrue(actionConfig.getAllowedMethods().contains("home"));
-        assertTrue(actionConfig.getAllowedMethods().contains("browse"));
+        int allowedMethodsSize = actionConfig.getAllowedMethods().size();
+        if (!pkgConfig.isStrictMethodInvocation()) {
+            // With strict method invocation disabled the allowed methods are "execute" and the wildcard "*"
+            assertEquals(2, allowedMethodsSize);
+        } else {
+            assertEquals(7, allowedMethodsSize);
+            assertTrue(actionConfig.getAllowedMethods().contains("end"));
+            assertTrue(actionConfig.getAllowedMethods().contains("input"));
+            assertTrue(actionConfig.getAllowedMethods().contains("cancel"));
+            assertTrue(actionConfig.getAllowedMethods().contains("start"));
+            assertTrue(actionConfig.getAllowedMethods().contains("home"));
+            assertTrue(actionConfig.getAllowedMethods().contains("browse"));
+        }
 
         /* org.apache.struts2.convention.actions.allowedmethods.sub package level */
         pkgConfig = configuration.getPackageConfig("org.apache.struts2.convention.actions.allowedmethods.sub#struts-default#/allowedmethods/sub");
         assertNotNull(pkgConfig);
+        checkSmiValue(pkgConfig, strutsDefault, isSmiInheritanceEnabled);
         assertEquals(1, pkgConfig.getActionConfigs().size());
         verifyActionConfig(pkgConfig, "package-level-allowed-methods-child", PackageLevelAllowedMethodsChildAction.class, "execute", pkgConfig.getName());
         assertEquals("struts-default", pkgConfig.getParents().get(0).getName());
 
         actionConfig = pkgConfig.getActionConfigs().get("package-level-allowed-methods-child");
-        assertEquals(actionConfig.getAllowedMethods().size(), 6);
         assertTrue(actionConfig.getAllowedMethods().contains("execute"));
-        assertTrue(actionConfig.getAllowedMethods().contains("home"));
-        assertTrue(actionConfig.getAllowedMethods().contains("start"));
-        assertTrue(actionConfig.getAllowedMethods().contains("input"));
+        allowedMethodsSize = actionConfig.getAllowedMethods().size();
+        if (!pkgConfig.isStrictMethodInvocation()) {
+            // With strict method invocation disabled the allowed methods are execute and the wildcard *
+            assertEquals(2, allowedMethodsSize);
+        } else {
+            assertEquals(6, allowedMethodsSize);
+            assertTrue(actionConfig.getAllowedMethods().contains("home"));
+            assertTrue(actionConfig.getAllowedMethods().contains("start"));
+            assertTrue(actionConfig.getAllowedMethods().contains("input"));
+        }
 
         /* org.apache.struts2.convention.actions.result */
         pkgConfig = configuration.getPackageConfig("org.apache.struts2.convention.actions.result#struts-default#/result");
         assertNotNull(pkgConfig);
+        checkSmiValue(pkgConfig, strutsDefault, isSmiInheritanceEnabled);
         assertEquals(7, pkgConfig.getActionConfigs().size());
         verifyActionConfig(pkgConfig, "class-level-result", ClassLevelResultAction.class, "execute", pkgConfig.getName());
         verifyActionConfig(pkgConfig, "class-level-results", ClassLevelResultsAction.class, "execute", pkgConfig.getName());
@@ -580,6 +634,7 @@ public class PackageBasedActionConfigBuilderTest extends TestCase {
         /* org.apache.struts2.convention.actions.resultpath */
         pkgConfig = configuration.getPackageConfig("org.apache.struts2.convention.actions.resultpath#struts-default#/resultpath");
         assertNotNull(pkgConfig);
+        checkSmiValue(pkgConfig, strutsDefault, isSmiInheritanceEnabled);
         assertEquals(2, pkgConfig.getActionConfigs().size());
         verifyActionConfig(pkgConfig, "class-level-result-path", ClassLevelResultPathAction.class, "execute", pkgConfig.getName());
         verifyActionConfig(pkgConfig, "package-level-result-path", PackageLevelResultPathAction.class, "execute", pkgConfig.getName());
@@ -587,6 +642,7 @@ public class PackageBasedActionConfigBuilderTest extends TestCase {
         /* org.apache.struts2.convention.actions.interceptorRefs */
         pkgConfig = configuration.getPackageConfig("org.apache.struts2.convention.actions.interceptor#struts-default#/interceptor");
         assertNotNull(pkgConfig);
+        checkSmiValue(pkgConfig, strutsDefault, isSmiInheritanceEnabled);
         assertEquals(9, pkgConfig.getActionConfigs().size());
         verifyActionConfigInterceptors(pkgConfig, "action100", "interceptor-1");
         verifyActionConfigInterceptors(pkgConfig, "action200", "interceptor-1", "interceptor-2");
@@ -605,6 +661,7 @@ public class PackageBasedActionConfigBuilderTest extends TestCase {
         /* org.apache.struts2.convention.actions */
         pkgConfig = configuration.getPackageConfig("org.apache.struts2.convention.actions#struts-default#");
         assertNotNull(pkgConfig);
+        checkSmiValue(pkgConfig, strutsDefault, isSmiInheritanceEnabled);
 
         assertEquals(4, pkgConfig.getActionConfigs().size());
         verifyActionConfig(pkgConfig, "no-annotation", NoAnnotationAction.class, "execute", pkgConfig.getName());
@@ -615,6 +672,7 @@ public class PackageBasedActionConfigBuilderTest extends TestCase {
 
         /* org.apache.struts2.convention.actions.transactions */
         pkgConfig = configuration.getPackageConfig("org.apache.struts2.convention.actions.transactions#struts-default#/transactions");
+        checkSmiValue(pkgConfig, strutsDefault, isSmiInheritanceEnabled);
         verifyActionConfig(pkgConfig, "trans1", TransNameAction.class, "trans1", pkgConfig.getName());
         verifyActionConfig(pkgConfig, "trans2", TransNameAction.class, "trans2", pkgConfig.getName());
 
@@ -628,6 +686,7 @@ public class PackageBasedActionConfigBuilderTest extends TestCase {
 
         //test unknown handler automatic chaining
         pkgConfig = configuration.getPackageConfig("org.apache.struts2.convention.actions.chain#struts-default#/chain");
+        checkSmiValue(pkgConfig, strutsDefault, isSmiInheritanceEnabled);
         ServletContext context = EasyMock.createNiceMock(ServletContext.class);
         EasyMock.replay(context);
 
@@ -672,6 +731,14 @@ public class PackageBasedActionConfigBuilderTest extends TestCase {
         assertEquals(packageName, ac.getPackageName());
     }
 
+    private void checkSmiValue(PackageConfig pkgConfig, PackageConfig parentConfig,  boolean isSmiInheritanceEnabled) {
+        if (isSmiInheritanceEnabled) {
+            assertEquals(parentConfig.isStrictMethodInvocation(), pkgConfig.isStrictMethodInvocation());
+        } else if (!isSmiInheritanceEnabled && !parentConfig.isStrictMethodInvocation()){
+            assertTrue(pkgConfig.isStrictMethodInvocation());
+        }
+    }
+
     private void verifyActionConfigInterceptors(PackageConfig pkgConfig, String actionName, String... refs) {
         ActionConfig ac = pkgConfig.getAllActionConfigs().get(actionName);
         assertNotNull(ac);
@@ -684,12 +751,12 @@ public class PackageBasedActionConfigBuilderTest extends TestCase {
 
     private PackageConfig makePackageConfig(String name, String namespace, PackageConfig parent,
             String defaultResultType, ResultTypeConfig... results) {
-        return makePackageConfig(name, namespace, parent, defaultResultType, results, null, null, null);
+        return makePackageConfig(name, namespace, parent, defaultResultType, results, null, null, null, true);
     }
 
     private PackageConfig makePackageConfig(String name, String namespace, PackageConfig parent,
             String defaultResultType, ResultTypeConfig[] results, List<InterceptorConfig> interceptors,
-            List<InterceptorStackConfig> interceptorStacks, Set<String> globalAllowedMethods) {
+            List<InterceptorStackConfig> interceptorStacks, Set<String> globalAllowedMethods, boolean strictMethodInvocation) {
         PackageConfig.Builder builder = new PackageConfig.Builder(name);
         if (namespace != null) {
             builder.namespace(namespace);
@@ -718,6 +785,10 @@ public class PackageBasedActionConfigBuilderTest extends TestCase {
 
         if (globalAllowedMethods != null) {
             builder.addGlobalAllowedMethods(globalAllowedMethods);
+        }
+
+        if (!strictMethodInvocation) {
+            builder.strictMethodInvocation(strictMethodInvocation);
         }
 
         return new MyPackageConfig(builder.build());


### PR DESCRIPTION
Adds the `struts.convention.enable.smi.inheritance` constant which determines if a newly created package config inherits the strict-method-invocation value of its parent package config.