### PR TITLE
Back-port enhancement/fix to 2.5.19 unit tests (permits build on Windows)

### DIFF
--- a/core/src/test/java/com/opensymphony/xwork2/config/providers/EnvsValueSubstitutorTest.java
+++ b/core/src/test/java/com/opensymphony/xwork2/config/providers/EnvsValueSubstitutorTest.java
@@ -20,16 +20,55 @@ package com.opensymphony.xwork2.config.providers;
 
 import org.apache.struts2.StrutsInternalTestCase;
 
-
 public class EnvsValueSubstitutorTest extends StrutsInternalTestCase {
 
+    private boolean osIsWindows = false;  // Assume Linux/Unix environment by default
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+
+        final String os = System.getProperty("os.name");
+        if (os != null && os.startsWith("Windows")) {
+            osIsWindows = true;   // Determined that the OS is Windows (must use different environment variables)
+        }
+        else {
+            osIsWindows = false;  // Assume Linux/Unix environment by default
+        }
+    }
+
     public void testSimpleValue() throws Exception {
+
+        String expected;
+        String actual;
+        final ValueSubstitutor substitutor = new EnvsValueSubstitutor();
+
+        if (osIsWindows) {
+            // given
+            expected = System.getenv("USERNAME");
+
+            // when
+            actual = substitutor.substitute("${env.USERNAME}");
+        }
+        else {
+            // given
+            expected = System.getenv("USER");
+
+            // when
+            actual = substitutor.substitute("${env.USER}");
+        }
+
+        // then
+        assertEquals(expected, actual);
+    }
+
+    public void testDefaultValue() throws Exception {
         // given
-        String expected = System.getenv("USER");
+        String expected = "defaultValue";
         ValueSubstitutor substitutor = new EnvsValueSubstitutor();
 
         // when
-        String actual = substitutor.substitute("${env.USER}");
+        String actual = substitutor.substitute("${env.UNKNOWN:" + expected + "}");
 
         // then
         assertEquals(expected, actual);

--- a/core/src/test/java/com/opensymphony/xwork2/config/providers/XmlConfigurationProviderEnvsSubstitutionTest.java
+++ b/core/src/test/java/com/opensymphony/xwork2/config/providers/XmlConfigurationProviderEnvsSubstitutionTest.java
@@ -24,6 +24,21 @@ import org.apache.struts2.StrutsConstants;
 
 public class XmlConfigurationProviderEnvsSubstitutionTest extends ConfigurationTestBase {
 
+    private boolean osIsWindows = false;  // Assume Linux/Unix environment by default
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+
+        final String os = System.getProperty("os.name");
+        if (os != null && os.startsWith("Windows")) {
+            osIsWindows = true;   // Determined that the OS is Windows (must use different environment variables)
+        }
+        else {
+            osIsWindows = false;  // Assume Linux/Unix environment by default
+        }
+    }
+
     public void testSubstitution() throws ConfigurationException {
         final String filename = "com/opensymphony/xwork2/config/providers/xwork-test-envs-substitution.xml";
         ConfigurationProvider provider = buildConfigurationProvider(filename);
@@ -36,11 +51,25 @@ public class XmlConfigurationProviderEnvsSubstitutionTest extends ConfigurationT
         String foo = container.getInstance(String.class, "foo");
         assertEquals("bar", foo);
 
-        String user = container.getInstance(String.class, "user");
-        assertEquals(System.getenv("USER"), user);
+        String user;
+        if (osIsWindows) {
+            user = container.getInstance(String.class, "username");
+            assertEquals(System.getenv("USERNAME"), user);
+        }
+        else {
+            user = container.getInstance(String.class, "user");
+            assertEquals(System.getenv("USER"), user);
+        }
 
-        String home = container.getInstance(String.class, "home");
-        assertEquals("Current HOME = " + System.getenv("HOME"), home);
+        String home;
+        if (osIsWindows) {
+            home = container.getInstance(String.class, "homedrive.homepath");
+            assertEquals("Current HOMEDRIVE.HOMEPATH = " + System.getenv("HOMEDRIVE") + System.getenv("HOMEPATH"), home);
+        }
+        else {
+            home = container.getInstance(String.class, "home");
+            assertEquals("Current HOME = " + System.getenv("HOME"), home);
+        }
 
         String os = container.getInstance(String.class, "os");
         assertEquals("Current OS = " + System.getProperty("os.name"), os);

--- a/core/src/test/resources/com/opensymphony/xwork2/config/providers/xwork-test-envs-substitution.xml
+++ b/core/src/test/resources/com/opensymphony/xwork2/config/providers/xwork-test-envs-substitution.xml
@@ -28,8 +28,16 @@
 
     <constant name="foo" value="bar"/>
 
+    <!-- Linux/Unix (or Unix-like) Environment -->
     <constant name="user" value="${env.USER}"/>
     <constant name="home" value="Current HOME = ${env.HOME}"/>
+    <!-- Linux/Unix (or Unix-like) Environment -->
+
+    <!-- Windows (or Windows-like) Environment -->
+    <constant name="username" value="${env.USERNAME}"/>
+    <constant name="homedrive.homepath" value="Current HOMEDRIVE.HOMEPATH = ${env.HOMEDRIVE}${env.HOMEPATH}"/>
+    <!-- Windows (or Windows-like) Environment -->
+
     <constant name="os" value="Current OS = ${os.name}"/>
     <constant name="unknown" value="Unknown = ${env.UNKNOWN:default}"/>
 


### PR DESCRIPTION
Back-port enhancement/fix from 2.6 to 2.5.x to allow Struts 2.5.x build to complete on Windows.  Without the changes the build fails on Windows due to differences in Linux/Unix vs. Windows environments.

- Involves changes to: EnvsValueSubstitutorTest, XmlConfigurationProviderEnvsSubstitutionTest, xwork-test-envs-substitution.xml.
- Note: 2.5.x EnvValueSubstitutor doesn't support system properties (only env properties) so some tests were not back-ported.
