### PR TITLE
Enhance after_success for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,10 @@ script: mvn test -DskipAssembly
 
 after_success:
   # TODO delete following if statement after fix of https://github.com/cobertura/cobertura/issues/271
-  - if [ "$TRAVIS_JDK_VERSION" == "openjdk8" ] || [ "$TRAVIS_JDK_VERSION" == "oraclejdk8" ];
-      then mvn clean cobertura:cobertura org.eluder.coveralls:coveralls-maven-plugin:report com.updateimpact:updateimpact-maven-plugin:submit -Ptravis-coveralls,update-impact -DskipAssembly;
-      else echo "Not reporting coverage for $TRAVIS_JDK_VERSION due to incomatibility or to save performance";
+  - if [ "$TRAVIS_JDK_VERSION" == "openjdk8" ] || [ "$TRAVIS_JDK_VERSION" == "oraclejdk8" ]; then
+      mvn cobertura:cobertura org.eluder.coveralls:coveralls-maven-plugin:report com.updateimpact:updateimpact-maven-plugin:submit -Ptravis-coveralls,update-impact -DskipAssembly;
+    else
+      echo "Not reporting coverage for $TRAVIS_JDK_VERSION due to incompatibility or to save performance";
     fi;
 
 env:


### PR DESCRIPTION
Use default bash if-then-else block with semicolon after each command and fix spelling for "incompatibility".

Don't do `mvn clean` b/c we need the test results for the following tasks and don't need to rebuild everything.