### PR TITLE
Remove dependencies cglib and cglib-nodep

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -289,12 +289,6 @@
         </dependency>
 
         <dependency>
-            <groupId>cglib</groupId>
-            <artifactId>cglib-nodep</artifactId>
-            <optional>true</optional>
-        </dependency>
-
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <optional>true</optional>

--- a/plugins/portlet/pom.xml
+++ b/plugins/portlet/pom.xml
@@ -137,11 +137,6 @@
             <artifactId>commons-fileupload</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>cglib</groupId>
-            <artifactId>cglib</artifactId>
-            <scope>test</scope>
-        </dependency>
 
         <!-- The Servlet API mocks in Spring Framework 4.x only supports Servlet 3.0 and higher.
            This is only necessary in tests-->

--- a/pom.xml
+++ b/pom.xml
@@ -704,12 +704,6 @@
                 <artifactId>junit</artifactId>
                 <version>4.12</version>
             </dependency>
-            <dependency>
-                <groupId>cglib</groupId>
-                <artifactId>cglib-nodep</artifactId>
-                <version>2.1_3</version>
-                <!-- Recommended version for jmock-cglib 1.2.0 -->
-            </dependency>
 
             <dependency>
                 <groupId>org.easymock</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1054,13 +1054,6 @@
             </dependency>
 
             <dependency>
-                <groupId>cglib</groupId>
-                <artifactId>cglib</artifactId>
-                <version>2.2.2</version>
-                <!-- Note: cglib-nodep (for JMock 1.2.0) is at 2.1_3 -->
-            </dependency>
-
-            <dependency>
                 <groupId>net.sf.json-lib</groupId>
                 <artifactId>json-lib</artifactId>
                 <classifier>jdk15</classifier>


### PR DESCRIPTION
* jmock-cglib brings cglib-nodep as a transitive dependency -- no need for explicit declaration
* cglib isn't needed at all -- plugins/portlet build runs perfectly fine without it (`mvn install`)

