### PR TITLE
Upgrade DWR from 1.x to 2.x

### DIFF
--- a/apps/showcase/pom.xml
+++ b/apps/showcase/pom.xml
@@ -133,7 +133,7 @@
             <artifactId>sitemesh</artifactId>
         </dependency>
         <dependency>
-            <groupId>uk.ltd.getahead</groupId>
+            <groupId>org.directwebremoting</groupId>
             <artifactId>dwr</artifactId>
         </dependency>
         <dependency>

--- a/plugins/dwr/pom.xml
+++ b/plugins/dwr/pom.xml
@@ -33,7 +33,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>uk.ltd.getahead</groupId>
+            <groupId>org.directwebremoting</groupId>
             <artifactId>dwr</artifactId>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -648,9 +648,9 @@
             </dependency>
 
             <dependency>
-                <groupId>uk.ltd.getahead</groupId>
+                <groupId>org.directwebremoting</groupId>
                 <artifactId>dwr</artifactId>
-                <version>1.1.1</version>
+                <version>2.0.11-RELEASE</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Upgrade `DWR` from 1.x to 2.x
- intended to resolve Jenkins build failure with old DWR version.

`pom.xml` changes:
- entry change in `struts2-parent pom.xml`
  - upgrade 1.1.1 (uk.ltd.getahead) -> 2.0.11-RELEASE (org.directwebremoting)
- entry change in `struts2-dwr-plugin pom.xml`
- entry change in `struts2-showcase pom.xml`