### PR TITLE
Updates and cleanup for some configuration-related items (2.5.x).

### DIFF
--- a/core/src/main/java/com/opensymphony/xwork2/config/providers/XWorkConfigurationProvider.java
+++ b/core/src/main/java/com/opensymphony/xwork2/config/providers/XWorkConfigurationProvider.java
@@ -226,6 +226,7 @@ public class XWorkConfigurationProvider implements ConfigurationProvider {
         props.setProperty(XWorkConstants.ENABLE_OGNL_EXPRESSION_CACHE, Boolean.TRUE.toString());
         props.setProperty(XWorkConstants.ENABLE_OGNL_EVAL_EXPRESSION, Boolean.FALSE.toString());
         props.setProperty(XWorkConstants.RELOAD_XML_CONFIGURATION, Boolean.FALSE.toString());
+        props.setProperty(StrutsConstants.STRUTS_ALLOW_STATIC_METHOD_ACCESS, Boolean.FALSE.toString());
     }
 
 }

--- a/core/src/main/java/com/opensymphony/xwork2/ognl/ErrorMessageBuilder.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/ErrorMessageBuilder.java
@@ -23,7 +23,7 @@ package com.opensymphony.xwork2.ognl;
  */
 public class ErrorMessageBuilder {
 
-    private StringBuilder message = new StringBuilder();
+    private final StringBuilder message = new StringBuilder();
 
     public static ErrorMessageBuilder create() {
         return new ErrorMessageBuilder();

--- a/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlNullHandlerWrapper.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlNullHandlerWrapper.java
@@ -24,7 +24,7 @@ import java.util.Map;
 
 public class OgnlNullHandlerWrapper implements ognl.NullHandler {
 
-    private NullHandler wrapped;
+    private final NullHandler wrapped;
     
     public OgnlNullHandlerWrapper(NullHandler target) {
         this.wrapped = target;

--- a/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlTypeConverterWrapper.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlTypeConverterWrapper.java
@@ -28,7 +28,7 @@ import java.util.Map;
  */
 public class OgnlTypeConverterWrapper implements ognl.TypeConverter {
 
-    private TypeConverter typeConverter;
+    private final TypeConverter typeConverter;
 
     public OgnlTypeConverterWrapper(TypeConverter converter) {
         if (converter == null) {

--- a/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlUtil.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlUtil.java
@@ -58,21 +58,17 @@ public class OgnlUtil {
     private final ConcurrentMap<Class, BeanInfo> beanInfoCache = new ConcurrentHashMap<>();
     private TypeConverter defaultConverter;
 
-    private boolean devMode;                       // Defaults to false
-    private boolean devModeValueSet;               // Defaults to false (not explicitly set yet)
+    private boolean devMode;
     private boolean enableExpressionCache = true;
-    private boolean enableEvalExpression;          // Defaults to false
-    private boolean enableEvalExpressionValueSet;  // Defaults to false (not explicitly set yet)
+    private boolean enableEvalExpression;
 
     private Set<Class<?>> excludedClasses;
     private Set<Pattern> excludedPackageNamePatterns;
     private Set<String> excludedPackageNames;
 
     private Container container;
-    private boolean allowStaticMethodAccess;            // Defaults to false
-    private boolean allowStaticMethodAccessValueSet;    // Defaults to false (not explicitly set yet)
-    private boolean disallowProxyMemberAccess;          // Defaults to false
-    private boolean disallowProxyMemberAccessValueSet;  // Defaults to false (not explicitly set yet)
+    private boolean allowStaticMethodAccess;
+    private boolean disallowProxyMemberAccess;
 
     public OgnlUtil() {
         excludedClasses = new HashSet<>();
@@ -81,49 +77,35 @@ public class OgnlUtil {
     }
 
     @Inject
-    public void setXWorkConverter(XWorkConverter conv) {
+    protected void setXWorkConverter(XWorkConverter conv) {
         this.defaultConverter = new OgnlTypeConverterWrapper(conv);
     }
 
     @Inject(XWorkConstants.DEV_MODE)
-    public void setDevMode(String mode) {
-        final boolean booleanMode = BooleanUtils.toBoolean(mode);
-        if (!this.devModeValueSet) {
-            this.devMode = booleanMode;
-            this.devModeValueSet = true;  // Permit setting devMode only once
-            if (this.devMode) {
-                LOG.warn("Setting development mode [{}] affects the safety of your application!",
-                            this.devMode);
-            }
-        }
-        else {
-            LOG.debug("Error setting development mode value [{}], already previously set to [{}]", mode, this.devMode);
+    protected void setDevMode(String mode) {
+        this.devMode = BooleanUtils.toBoolean(mode);
+        if (this.devMode) {
+            LOG.warn("Setting development mode [{}] affects the safety of your application!",
+                        this.devMode);
         }
     }
 
     @Inject(XWorkConstants.ENABLE_OGNL_EXPRESSION_CACHE)
-    public void setEnableExpressionCache(String cache) {
+    protected void setEnableExpressionCache(String cache) {
         enableExpressionCache = BooleanUtils.toBoolean(cache);
     }
 
     @Inject(value = XWorkConstants.ENABLE_OGNL_EVAL_EXPRESSION, required = false)
-    public void setEnableEvalExpression(String evalExpression) {
-        if (!this.enableEvalExpressionValueSet) {
-            this.enableEvalExpression = "true".equals(evalExpression);
-            this.enableEvalExpressionValueSet = true;  // Permit setting enableEvalExpression only once
-            if (this.enableEvalExpression) {
-                LOG.warn("Enabling OGNL expression evaluation may introduce security risks " +
-                        "(see http://struts.apache.org/release/2.3.x/docs/s2-013.html for further details)");
-            }
-        }
-        else {
-            LOG.debug("Error setting enable OGNL expression evaluation value [{}], already previously set to [{}]",
-                    evalExpression, this.enableEvalExpression);
+    protected void setEnableEvalExpression(String evalExpression) {
+        this.enableEvalExpression = BooleanUtils.toBoolean(evalExpression);
+        if (this.enableEvalExpression) {
+            LOG.warn("Enabling OGNL expression evaluation may introduce security risks " +
+                    "(see http://struts.apache.org/release/2.3.x/docs/s2-013.html for further details)");
         }
     }
 
     @Inject(value = XWorkConstants.OGNL_EXCLUDED_CLASSES, required = false)
-    public void setExcludedClasses(String commaDelimitedClasses) {
+    protected void setExcludedClasses(String commaDelimitedClasses) {
         Set<Class<?>> excludedClasses = new HashSet<>();
         excludedClasses.addAll(this.excludedClasses);
         excludedClasses.addAll(parseExcludedClasses(commaDelimitedClasses));
@@ -146,7 +128,7 @@ public class OgnlUtil {
     }
 
     @Inject(value = XWorkConstants.OGNL_EXCLUDED_PACKAGE_NAME_PATTERNS, required = false)
-    public void setExcludedPackageNamePatterns(String commaDelimitedPackagePatterns) {
+    protected void setExcludedPackageNamePatterns(String commaDelimitedPackagePatterns) {
         Set<Pattern> excludedPackageNamePatterns = new HashSet<>();
         excludedPackageNamePatterns.addAll(this.excludedPackageNamePatterns);
         excludedPackageNamePatterns.addAll(parseExcludedPackageNamePatterns(commaDelimitedPackagePatterns));
@@ -165,7 +147,7 @@ public class OgnlUtil {
     }
 
     @Inject(value = XWorkConstants.OGNL_EXCLUDED_PACKAGE_NAMES, required = false)
-    public void setExcludedPackageNames(String commaDelimitedPackageNames) {
+    protected void setExcludedPackageNames(String commaDelimitedPackageNames) {
         Set<String> excludedPackageNames = new HashSet<>();
         excludedPackageNames.addAll(this.excludedPackageNames);
         excludedPackageNames.addAll(parseExcludedPackageNames(commaDelimitedPackageNames));
@@ -189,41 +171,26 @@ public class OgnlUtil {
     }
 
     @Inject
-    public void setContainer(Container container) {
+    protected void setContainer(Container container) {
         this.container = container;
     }
 
     @Inject(value = XWorkConstants.ALLOW_STATIC_METHOD_ACCESS, required = false)
-    public void setAllowStaticMethodAccess(String allowStaticMethodAccess) {
-        final boolean booleanAllowStaticMethodAccess = BooleanUtils.toBoolean(allowStaticMethodAccess);
-        if (!this.allowStaticMethodAccessValueSet) {
-            this.allowStaticMethodAccess = booleanAllowStaticMethodAccess;
-            this.allowStaticMethodAccessValueSet = true;  // Permit setting allowStaticMethodAccess only once
-            if (this.allowStaticMethodAccess) {
-                LOG.warn("Setting allow static method access [{}] affects the safety of your application!",
-                            this.allowStaticMethodAccess);
-            }
-        }
-        else {
-            LOG.debug("Error setting allow static method access value [{}], already previously set to [{}]",
-                        allowStaticMethodAccess, this.allowStaticMethodAccess);
+    protected void setAllowStaticMethodAccess(String allowStaticMethodAccess) {
+        this.allowStaticMethodAccess = BooleanUtils.toBoolean(allowStaticMethodAccess);
+        if (this.allowStaticMethodAccess) {
+            LOG.warn("Setting allow static method access [{}] affects the safety of your application!",
+                        this.allowStaticMethodAccess);
         }
     }
 
     @Inject(value = StrutsConstants.STRUTS_DISALLOW_PROXY_MEMBER_ACCESS, required = false)
-    public void setDisallowProxyMemberAccess(String disallowProxyMemberAccess) {
+    protected void setDisallowProxyMemberAccess(String disallowProxyMemberAccess) {
 
-        if (!this.disallowProxyMemberAccessValueSet) {
-            this.disallowProxyMemberAccess = Boolean.parseBoolean(disallowProxyMemberAccess);
-            this.disallowProxyMemberAccessValueSet = true;  // Permit setting disallowProxyMemberAccess only once
-            if (!this.disallowProxyMemberAccess) {
-                LOG.warn("Setting disallow proxy member access [{}] should only be done intentionally!",
-                            this.disallowProxyMemberAccess);
-            }
-        }
-        else {
-            LOG.debug("Error setting disallow proxy member access value [{}], already previously set to [{}]",
-                    disallowProxyMemberAccess, this.disallowProxyMemberAccess);
+        this.disallowProxyMemberAccess = Boolean.parseBoolean(disallowProxyMemberAccess);
+        if (this.disallowProxyMemberAccess == false) {
+            LOG.warn("Setting disallow proxy member access [{}] should only be done intentionally!",
+                        this.disallowProxyMemberAccess);
         }
     }
 

--- a/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlValueStack.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlValueStack.java
@@ -69,8 +69,9 @@ public class OgnlValueStack implements Serializable, ValueStack, ClearableValueS
     protected transient SecurityMemberAccess securityMemberAccess;
 
     private transient XWorkConverter converter;
-    private boolean devMode;
-    private boolean logMissingProperties;
+    private boolean devMode;               // Defaults to false
+    private boolean devModeValueSet;       // Defaults to false (not explicitly set yet)
+    private boolean logMissingProperties;  // Defaults to false
 
     protected OgnlValueStack(XWorkConverter xworkConverter, CompoundRootAccessor accessor, TextProvider prov, boolean allowStaticAccess) {
         setRoot(xworkConverter, accessor, new CompoundRoot(), allowStaticAccess);
@@ -103,7 +104,18 @@ public class OgnlValueStack implements Serializable, ValueStack, ClearableValueS
 
     @Inject(XWorkConstants.DEV_MODE)
     public void setDevMode(String mode) {
-        this.devMode = BooleanUtils.toBoolean(mode);
+        final boolean booleanMode = BooleanUtils.toBoolean(mode);
+        if (!this.devModeValueSet) {
+            this.devMode = booleanMode;
+            this.devModeValueSet = true;  // Permit setting devMode only once
+            if (this.devMode) {
+                LOG.warn("Setting development mode [{}] affects the safety of your application!",
+                            this.devMode);
+            }
+        }
+        else {
+            LOG.debug("Error setting development mode value [{}], already previously set to [{}]", mode, this.devMode);
+        }
     }
 
     @Inject(value = "logMissingProperties", required = false)

--- a/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlValueStack.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlValueStack.java
@@ -69,9 +69,8 @@ public class OgnlValueStack implements Serializable, ValueStack, ClearableValueS
     protected transient SecurityMemberAccess securityMemberAccess;
 
     private transient XWorkConverter converter;
-    private boolean devMode;               // Defaults to false
-    private boolean devModeValueSet;       // Defaults to false (not explicitly set yet)
-    private boolean logMissingProperties;  // Defaults to false
+    private boolean devMode;
+    private boolean logMissingProperties;
 
     protected OgnlValueStack(XWorkConverter xworkConverter, CompoundRootAccessor accessor, TextProvider prov, boolean allowStaticAccess) {
         setRoot(xworkConverter, accessor, new CompoundRoot(), allowStaticAccess);
@@ -83,7 +82,7 @@ public class OgnlValueStack implements Serializable, ValueStack, ClearableValueS
     }
 
     @Inject
-    public void setOgnlUtil(OgnlUtil ognlUtil) {
+    protected void setOgnlUtil(OgnlUtil ognlUtil) {
         this.ognlUtil = ognlUtil;
         securityMemberAccess.setExcludedClasses(ognlUtil.getExcludedClasses());
         securityMemberAccess.setExcludedPackageNamePatterns(ognlUtil.getExcludedPackageNamePatterns());
@@ -103,23 +102,16 @@ public class OgnlValueStack implements Serializable, ValueStack, ClearableValueS
     }
 
     @Inject(XWorkConstants.DEV_MODE)
-    public void setDevMode(String mode) {
-        final boolean booleanMode = BooleanUtils.toBoolean(mode);
-        if (!this.devModeValueSet) {
-            this.devMode = booleanMode;
-            this.devModeValueSet = true;  // Permit setting devMode only once
-            if (this.devMode) {
-                LOG.warn("Setting development mode [{}] affects the safety of your application!",
-                            this.devMode);
-            }
-        }
-        else {
-            LOG.debug("Error setting development mode value [{}], already previously set to [{}]", mode, this.devMode);
+    protected void setDevMode(String mode) {
+        this.devMode = BooleanUtils.toBoolean(mode);
+        if (this.devMode) {
+            LOG.warn("Setting development mode [{}] affects the safety of your application!",
+                        this.devMode);
         }
     }
 
     @Inject(value = "logMissingProperties", required = false)
-    public void setLogMissingProperties(String logMissingProperties) {
+    protected void setLogMissingProperties(String logMissingProperties) {
         this.logMissingProperties = BooleanUtils.toBoolean(logMissingProperties);
     }
 
@@ -391,7 +383,7 @@ public class OgnlValueStack implements Serializable, ValueStack, ClearableValueS
      * @param e    The thrown exception.
      */
     private void logLookupFailure(String expr, Exception e) {
-        if (devMode && LOG.isWarnEnabled()) {
+        if (devMode) {
             LOG.warn("Caught an exception while evaluating expression '{}' against value stack", expr, e);
             LOG.warn("NOTE: Previous warning message was issued due to devMode set to true.");
         } else {
@@ -487,7 +479,7 @@ public class OgnlValueStack implements Serializable, ValueStack, ClearableValueS
     }
 
     @Inject
-    public void setXWorkConverter(final XWorkConverter converter) {
+    protected void setXWorkConverter(final XWorkConverter converter) {
         this.converter = converter;
     }
 }

--- a/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlValueStackFactory.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlValueStackFactory.java
@@ -44,7 +44,7 @@ import java.util.Set;
  */
 public class OgnlValueStackFactory implements ValueStackFactory {
     
-	private static final Logger LOG = LogManager.getLogger(OgnlValueStackFactory.class);
+    private static final Logger LOG = LogManager.getLogger(OgnlValueStackFactory.class);
 
     protected XWorkConverter xworkConverter;
     protected CompoundRootAccessor compoundRootAccessor;

--- a/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlValueStackFactory.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlValueStackFactory.java
@@ -34,7 +34,6 @@ import ognl.PropertyAccessor;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.struts2.StrutsConstants;
 
 import java.util.Map;
 import java.util.Set;
@@ -50,33 +49,24 @@ public class OgnlValueStackFactory implements ValueStackFactory {
     protected CompoundRootAccessor compoundRootAccessor;
     protected TextProvider textProvider;
     protected Container container;
-    private boolean allowStaticMethodAccess;          // Defaults to false
-    private boolean allowStaticMethodAccessValueSet;  // Defaults to false (not explicitly set yet)
+    private boolean allowStaticMethodAccess;
 
     @Inject
-    public void setXWorkConverter(XWorkConverter converter) {
+    protected void setXWorkConverter(XWorkConverter converter) {
         this.xworkConverter = converter;
     }
     
     @Inject("system")
-    public void setTextProvider(TextProvider textProvider) {
+    protected void setTextProvider(TextProvider textProvider) {
         this.textProvider = textProvider;
     }
     
     @Inject(value="allowStaticMethodAccess", required=false)
-    public void setAllowStaticMethodAccess(String allowStaticMethodAccess) {
-        final boolean booleanAllowStaticMethodAccess = BooleanUtils.toBoolean(allowStaticMethodAccess);
-        if (!this.allowStaticMethodAccessValueSet) {
-            this.allowStaticMethodAccess = booleanAllowStaticMethodAccess;
-            this.allowStaticMethodAccessValueSet = true;  // Permit setting allowStaticMethodAccess only once
-            if (this.allowStaticMethodAccess) {
-                LOG.warn("Setting allow static method access [{}] affects the safety of your application!",
-                            this.allowStaticMethodAccess);
-            }
-        }
-        else {
-            LOG.debug("Error setting allow static method access value [{}], already previously set to [{}]",
-                        allowStaticMethodAccess, this.allowStaticMethodAccess);
+    protected void setAllowStaticMethodAccess(String allowStaticMethodAccess) {
+        this.allowStaticMethodAccess = BooleanUtils.toBoolean(allowStaticMethodAccess);
+        if (this.allowStaticMethodAccess) {
+            LOG.warn("Setting allow static method access [{}] affects the safety of your application!",
+                        this.allowStaticMethodAccess);
         }
     }
 
@@ -95,7 +85,7 @@ public class OgnlValueStackFactory implements ValueStackFactory {
     }
     
     @Inject
-    public void setContainer(Container container) throws ClassNotFoundException {
+    protected void setContainer(Container container) throws ClassNotFoundException {
         Set<String> names = container.getInstanceNames(PropertyAccessor.class);
         for (String name : names) {
             Class cls = Class.forName(name);

--- a/core/src/main/java/com/opensymphony/xwork2/ognl/XWorkTypeConverterWrapper.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/XWorkTypeConverterWrapper.java
@@ -28,7 +28,7 @@ import java.util.Map;
  */
 public class XWorkTypeConverterWrapper implements TypeConverter {
 
-    private ognl.TypeConverter typeConverter;
+    private final ognl.TypeConverter typeConverter;
     
     public XWorkTypeConverterWrapper(ognl.TypeConverter conv) {
         this.typeConverter = conv;

--- a/core/src/main/java/com/opensymphony/xwork2/ognl/accessor/CompoundRootAccessor.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/accessor/CompoundRootAccessor.java
@@ -63,22 +63,14 @@ public class CompoundRootAccessor implements PropertyAccessor, MethodAccessor, C
     private final static Logger LOG = LogManager.getLogger(CompoundRootAccessor.class);
     private final static Class[] EMPTY_CLASS_ARRAY = new Class[0];
     private static Map<MethodCall, Boolean> invalidMethods = new ConcurrentHashMap<>();
-    private boolean devMode;          // Defaults to false
-    private boolean devModeValueSet;  // Defaults to false (not explicitly set yet)
+    private boolean devMode;
 
     @Inject(XWorkConstants.DEV_MODE)
-    public void setDevMode(String mode) {
-        final boolean booleanMode = BooleanUtils.toBoolean(mode);
-        if (!this.devModeValueSet) {
-            this.devMode = booleanMode;
-            this.devModeValueSet = true;  // Permit setting devMode only once
-            if (this.devMode) {
-                LOG.warn("Setting development mode [{}] affects the safety of your application!",
-                            this.devMode);
-            }
-        }
-        else {
-            LOG.debug("Error setting development mode value [{}], already previously set to [{}]", mode, this.devMode);
+    protected void setDevMode(String mode) {
+        this.devMode = BooleanUtils.toBoolean(mode);
+        if (this.devMode) {
+            LOG.warn("Setting development mode [{}] affects the safety of your application!",
+                        this.devMode);
         }
     }
 

--- a/core/src/main/java/com/opensymphony/xwork2/ognl/accessor/CompoundRootAccessor.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/accessor/CompoundRootAccessor.java
@@ -63,11 +63,23 @@ public class CompoundRootAccessor implements PropertyAccessor, MethodAccessor, C
     private final static Logger LOG = LogManager.getLogger(CompoundRootAccessor.class);
     private final static Class[] EMPTY_CLASS_ARRAY = new Class[0];
     private static Map<MethodCall, Boolean> invalidMethods = new ConcurrentHashMap<>();
-    private boolean devMode = false;
+    private boolean devMode;          // Defaults to false
+    private boolean devModeValueSet;  // Defaults to false (not explicitly set yet)
 
     @Inject(XWorkConstants.DEV_MODE)
     public void setDevMode(String mode) {
-        this.devMode = BooleanUtils.toBoolean(mode);
+        final boolean booleanMode = BooleanUtils.toBoolean(mode);
+        if (!this.devModeValueSet) {
+            this.devMode = booleanMode;
+            this.devModeValueSet = true;  // Permit setting devMode only once
+            if (this.devMode) {
+                LOG.warn("Setting development mode [{}] affects the safety of your application!",
+                            this.devMode);
+            }
+        }
+        else {
+            LOG.debug("Error setting development mode value [{}], already previously set to [{}]", mode, this.devMode);
+        }
     }
 
     public void setProperty(Map context, Object target, Object name, Object value) throws OgnlException {

--- a/core/src/main/java/com/opensymphony/xwork2/ognl/accessor/XWorkCollectionPropertyAccessor.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/accessor/XWorkCollectionPropertyAccessor.java
@@ -48,7 +48,7 @@ public class XWorkCollectionPropertyAccessor extends SetPropertyAccessor {
     //use a basic object Ognl property accessor here
     //to access properties of the objects in the Set
     //so that nothing is put in the context to screw things up
-    private ObjectPropertyAccessor _accessor = new ObjectPropertyAccessor();
+    private final ObjectPropertyAccessor _accessor = new ObjectPropertyAccessor();
     
     private XWorkConverter xworkConverter;
     private ObjectFactory objectFactory;

--- a/core/src/main/java/com/opensymphony/xwork2/ognl/accessor/XWorkEnumerationAccessor.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/accessor/XWorkEnumerationAccessor.java
@@ -30,7 +30,7 @@ import java.util.Map;
  */
 public class XWorkEnumerationAccessor extends EnumerationPropertyAccessor {
 
-    ObjectPropertyAccessor opa = new ObjectPropertyAccessor();
+    private final ObjectPropertyAccessor opa = new ObjectPropertyAccessor();
 
     @Override
     public void setProperty(Map context, Object target, Object name, Object value) throws OgnlException {

--- a/core/src/main/java/com/opensymphony/xwork2/ognl/accessor/XWorkIteratorPropertyAccessor.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/accessor/XWorkIteratorPropertyAccessor.java
@@ -30,7 +30,7 @@ import java.util.Map;
  */
 public class XWorkIteratorPropertyAccessor extends IteratorPropertyAccessor {
 
-    ObjectPropertyAccessor opa = new ObjectPropertyAccessor();
+    private final ObjectPropertyAccessor opa = new ObjectPropertyAccessor();
 
     @Override
     public void setProperty(Map context, Object target, Object name, Object value) throws OgnlException {

--- a/core/src/main/java/com/opensymphony/xwork2/security/DefaultAcceptedPatternsChecker.java
+++ b/core/src/main/java/com/opensymphony/xwork2/security/DefaultAcceptedPatternsChecker.java
@@ -71,8 +71,8 @@ public class DefaultAcceptedPatternsChecker implements AcceptedPatternsChecker {
 
     public void setAcceptedPatterns(Set<String> patterns) {
         if (acceptedPatterns == null) {
-            LOG.debug("Replacing accepted patterns [{}] with [{}], be aware that this affects all instances and safety of your application!",
-                         acceptedPatterns, patterns);  // Limit unwanted log entries (for 1st call, acceptedPatterns null)
+            LOG.debug("Sets accepted patterns to [{}], be aware that this affects all instances and safety of your application!",
+                         patterns);  // Limit unwanted log entries (for 1st call, acceptedPatterns null)
         }
         else {
             LOG.warn("Replacing accepted patterns [{}] with [{}], be aware that this affects all instances and safety of your application!",

--- a/core/src/main/java/com/opensymphony/xwork2/security/DefaultAcceptedPatternsChecker.java
+++ b/core/src/main/java/com/opensymphony/xwork2/security/DefaultAcceptedPatternsChecker.java
@@ -44,11 +44,9 @@ public class DefaultAcceptedPatternsChecker implements AcceptedPatternsChecker {
     }
 
     @Inject(value = XWorkConstants.OVERRIDE_ACCEPTED_PATTERNS, required = false)
-    public void setOverrideAcceptedPatterns(String acceptablePatterns) {
-        if (LOG.isWarnEnabled()) {
-            LOG.warn("Overriding accepted patterns [{}] with [{}], be aware that this affects all instances and safety of your application!",
-                        acceptedPatterns, acceptablePatterns);
-        }
+    protected void setOverrideAcceptedPatterns(String acceptablePatterns) {
+        LOG.warn("Overriding accepted patterns [{}] with [{}], be aware that this affects all instances and safety of your application!",
+                    acceptedPatterns, acceptablePatterns);
         acceptedPatterns = new HashSet<>();
         for (String pattern : TextParseUtil.commaDelimitedStringToSet(acceptablePatterns)) {
             acceptedPatterns.add(Pattern.compile(pattern, Pattern.CASE_INSENSITIVE));
@@ -56,10 +54,8 @@ public class DefaultAcceptedPatternsChecker implements AcceptedPatternsChecker {
     }
 
     @Inject(value = XWorkConstants.ADDITIONAL_ACCEPTED_PATTERNS, required = false)
-    public void setAdditionalAcceptedPatterns(String acceptablePatterns) {
-        if (LOG.isWarnEnabled()) {
-            LOG.warn("Adding additional global patterns [{}] to accepted patterns!", acceptablePatterns);
-        }
+    protected void setAdditionalAcceptedPatterns(String acceptablePatterns) {
+        LOG.warn("Adding additional global patterns [{}] to accepted patterns!", acceptablePatterns);
         for (String pattern : TextParseUtil.commaDelimitedStringToSet(acceptablePatterns)) {
             acceptedPatterns.add(Pattern.compile(pattern, Pattern.CASE_INSENSITIVE));
         }
@@ -75,12 +71,10 @@ public class DefaultAcceptedPatternsChecker implements AcceptedPatternsChecker {
 
     public void setAcceptedPatterns(Set<String> patterns) {
         if (acceptedPatterns == null) {
-            if (LOG.isDebugEnabled()) {  // Limit unwanted log entries (for 1st call acceptedPatterns null)
-                LOG.debug("Replacing accepted patterns [{}] with [{}], be aware that this affects all instances and safety of your application!",
-                             acceptedPatterns, patterns);
-            }
+            LOG.debug("Replacing accepted patterns [{}] with [{}], be aware that this affects all instances and safety of your application!",
+                         acceptedPatterns, patterns);  // Limit unwanted log entries (for 1st call, acceptedPatterns null)
         }
-        else if (LOG.isWarnEnabled()) {
+        else {
             LOG.warn("Replacing accepted patterns [{}] with [{}], be aware that this affects all instances and safety of your application!",
                         acceptedPatterns, patterns);
         }
@@ -93,9 +87,7 @@ public class DefaultAcceptedPatternsChecker implements AcceptedPatternsChecker {
     public IsAccepted isAccepted(String value) {
         for (Pattern acceptedPattern : acceptedPatterns) {
             if (acceptedPattern.matcher(value).matches()) {
-                if (LOG.isTraceEnabled()) {
-                    LOG.trace("[{}] matches accepted pattern [{}]", value, acceptedPattern);
-                }
+                LOG.trace("[{}] matches accepted pattern [{}]", value, acceptedPattern);
                 return IsAccepted.yes(acceptedPattern.toString());
             }
         }

--- a/core/src/main/java/com/opensymphony/xwork2/security/DefaultAcceptedPatternsChecker.java
+++ b/core/src/main/java/com/opensymphony/xwork2/security/DefaultAcceptedPatternsChecker.java
@@ -45,8 +45,10 @@ public class DefaultAcceptedPatternsChecker implements AcceptedPatternsChecker {
 
     @Inject(value = XWorkConstants.OVERRIDE_ACCEPTED_PATTERNS, required = false)
     public void setOverrideAcceptedPatterns(String acceptablePatterns) {
-        LOG.warn("Overriding accepted patterns [{}] with [{}], be aware that this affects all instances and safety of your application!",
-                    XWorkConstants.OVERRIDE_ACCEPTED_PATTERNS, acceptablePatterns);
+        if (LOG.isWarnEnabled()) {
+            LOG.warn("Overriding accepted patterns [{}] with [{}], be aware that this affects all instances and safety of your application!",
+                        acceptedPatterns, acceptablePatterns);
+        }
         acceptedPatterns = new HashSet<>();
         for (String pattern : TextParseUtil.commaDelimitedStringToSet(acceptablePatterns)) {
             acceptedPatterns.add(Pattern.compile(pattern, Pattern.CASE_INSENSITIVE));
@@ -55,7 +57,9 @@ public class DefaultAcceptedPatternsChecker implements AcceptedPatternsChecker {
 
     @Inject(value = XWorkConstants.ADDITIONAL_ACCEPTED_PATTERNS, required = false)
     public void setAdditionalAcceptedPatterns(String acceptablePatterns) {
-        LOG.warn("Adding additional global patterns [{}] to accepted patterns!", acceptablePatterns);
+        if (LOG.isWarnEnabled()) {
+            LOG.warn("Adding additional global patterns [{}] to accepted patterns!", acceptablePatterns);
+        }
         for (String pattern : TextParseUtil.commaDelimitedStringToSet(acceptablePatterns)) {
             acceptedPatterns.add(Pattern.compile(pattern, Pattern.CASE_INSENSITIVE));
         }
@@ -70,7 +74,16 @@ public class DefaultAcceptedPatternsChecker implements AcceptedPatternsChecker {
     }
 
     public void setAcceptedPatterns(Set<String> patterns) {
-        LOG.trace("Sets accepted patterns [{}]", patterns);
+        if (acceptedPatterns == null) {
+            if (LOG.isDebugEnabled()) {  // Limit unwanted log entries (for 1st call acceptedPatterns null)
+                LOG.debug("Replacing accepted patterns [{}] with [{}], be aware that this affects all instances and safety of your application!",
+                             acceptedPatterns, patterns);
+            }
+        }
+        else if (LOG.isWarnEnabled()) {
+            LOG.warn("Replacing accepted patterns [{}] with [{}], be aware that this affects all instances and safety of your application!",
+                        acceptedPatterns, patterns);
+        }
         acceptedPatterns = new HashSet<>(patterns.size());
         for (String pattern : patterns) {
             acceptedPatterns.add(Pattern.compile(pattern, Pattern.CASE_INSENSITIVE));
@@ -80,7 +93,9 @@ public class DefaultAcceptedPatternsChecker implements AcceptedPatternsChecker {
     public IsAccepted isAccepted(String value) {
         for (Pattern acceptedPattern : acceptedPatterns) {
             if (acceptedPattern.matcher(value).matches()) {
-                LOG.trace("[{}] matches accepted pattern [{}]", value, acceptedPattern);
+                if (LOG.isTraceEnabled()) {
+                    LOG.trace("[{}] matches accepted pattern [{}]", value, acceptedPattern);
+                }
                 return IsAccepted.yes(acceptedPattern.toString());
             }
         }

--- a/core/src/main/java/com/opensymphony/xwork2/security/DefaultAcceptedPatternsChecker.java
+++ b/core/src/main/java/com/opensymphony/xwork2/security/DefaultAcceptedPatternsChecker.java
@@ -71,8 +71,8 @@ public class DefaultAcceptedPatternsChecker implements AcceptedPatternsChecker {
 
     public void setAcceptedPatterns(Set<String> patterns) {
         if (acceptedPatterns == null) {
-            LOG.debug("Sets accepted patterns to [{}], be aware that this affects all instances and safety of your application!",
-                         patterns);  // Limit unwanted log entries (for 1st call, acceptedPatterns null)
+            // Limit unwanted log entries (for 1st call, acceptedPatterns null)
+            LOG.debug("Sets accepted patterns to [{}], note this impacts the safety of your application!", patterns);
         }
         else {
             LOG.warn("Replacing accepted patterns [{}] with [{}], be aware that this affects all instances and safety of your application!",

--- a/core/src/main/java/com/opensymphony/xwork2/security/DefaultExcludedPatternsChecker.java
+++ b/core/src/main/java/com/opensymphony/xwork2/security/DefaultExcludedPatternsChecker.java
@@ -47,16 +47,14 @@ public class DefaultExcludedPatternsChecker implements ExcludedPatternsChecker {
     }
 
     @Inject(value = XWorkConstants.OVERRIDE_EXCLUDED_PATTERNS, required = false)
-    public void setOverrideExcludePatterns(String excludePatterns) {
+    protected void setOverrideExcludePatterns(String excludePatterns) {
         if (excludedPatterns != null && excludedPatterns.size() > 0) {
-            if (LOG.isWarnEnabled()) {
-                LOG.warn("Overriding excluded patterns [{}] with [{}], be aware that this affects all instances and safety of your application!",
-                            excludedPatterns, excludePatterns);
-            }
+            LOG.warn("Overriding excluded patterns [{}] with [{}], be aware that this affects all instances and safety of your application!",
+                        excludedPatterns, excludePatterns);
         }
-        else if (LOG.isDebugEnabled()) {  // Limit unwanted log entries (when excludedPatterns null/empty - usually 1st call)
+        else {
             LOG.debug("Overriding excluded patterns [{}] with [{}], be aware that this affects all instances and safety of your application!",
-                         excludedPatterns, excludePatterns);
+                         excludedPatterns, excludePatterns);  // Limit unwanted log entries (when excludedPatterns null/empty - usually 1st call)
         }
         excludedPatterns = new HashSet<Pattern>();
         for (String pattern : TextParseUtil.commaDelimitedStringToSet(excludePatterns)) {
@@ -66,23 +64,19 @@ public class DefaultExcludedPatternsChecker implements ExcludedPatternsChecker {
 
     @Inject(value = XWorkConstants.ADDITIONAL_EXCLUDED_PATTERNS, required = false)
     public void setAdditionalExcludePatterns(String excludePatterns) {
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Adding additional global patterns [{}] to excluded patterns!", excludePatterns);
-        }
+        LOG.debug("Adding additional global patterns [{}] to excluded patterns!", excludePatterns);
         for (String pattern : TextParseUtil.commaDelimitedStringToSet(excludePatterns)) {
             excludedPatterns.add(Pattern.compile(pattern, Pattern.CASE_INSENSITIVE));
         }
     }
 
     @Inject(StrutsConstants.STRUTS_ENABLE_DYNAMIC_METHOD_INVOCATION)
-    public void setDynamicMethodInvocation(String dmiValue) {
-        if (!BooleanUtils.toBoolean(dmiValue)) {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("DMI is disabled, adding DMI related excluded patterns");
-            }
+    protected void setDynamicMethodInvocation(String dmiValue) {
+        if (BooleanUtils.toBoolean(dmiValue) == false) {
+            LOG.debug("DMI is disabled, adding DMI related excluded patterns");
             setAdditionalExcludePatterns("^(action|method):.*");
         }
-        else if (LOG.isWarnEnabled()) {
+        else {
             LOG.warn("DMI is enabled, *NOT* adding DMI related excluded patterns");
         }
     }
@@ -97,14 +91,12 @@ public class DefaultExcludedPatternsChecker implements ExcludedPatternsChecker {
 
     public void setExcludedPatterns(Set<String> patterns) {
         if (excludedPatterns != null && excludedPatterns.size() > 0) {
-            if (LOG.isWarnEnabled()) {
-                LOG.warn("Replacing excluded patterns [{}] with [{}], be aware that this affects all instances and safety of your application!",
-                            excludedPatterns, patterns);
-            }
+            LOG.warn("Replacing excluded patterns [{}] with [{}], be aware that this affects all instances and safety of your application!",
+                        excludedPatterns, patterns);
         }
-        else if (LOG.isDebugEnabled()) {  // Limit unwanted log entries (when excludedPatterns null/empty - usually 1st call)
+        else {
             LOG.debug("Replacing excluded patterns [{}] with [{}], be aware that this affects all instances and safety of your application!",
-                    excludedPatterns, patterns);
+                    excludedPatterns, patterns);  // Limit unwanted log entries (when excludedPatterns null/empty - usually 1st call)
         }
         excludedPatterns = new HashSet<>(patterns.size());
         for (String pattern : patterns) {
@@ -115,9 +107,7 @@ public class DefaultExcludedPatternsChecker implements ExcludedPatternsChecker {
     public IsExcluded isExcluded(String value) {
         for (Pattern excludedPattern : excludedPatterns) {
             if (excludedPattern.matcher(value).matches()) {
-                if (LOG.isTraceEnabled()) {
-                    LOG.trace("[{}] matches excluded pattern [{}]", value, excludedPattern);
-                }
+                LOG.trace("[{}] matches excluded pattern [{}]", value, excludedPattern);
                 return IsExcluded.yes(excludedPattern);
             }
         }

--- a/core/src/main/java/com/opensymphony/xwork2/security/DefaultExcludedPatternsChecker.java
+++ b/core/src/main/java/com/opensymphony/xwork2/security/DefaultExcludedPatternsChecker.java
@@ -53,8 +53,8 @@ public class DefaultExcludedPatternsChecker implements ExcludedPatternsChecker {
                         excludedPatterns, excludePatterns);
         }
         else {
-            LOG.debug("Overriding excluded patterns with [{}], be aware that this affects all instances and safety of your application!",
-                         excludePatterns);  // Limit unwanted log entries (when excludedPatterns null/empty - usually 1st call)
+            // Limit unwanted log entries (when excludedPatterns null/empty - usually 1st call)
+            LOG.debug("Overriding excluded patterns with [{}]", excludePatterns);
         }
         excludedPatterns = new HashSet<Pattern>();
         for (String pattern : TextParseUtil.commaDelimitedStringToSet(excludePatterns)) {
@@ -95,8 +95,8 @@ public class DefaultExcludedPatternsChecker implements ExcludedPatternsChecker {
                         excludedPatterns, patterns);
         }
         else {
-            LOG.debug("Sets excluded patterns to [{}], be aware that this affects all instances and safety of your application!",
-                         patterns);  // Limit unwanted log entries (when excludedPatterns null/empty - usually 1st call)
+            // Limit unwanted log entries (when excludedPatterns null/empty - usually 1st call)
+            LOG.debug("Sets excluded patterns to [{}]", patterns);
         }
         excludedPatterns = new HashSet<>(patterns.size());
         for (String pattern : patterns) {

--- a/core/src/main/java/com/opensymphony/xwork2/security/DefaultExcludedPatternsChecker.java
+++ b/core/src/main/java/com/opensymphony/xwork2/security/DefaultExcludedPatternsChecker.java
@@ -53,8 +53,8 @@ public class DefaultExcludedPatternsChecker implements ExcludedPatternsChecker {
                         excludedPatterns, excludePatterns);
         }
         else {
-            LOG.debug("Overriding excluded patterns [{}] with [{}], be aware that this affects all instances and safety of your application!",
-                         excludedPatterns, excludePatterns);  // Limit unwanted log entries (when excludedPatterns null/empty - usually 1st call)
+            LOG.debug("Overriding excluded patterns with [{}], be aware that this affects all instances and safety of your application!",
+                         excludePatterns);  // Limit unwanted log entries (when excludedPatterns null/empty - usually 1st call)
         }
         excludedPatterns = new HashSet<Pattern>();
         for (String pattern : TextParseUtil.commaDelimitedStringToSet(excludePatterns)) {
@@ -95,8 +95,8 @@ public class DefaultExcludedPatternsChecker implements ExcludedPatternsChecker {
                         excludedPatterns, patterns);
         }
         else {
-            LOG.debug("Replacing excluded patterns [{}] with [{}], be aware that this affects all instances and safety of your application!",
-                    excludedPatterns, patterns);  // Limit unwanted log entries (when excludedPatterns null/empty - usually 1st call)
+            LOG.debug("Sets excluded patterns to [{}], be aware that this affects all instances and safety of your application!",
+                         patterns);  // Limit unwanted log entries (when excludedPatterns null/empty - usually 1st call)
         }
         excludedPatterns = new HashSet<>(patterns.size());
         for (String pattern : patterns) {

--- a/core/src/main/java/com/opensymphony/xwork2/security/DefaultExcludedPatternsChecker.java
+++ b/core/src/main/java/com/opensymphony/xwork2/security/DefaultExcludedPatternsChecker.java
@@ -48,8 +48,16 @@ public class DefaultExcludedPatternsChecker implements ExcludedPatternsChecker {
 
     @Inject(value = XWorkConstants.OVERRIDE_EXCLUDED_PATTERNS, required = false)
     public void setOverrideExcludePatterns(String excludePatterns) {
-        LOG.warn("Overriding excluded patterns [{}] with [{}], be aware that this affects all instances and safety of your application!",
-                    XWorkConstants.OVERRIDE_EXCLUDED_PATTERNS, excludePatterns);
+        if (excludedPatterns != null && excludedPatterns.size() > 0) {
+            if (LOG.isWarnEnabled()) {
+                LOG.warn("Overriding excluded patterns [{}] with [{}], be aware that this affects all instances and safety of your application!",
+                            excludedPatterns, excludePatterns);
+            }
+        }
+        else if (LOG.isDebugEnabled()) {  // Limit unwanted log entries (when excludedPatterns null/empty - usually 1st call)
+            LOG.debug("Overriding excluded patterns [{}] with [{}], be aware that this affects all instances and safety of your application!",
+                         excludedPatterns, excludePatterns);
+        }
         excludedPatterns = new HashSet<Pattern>();
         for (String pattern : TextParseUtil.commaDelimitedStringToSet(excludePatterns)) {
             excludedPatterns.add(Pattern.compile(pattern, Pattern.CASE_INSENSITIVE));
@@ -58,7 +66,9 @@ public class DefaultExcludedPatternsChecker implements ExcludedPatternsChecker {
 
     @Inject(value = XWorkConstants.ADDITIONAL_EXCLUDED_PATTERNS, required = false)
     public void setAdditionalExcludePatterns(String excludePatterns) {
-        LOG.debug("Adding additional global patterns [{}] to excluded patterns!", excludePatterns);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Adding additional global patterns [{}] to excluded patterns!", excludePatterns);
+        }
         for (String pattern : TextParseUtil.commaDelimitedStringToSet(excludePatterns)) {
             excludedPatterns.add(Pattern.compile(pattern, Pattern.CASE_INSENSITIVE));
         }
@@ -67,8 +77,13 @@ public class DefaultExcludedPatternsChecker implements ExcludedPatternsChecker {
     @Inject(StrutsConstants.STRUTS_ENABLE_DYNAMIC_METHOD_INVOCATION)
     public void setDynamicMethodInvocation(String dmiValue) {
         if (!BooleanUtils.toBoolean(dmiValue)) {
-            LOG.debug("DMI is disabled, adding DMI related excluded patterns");
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("DMI is disabled, adding DMI related excluded patterns");
+            }
             setAdditionalExcludePatterns("^(action|method):.*");
+        }
+        else if (LOG.isWarnEnabled()) {
+            LOG.warn("DMI is enabled, *NOT* adding DMI related excluded patterns");
         }
     }
 
@@ -81,7 +96,16 @@ public class DefaultExcludedPatternsChecker implements ExcludedPatternsChecker {
     }
 
     public void setExcludedPatterns(Set<String> patterns) {
-        LOG.trace("Sets excluded patterns [{}]", patterns);
+        if (excludedPatterns != null && excludedPatterns.size() > 0) {
+            if (LOG.isWarnEnabled()) {
+                LOG.warn("Replacing excluded patterns [{}] with [{}], be aware that this affects all instances and safety of your application!",
+                            excludedPatterns, patterns);
+            }
+        }
+        else if (LOG.isDebugEnabled()) {  // Limit unwanted log entries (when excludedPatterns null/empty - usually 1st call)
+            LOG.debug("Replacing excluded patterns [{}] with [{}], be aware that this affects all instances and safety of your application!",
+                    excludedPatterns, patterns);
+        }
         excludedPatterns = new HashSet<>(patterns.size());
         for (String pattern : patterns) {
             excludedPatterns.add(Pattern.compile(pattern, Pattern.CASE_INSENSITIVE));
@@ -91,7 +115,9 @@ public class DefaultExcludedPatternsChecker implements ExcludedPatternsChecker {
     public IsExcluded isExcluded(String value) {
         for (Pattern excludedPattern : excludedPatterns) {
             if (excludedPattern.matcher(value).matches()) {
-                LOG.trace("[{}] matches excluded pattern [{}]", value, excludedPattern);
+                if (LOG.isTraceEnabled()) {
+                    LOG.trace("[{}] matches excluded pattern [{}]", value, excludedPattern);
+                }
                 return IsExcluded.yes(excludedPattern);
             }
         }

--- a/core/src/main/resources/struts-default.xml
+++ b/core/src/main/resources/struts-default.xml
@@ -61,6 +61,7 @@
                 freemarker.ext.rhino.,
                 sun.reflect.,
                 javassist.,
+                org.objectweb.asm.,
                 com.opensymphony.xwork2.ognl.,
                 com.opensymphony.xwork2.security.,
                 com.opensymphony.xwork2.util." />

--- a/core/src/test/java/com/opensymphony/xwork2/ognl/OgnlUtilTest.java
+++ b/core/src/test/java/com/opensymphony/xwork2/ognl/OgnlUtilTest.java
@@ -636,20 +636,6 @@ public class OgnlUtilTest extends XWorkTestCase {
         String[] foo = new String[]{"asdf"};
         ((OgnlValueStack)stack).setDevMode("true");
         try {
-            reloadTestContainerConfiguration(true, false);  // Set dev mode true (above set now refused)
-        }
-        catch (Exception ex) {
-            fail("Unable to reload container configuration - exception: " + ex);
-        }
-
-        // Repeat stack/context set after retrieving updated stack
-        stack = ActionContext.getContext().getValueStack();
-        stackContext = stack.getContext();
-        stackContext.put(ReflectionContextState.CREATE_NULL_OBJECTS, Boolean.FALSE);
-        stackContext.put(ReflectionContextState.DENY_METHOD_EXECUTION, Boolean.TRUE);
-        stackContext.put(XWorkConverter.REPORT_CONVERSION_ERRORS, Boolean.TRUE);
-
-        try {
             stack.setValue("list.1114778947765", foo);
             fail("non-valid expression: list.1114778947765"); 
         }
@@ -674,20 +660,6 @@ public class OgnlUtilTest extends XWorkTestCase {
         }
         
         ((OgnlValueStack)stack).setDevMode("false");
-        try {
-            reloadTestContainerConfiguration(false, false);  // Set dev mode false (above set now refused)
-        }
-        catch (Exception ex) {
-            fail("Unable to reload container configuration - exception: " + ex);
-        }
-
-        // Repeat stack/context set after retrieving updated stack
-        stack = ActionContext.getContext().getValueStack();
-        stackContext = stack.getContext();
-        stackContext.put(ReflectionContextState.CREATE_NULL_OBJECTS, Boolean.FALSE);
-        stackContext.put(ReflectionContextState.DENY_METHOD_EXECUTION, Boolean.TRUE);
-        stackContext.put(XWorkConverter.REPORT_CONVERSION_ERRORS, Boolean.TRUE);
-
         stack.setValue("list.1114778947765", foo);
         stack.setValue("1114778947765", foo);
         stack.setValue("1234", foo);
@@ -715,12 +687,6 @@ public class OgnlUtilTest extends XWorkTestCase {
         stack.setValue("1114778947765", foo);
         stack.setValue("1234", foo);
 
-        ((OgnlValueStack)stack).setDevMode("true");  // Previously set, should remain false
-        // With dev mode false, the following set values should not cause failures
-        stack.setValue("list.1114778947765", foo);
-        stack.setValue("1114778947765", foo);
-        stack.setValue("1234", foo);
-
         try {
             reloadTestContainerConfiguration(true, false);  // Set dev mode true
         }
@@ -735,29 +701,6 @@ public class OgnlUtilTest extends XWorkTestCase {
         stackContext.put(ReflectionContextState.DENY_METHOD_EXECUTION, Boolean.TRUE);
         stackContext.put(XWorkConverter.REPORT_CONVERSION_ERRORS, Boolean.TRUE);
 
-        try {
-            stack.setValue("list.1114778947765", foo);
-            fail("non-valid expression: list.1114778947765");
-        }
-        catch(RuntimeException ex) {
-            // Expected with dev mode true
-        }
-        try {
-            stack.setValue("1114778947765", foo);
-            fail("non-valid expression: 1114778947765");
-        }
-        catch(RuntimeException ex) {
-            // Expected with dev mode true
-        }
-        try {
-            stack.setValue("1234", foo);
-            fail("non-valid expression: 1234");
-        }
-        catch(RuntimeException ex) {
-            // Expected with dev mode true
-        }
-
-        ((OgnlValueStack)stack).setDevMode("false");  // Previously set, should remain true
         try {
             stack.setValue("list.1114778947765", foo);
             fail("non-valid expression: list.1114778947765");
@@ -804,12 +747,6 @@ public class OgnlUtilTest extends XWorkTestCase {
         stack.setValue("1114778947765", foo);
         stack.setValue("1234", foo);
 
-        ognlUtil.setDevMode("true");  // Previously set, should remain false
-        // With dev mode false, the following set values should not cause failures
-        stack.setValue("list.1114778947765", foo);
-        stack.setValue("1114778947765", foo);
-        stack.setValue("1234", foo);
-
         try {
             reloadTestContainerConfiguration(true, false);  // Set dev mode true
         }
@@ -824,29 +761,6 @@ public class OgnlUtilTest extends XWorkTestCase {
         stackContext.put(ReflectionContextState.DENY_METHOD_EXECUTION, Boolean.TRUE);
         stackContext.put(XWorkConverter.REPORT_CONVERSION_ERRORS, Boolean.TRUE);
 
-        try {
-            stack.setValue("list.1114778947765", foo);
-            fail("non-valid expression: list.1114778947765");
-        }
-        catch(RuntimeException ex) {
-            // Expected with dev mode true
-        }
-        try {
-            stack.setValue("1114778947765", foo);
-            fail("non-valid expression: 1114778947765");
-        }
-        catch(RuntimeException ex) {
-            // Expected with dev mode true
-        }
-        try {
-            stack.setValue("1234", foo);
-            fail("non-valid expression: 1234");
-        }
-        catch(RuntimeException ex) {
-            // Expected with dev mode true
-        }
-
-        ognlUtil.setDevMode("false");  // Previously set, should remain true
         try {
             stack.setValue("list.1114778947765", foo);
             fail("non-valid expression: list.1114778947765");

--- a/core/src/test/java/com/opensymphony/xwork2/ognl/OgnlValueStackTest.java
+++ b/core/src/test/java/com/opensymphony/xwork2/ognl/OgnlValueStackTest.java
@@ -601,10 +601,8 @@ public class OgnlValueStackTest extends XWorkTestCase {
     public void testPrimitiveSettingWithInvalidValueAddsFieldErrorInDevMode() throws Exception {
         SimpleAction action = new SimpleAction();
         OgnlValueStack stack = createValueStack();
-        reloadTestContainerConfiguration(true, true);
-        stack = (OgnlValueStack) ActionContext.getContext().getValueStack();  // Retrieve updated stack
         stack.getContext().put(XWorkConverter.REPORT_CONVERSION_ERRORS, Boolean.TRUE);
-        stack.setDevMode("true");  // No effect, but matches loaded config
+        stack.setDevMode("true");
         stack.push(action);
 
         try {
@@ -622,10 +620,8 @@ public class OgnlValueStackTest extends XWorkTestCase {
     public void testPrimitiveSettingWithInvalidValueAddsFieldErrorInNonDevMode() throws Exception {
         SimpleAction action = new SimpleAction();
         OgnlValueStack stack = createValueStack();
-        reloadTestContainerConfiguration(false, true);
-        stack = (OgnlValueStack) ActionContext.getContext().getValueStack();  // Retrieve updated stack
         stack.getContext().put(XWorkConverter.REPORT_CONVERSION_ERRORS, Boolean.TRUE);
-        stack.setDevMode("false");  // No effect, but matches loaded config
+        stack.setDevMode("false");
         stack.push(action);
         stack.setValue("bar", "3x");
 

--- a/core/src/test/java/com/opensymphony/xwork2/ognl/OgnlValueStackTest.java
+++ b/core/src/test/java/com/opensymphony/xwork2/ognl/OgnlValueStackTest.java
@@ -19,7 +19,11 @@
 package com.opensymphony.xwork2.ognl;
 
 import com.opensymphony.xwork2.*;
+import com.opensymphony.xwork2.config.ConfigurationManager;
+import com.opensymphony.xwork2.config.ConfigurationProvider;
+import com.opensymphony.xwork2.config.providers.XmlConfigurationProvider;
 import com.opensymphony.xwork2.conversion.impl.XWorkConverter;
+import com.opensymphony.xwork2.inject.Container;
 import com.opensymphony.xwork2.ognl.accessor.CompoundRootAccessor;
 import com.opensymphony.xwork2.test.TestBean2;
 import com.opensymphony.xwork2.util.*;
@@ -594,11 +598,13 @@ public class OgnlValueStackTest extends XWorkTestCase {
         assertEquals("bar:123", vs.findValue("foo.bar", String.class));
     }
 
-    public void testPrimitiveSettingWithInvalidValueAddsFieldErrorInDevMode() {
+    public void testPrimitiveSettingWithInvalidValueAddsFieldErrorInDevMode() throws Exception {
         SimpleAction action = new SimpleAction();
         OgnlValueStack stack = createValueStack();
+        reloadTestContainerConfiguration(true, true);
+        stack = (OgnlValueStack) ActionContext.getContext().getValueStack();  // Retrieve updated stack
         stack.getContext().put(XWorkConverter.REPORT_CONVERSION_ERRORS, Boolean.TRUE);
-        stack.setDevMode("true");
+        stack.setDevMode("true");  // No effect, but matches loaded config
         stack.push(action);
 
         try {
@@ -613,11 +619,13 @@ public class OgnlValueStackTest extends XWorkTestCase {
         assertTrue(conversionErrors.containsKey("bar"));
     }
 
-    public void testPrimitiveSettingWithInvalidValueAddsFieldErrorInNonDevMode() {
+    public void testPrimitiveSettingWithInvalidValueAddsFieldErrorInNonDevMode() throws Exception {
         SimpleAction action = new SimpleAction();
         OgnlValueStack stack = createValueStack();
+        reloadTestContainerConfiguration(false, true);
+        stack = (OgnlValueStack) ActionContext.getContext().getValueStack();  // Retrieve updated stack
         stack.getContext().put(XWorkConverter.REPORT_CONVERSION_ERRORS, Boolean.TRUE);
-        stack.setDevMode("false");
+        stack.setDevMode("false");  // No effect, but matches loaded config
         stack.push(action);
         stack.setValue("bar", "3x");
 
@@ -966,6 +974,39 @@ public class OgnlValueStackTest extends XWorkTestCase {
         // should log warning
         assertEquals(null, stack.findValue("address.country.id", String.class));
         assertEquals(null, stack.findValue("address.country.name", String.class));
+    }
+
+    private void reloadTestContainerConfiguration(boolean devMode, boolean allowStatic) throws Exception {
+        super.tearDown();
+
+        ConfigurationProvider configurationProvider;
+        if (devMode == true && allowStatic == true) {
+            configurationProvider = new XmlConfigurationProvider("com/opensymphony/xwork2/config/providers/xwork-test-allowstatic-devmode-true.xml", true);
+        }
+        else if (devMode == true && allowStatic == false) {
+            configurationProvider = new XmlConfigurationProvider("com/opensymphony/xwork2/config/providers/xwork-test-devmode-true.xml", true);
+        }
+        else if (devMode == false && allowStatic == true) {
+            configurationProvider = new XmlConfigurationProvider("com/opensymphony/xwork2/config/providers/xwork-test-allowstatic-true.xml", true);
+        }
+        else {  // devMode, allowStatic both false
+            configurationProvider = new XmlConfigurationProvider("com/opensymphony/xwork2/config/providers/xwork-test-allowstatic-devmode-false.xml", true);
+        }
+
+        configurationManager = new ConfigurationManager(Container.DEFAULT_NAME);
+        configurationManager.addContainerProvider(configurationProvider);
+        configuration = configurationManager.getConfiguration();
+        container = configuration.getContainer();
+        container.inject(configurationProvider);
+        configurationProvider.init(configuration);
+        actionProxyFactory = container.getInstance(ActionProxyFactory.class);
+
+        // Reset the value stack
+        ValueStack stack = container.getInstance(ValueStackFactory.class).createValueStack();
+        stack.getContext().put(ActionContext.CONTAINER, container);
+        ActionContext.setContext(new ActionContext(stack.getContext()));
+
+        ognlUtil = container.getInstance(OgnlUtil.class);
     }
 
     class BadJavaBean {

--- a/core/src/test/resources/com/opensymphony/xwork2/config/providers/xwork-test-allowstatic-devmode-false.xml
+++ b/core/src/test/resources/com/opensymphony/xwork2/config/providers/xwork-test-allowstatic-devmode-false.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+-->
+<!DOCTYPE xwork PUBLIC
+    "-//Apache Struts//XWork 2.5//EN"
+    "http://struts.apache.org/dtds/xwork-2.5.dtd"
+ >
+
+<xwork>
+
+    <constant name="struts.devMode" value="false" />
+    <constant name="devMode" value="false" />
+    <constant name="struts.i18n.reload" value="false" />
+    <constant name="logMissingProperties" value="false" />
+    <constant name="enableOGNLExpressionCache" value="true" />
+    <constant name="enableOGNLEvalExpression" value="false" />
+    <constant name="reloadXmlConfiguration" value="false" />
+    <constant name="struts.ognl.allowStaticMethodAccess" value="false" />
+    <constant name="struts.enable.DynamicMethodInvocation" value="false" />
+    <constant name="struts.dispatcher.errorHandler" value="struts" />
+
+    <bean class="com.opensymphony.xwork2.ObjectFactory" name="default" />
+    <bean class="org.apache.struts2.views.freemarker.FreemarkerThemeTemplateLoader" />
+    <bean class="org.apache.struts2.views.freemarker.FreemarkerManager" name="default" />
+    <bean class="org.apache.struts2.views.velocity.VelocityManager" name="default" optional="true" />
+    <bean class="org.apache.struts2.components.template.TemplateEngineManager" />
+    <bean class="com.opensymphony.xwork2.conversion.impl.XWorkBasicConverter" />
+    <bean class="com.opensymphony.xwork2.ognl.OgnlUtil" />
+    <bean class="org.apache.struts2.views.jsp.ui.OgnlTool" />
+
+    <bean type="com.opensymphony.xwork2.ActionProxyFactory" name="default" class="org.apache.struts2.factory.StrutsActionProxyFactory"/>
+    <bean type="com.opensymphony.xwork2.FileManager" name="system" class="com.opensymphony.xwork2.util.fs.DefaultFileManager" scope="singleton"/>
+    <bean type="com.opensymphony.xwork2.FileManagerFactory" name="default" class="com.opensymphony.xwork2.util.fs.DefaultFileManagerFactory" scope="singleton"/>
+    <bean type="com.opensymphony.xwork2.LocalizedTextProvider" name="global-only" class="com.opensymphony.xwork2.util.GlobalLocalizedTextProvider" scope="singleton" />
+    <bean type="com.opensymphony.xwork2.LocalizedTextProvider" name="default" class="com.opensymphony.xwork2.util.StrutsLocalizedTextProvider" scope="singleton" />
+    <bean type="com.opensymphony.xwork2.TextProvider" name="system" class="com.opensymphony.xwork2.DefaultTextProvider" scope="singleton" />
+    <bean type="com.opensymphony.xwork2.conversion.ConversionAnnotationProcessor" name="default" class="com.opensymphony.xwork2.conversion.impl.DefaultConversionAnnotationProcessor" />
+    <bean type="com.opensymphony.xwork2.conversion.ConversionFileProcessor" name="default" class="com.opensymphony.xwork2.conversion.impl.DefaultConversionFileProcessor" />
+    <bean type="com.opensymphony.xwork2.conversion.ObjectTypeDeterminer" name="default" class="com.opensymphony.xwork2.conversion.impl.DefaultObjectTypeDeterminer"/>
+    <bean type="com.opensymphony.xwork2.conversion.TypeConverterCreator" name="default" class="com.opensymphony.xwork2.conversion.impl.DefaultTypeConverterCreator" />
+    <bean type="com.opensymphony.xwork2.conversion.TypeConverterHolder" name="default" class="com.opensymphony.xwork2.conversion.impl.DefaultTypeConverterHolder" />
+    <bean type="com.opensymphony.xwork2.conversion.impl.XWorkConverter" name="default" class="com.opensymphony.xwork2.conversion.impl.XWorkConverter" />
+
+    <bean type="com.opensymphony.xwork2.factory.ActionFactory" name="default" class="com.opensymphony.xwork2.factory.DefaultActionFactory" />
+    <bean type="com.opensymphony.xwork2.factory.ConverterFactory" name="default" class="com.opensymphony.xwork2.factory.DefaultConverterFactory" />
+    <bean type="com.opensymphony.xwork2.factory.ResultFactory" name="default" class="org.apache.struts2.factory.StrutsResultFactory" />
+    <bean type="com.opensymphony.xwork2.factory.UnknownHandlerFactory" name="default" class="com.opensymphony.xwork2.factory.DefaultUnknownHandlerFactory" />
+    <bean type="com.opensymphony.xwork2.factory.ValidatorFactory" name="default" class="com.opensymphony.xwork2.factory.DefaultValidatorFactory" />
+    <bean type="com.opensymphony.xwork2.factory.InterceptorFactory" name="default" class="com.opensymphony.xwork2.factory.DefaultInterceptorFactory" />
+    <bean type="com.opensymphony.xwork2.util.ValueStackFactory" name="default" class="com.opensymphony.xwork2.ognl.OgnlValueStackFactory" />
+    <bean type="com.opensymphony.xwork2.util.reflection.ReflectionProvider" name="default" class="com.opensymphony.xwork2.ognl.OgnlReflectionProvider" />
+
+    <bean type="ognl.MethodAccessor" name="java.lang.Object" class="com.opensymphony.xwork2.ognl.accessor.XWorkMethodAccessor" />
+    <bean type="ognl.MethodAccessor" name="com.opensymphony.xwork2.util.CompoundRoot" class="com.opensymphony.xwork2.ognl.accessor.CompoundRootAccessor" />
+    <bean type="ognl.PropertyAccessor" name="com.opensymphony.xwork2.util.CompoundRoot" class="com.opensymphony.xwork2.ognl.accessor.CompoundRootAccessor" />
+    <bean type="ognl.PropertyAccessor" name="org.apache.struts2.dispatcher.HttpParameters" class="com.opensymphony.xwork2.ognl.accessor.HttpParametersPropertyAccessor" />
+    <bean type="ognl.PropertyAccessor" name="com.opensymphony.xwork2.ognl.ObjectProxy" class="com.opensymphony.xwork2.ognl.accessor.ObjectProxyPropertyAccessor" />
+    <bean type="ognl.PropertyAccessor" name="org.apache.struts2.dispatcher.Parameter" class="com.opensymphony.xwork2.ognl.accessor.ParameterPropertyAccessor" />
+    <bean type="ognl.PropertyAccessor" name="java.util.ArrayList" class="com.opensymphony.xwork2.ognl.accessor.XWorkListPropertyAccessor" />
+    <bean type="ognl.PropertyAccessor" name="java.util.Collection" class="com.opensymphony.xwork2.ognl.accessor.XWorkCollectionPropertyAccessor" />
+    <bean type="ognl.PropertyAccessor" name="java.util.Enumeration" class="com.opensymphony.xwork2.ognl.accessor.XWorkEnumerationAccessor" />
+    <bean type="ognl.PropertyAccessor" name="java.util.HashMap" class="com.opensymphony.xwork2.ognl.accessor.XWorkMapPropertyAccessor" />
+    <bean type="ognl.PropertyAccessor" name="java.util.HashSet" class="com.opensymphony.xwork2.ognl.accessor.XWorkCollectionPropertyAccessor" />
+    <bean type="ognl.PropertyAccessor" name="java.util.Iterator" class="com.opensymphony.xwork2.ognl.accessor.XWorkIteratorPropertyAccessor" />
+    <bean type="ognl.PropertyAccessor" name="java.util.List" class="com.opensymphony.xwork2.ognl.accessor.XWorkListPropertyAccessor" />
+    <bean type="ognl.PropertyAccessor" name="java.util.Map" class="com.opensymphony.xwork2.ognl.accessor.XWorkMapPropertyAccessor" />
+    <bean type="ognl.PropertyAccessor" name="java.lang.Object" class="com.opensymphony.xwork2.ognl.accessor.ObjectAccessor" />
+    <bean type="ognl.PropertyAccessor" name="java.util.Set" class="com.opensymphony.xwork2.ognl.accessor.XWorkCollectionPropertyAccessor" />
+
+</xwork>

--- a/core/src/test/resources/com/opensymphony/xwork2/config/providers/xwork-test-allowstatic-devmode-true.xml
+++ b/core/src/test/resources/com/opensymphony/xwork2/config/providers/xwork-test-allowstatic-devmode-true.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+-->
+<!DOCTYPE xwork PUBLIC
+    "-//Apache Struts//XWork 2.5//EN"
+    "http://struts.apache.org/dtds/xwork-2.5.dtd"
+ >
+
+<xwork>
+
+    <constant name="struts.devMode" value="true" />
+    <constant name="devMode" value="true" />
+    <constant name="struts.i18n.reload" value="false" />
+    <constant name="logMissingProperties" value="false" />
+    <constant name="enableOGNLExpressionCache" value="true" />
+    <constant name="enableOGNLEvalExpression" value="false" />
+    <constant name="reloadXmlConfiguration" value="false" />
+    <constant name="struts.ognl.allowStaticMethodAccess" value="true" />
+    <constant name="struts.enable.DynamicMethodInvocation" value="false" />
+    <constant name="struts.dispatcher.errorHandler" value="struts" />
+
+    <bean class="com.opensymphony.xwork2.ObjectFactory" name="default" />
+    <bean class="org.apache.struts2.views.freemarker.FreemarkerThemeTemplateLoader" />
+    <bean class="org.apache.struts2.views.freemarker.FreemarkerManager" name="default" />
+    <bean class="org.apache.struts2.views.velocity.VelocityManager" name="default" optional="true" />
+    <bean class="org.apache.struts2.components.template.TemplateEngineManager" />
+    <bean class="com.opensymphony.xwork2.conversion.impl.XWorkBasicConverter" />
+    <bean class="com.opensymphony.xwork2.ognl.OgnlUtil" />
+    <bean class="org.apache.struts2.views.jsp.ui.OgnlTool" />
+
+    <bean type="com.opensymphony.xwork2.ActionProxyFactory" name="default" class="org.apache.struts2.factory.StrutsActionProxyFactory"/>
+    <bean type="com.opensymphony.xwork2.FileManager" name="system" class="com.opensymphony.xwork2.util.fs.DefaultFileManager" scope="singleton"/>
+    <bean type="com.opensymphony.xwork2.FileManagerFactory" name="default" class="com.opensymphony.xwork2.util.fs.DefaultFileManagerFactory" scope="singleton"/>
+    <bean type="com.opensymphony.xwork2.LocalizedTextProvider" name="global-only" class="com.opensymphony.xwork2.util.GlobalLocalizedTextProvider" scope="singleton" />
+    <bean type="com.opensymphony.xwork2.LocalizedTextProvider" name="default" class="com.opensymphony.xwork2.util.StrutsLocalizedTextProvider" scope="singleton" />
+    <bean type="com.opensymphony.xwork2.TextProvider" name="system" class="com.opensymphony.xwork2.DefaultTextProvider" scope="singleton" />
+    <bean type="com.opensymphony.xwork2.conversion.ConversionAnnotationProcessor" name="default" class="com.opensymphony.xwork2.conversion.impl.DefaultConversionAnnotationProcessor" />
+    <bean type="com.opensymphony.xwork2.conversion.ConversionFileProcessor" name="default" class="com.opensymphony.xwork2.conversion.impl.DefaultConversionFileProcessor" />
+    <bean type="com.opensymphony.xwork2.conversion.ObjectTypeDeterminer" name="default" class="com.opensymphony.xwork2.conversion.impl.DefaultObjectTypeDeterminer"/>
+    <bean type="com.opensymphony.xwork2.conversion.TypeConverterCreator" name="default" class="com.opensymphony.xwork2.conversion.impl.DefaultTypeConverterCreator" />
+    <bean type="com.opensymphony.xwork2.conversion.TypeConverterHolder" name="default" class="com.opensymphony.xwork2.conversion.impl.DefaultTypeConverterHolder" />
+    <bean type="com.opensymphony.xwork2.conversion.impl.XWorkConverter" name="default" class="com.opensymphony.xwork2.conversion.impl.XWorkConverter" />
+
+    <bean type="com.opensymphony.xwork2.factory.ActionFactory" name="default" class="com.opensymphony.xwork2.factory.DefaultActionFactory" />
+    <bean type="com.opensymphony.xwork2.factory.ConverterFactory" name="default" class="com.opensymphony.xwork2.factory.DefaultConverterFactory" />
+    <bean type="com.opensymphony.xwork2.factory.ResultFactory" name="default" class="org.apache.struts2.factory.StrutsResultFactory" />
+    <bean type="com.opensymphony.xwork2.factory.UnknownHandlerFactory" name="default" class="com.opensymphony.xwork2.factory.DefaultUnknownHandlerFactory" />
+    <bean type="com.opensymphony.xwork2.factory.ValidatorFactory" name="default" class="com.opensymphony.xwork2.factory.DefaultValidatorFactory" />
+    <bean type="com.opensymphony.xwork2.factory.InterceptorFactory" name="default" class="com.opensymphony.xwork2.factory.DefaultInterceptorFactory" />
+    <bean type="com.opensymphony.xwork2.util.ValueStackFactory" name="default" class="com.opensymphony.xwork2.ognl.OgnlValueStackFactory" />
+    <bean type="com.opensymphony.xwork2.util.reflection.ReflectionProvider" name="default" class="com.opensymphony.xwork2.ognl.OgnlReflectionProvider" />
+
+    <bean type="ognl.MethodAccessor" name="java.lang.Object" class="com.opensymphony.xwork2.ognl.accessor.XWorkMethodAccessor" />
+    <bean type="ognl.MethodAccessor" name="com.opensymphony.xwork2.util.CompoundRoot" class="com.opensymphony.xwork2.ognl.accessor.CompoundRootAccessor" />
+    <bean type="ognl.PropertyAccessor" name="com.opensymphony.xwork2.util.CompoundRoot" class="com.opensymphony.xwork2.ognl.accessor.CompoundRootAccessor" />
+    <bean type="ognl.PropertyAccessor" name="org.apache.struts2.dispatcher.HttpParameters" class="com.opensymphony.xwork2.ognl.accessor.HttpParametersPropertyAccessor" />
+    <bean type="ognl.PropertyAccessor" name="com.opensymphony.xwork2.ognl.ObjectProxy" class="com.opensymphony.xwork2.ognl.accessor.ObjectProxyPropertyAccessor" />
+    <bean type="ognl.PropertyAccessor" name="org.apache.struts2.dispatcher.Parameter" class="com.opensymphony.xwork2.ognl.accessor.ParameterPropertyAccessor" />
+    <bean type="ognl.PropertyAccessor" name="java.util.ArrayList" class="com.opensymphony.xwork2.ognl.accessor.XWorkListPropertyAccessor" />
+    <bean type="ognl.PropertyAccessor" name="java.util.Collection" class="com.opensymphony.xwork2.ognl.accessor.XWorkCollectionPropertyAccessor" />
+    <bean type="ognl.PropertyAccessor" name="java.util.Enumeration" class="com.opensymphony.xwork2.ognl.accessor.XWorkEnumerationAccessor" />
+    <bean type="ognl.PropertyAccessor" name="java.util.HashMap" class="com.opensymphony.xwork2.ognl.accessor.XWorkMapPropertyAccessor" />
+    <bean type="ognl.PropertyAccessor" name="java.util.HashSet" class="com.opensymphony.xwork2.ognl.accessor.XWorkCollectionPropertyAccessor" />
+    <bean type="ognl.PropertyAccessor" name="java.util.Iterator" class="com.opensymphony.xwork2.ognl.accessor.XWorkIteratorPropertyAccessor" />
+    <bean type="ognl.PropertyAccessor" name="java.util.List" class="com.opensymphony.xwork2.ognl.accessor.XWorkListPropertyAccessor" />
+    <bean type="ognl.PropertyAccessor" name="java.util.Map" class="com.opensymphony.xwork2.ognl.accessor.XWorkMapPropertyAccessor" />
+    <bean type="ognl.PropertyAccessor" name="java.lang.Object" class="com.opensymphony.xwork2.ognl.accessor.ObjectAccessor" />
+    <bean type="ognl.PropertyAccessor" name="java.util.Set" class="com.opensymphony.xwork2.ognl.accessor.XWorkCollectionPropertyAccessor" />
+
+</xwork>

--- a/core/src/test/resources/com/opensymphony/xwork2/config/providers/xwork-test-allowstatic-true.xml
+++ b/core/src/test/resources/com/opensymphony/xwork2/config/providers/xwork-test-allowstatic-true.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+-->
+<!DOCTYPE xwork PUBLIC
+    "-//Apache Struts//XWork 2.5//EN"
+    "http://struts.apache.org/dtds/xwork-2.5.dtd"
+ >
+
+<xwork>
+
+    <constant name="struts.devMode" value="false" />
+    <constant name="devMode" value="false" />
+    <constant name="struts.i18n.reload" value="false" />
+    <constant name="logMissingProperties" value="false" />
+    <constant name="enableOGNLExpressionCache" value="true" />
+    <constant name="enableOGNLEvalExpression" value="false" />
+    <constant name="reloadXmlConfiguration" value="false" />
+    <constant name="struts.ognl.allowStaticMethodAccess" value="true" />
+    <constant name="struts.enable.DynamicMethodInvocation" value="false" />
+    <constant name="struts.dispatcher.errorHandler" value="struts" />
+
+    <bean class="com.opensymphony.xwork2.ObjectFactory" name="default" />
+    <bean class="org.apache.struts2.views.freemarker.FreemarkerThemeTemplateLoader" />
+    <bean class="org.apache.struts2.views.freemarker.FreemarkerManager" name="default" />
+    <bean class="org.apache.struts2.views.velocity.VelocityManager" name="default" optional="true" />
+    <bean class="org.apache.struts2.components.template.TemplateEngineManager" />
+    <bean class="com.opensymphony.xwork2.conversion.impl.XWorkBasicConverter" />
+    <bean class="com.opensymphony.xwork2.ognl.OgnlUtil" />
+    <bean class="org.apache.struts2.views.jsp.ui.OgnlTool" />
+
+    <bean type="com.opensymphony.xwork2.ActionProxyFactory" name="default" class="org.apache.struts2.factory.StrutsActionProxyFactory"/>
+    <bean type="com.opensymphony.xwork2.FileManager" name="system" class="com.opensymphony.xwork2.util.fs.DefaultFileManager" scope="singleton"/>
+    <bean type="com.opensymphony.xwork2.FileManagerFactory" name="default" class="com.opensymphony.xwork2.util.fs.DefaultFileManagerFactory" scope="singleton"/>
+    <bean type="com.opensymphony.xwork2.LocalizedTextProvider" name="global-only" class="com.opensymphony.xwork2.util.GlobalLocalizedTextProvider" scope="singleton" />
+    <bean type="com.opensymphony.xwork2.LocalizedTextProvider" name="default" class="com.opensymphony.xwork2.util.StrutsLocalizedTextProvider" scope="singleton" />
+    <bean type="com.opensymphony.xwork2.TextProvider" name="system" class="com.opensymphony.xwork2.DefaultTextProvider" scope="singleton" />
+    <bean type="com.opensymphony.xwork2.conversion.ConversionAnnotationProcessor" name="default" class="com.opensymphony.xwork2.conversion.impl.DefaultConversionAnnotationProcessor" />
+    <bean type="com.opensymphony.xwork2.conversion.ConversionFileProcessor" name="default" class="com.opensymphony.xwork2.conversion.impl.DefaultConversionFileProcessor" />
+    <bean type="com.opensymphony.xwork2.conversion.ObjectTypeDeterminer" name="default" class="com.opensymphony.xwork2.conversion.impl.DefaultObjectTypeDeterminer"/>
+    <bean type="com.opensymphony.xwork2.conversion.TypeConverterCreator" name="default" class="com.opensymphony.xwork2.conversion.impl.DefaultTypeConverterCreator" />
+    <bean type="com.opensymphony.xwork2.conversion.TypeConverterHolder" name="default" class="com.opensymphony.xwork2.conversion.impl.DefaultTypeConverterHolder" />
+    <bean type="com.opensymphony.xwork2.conversion.impl.XWorkConverter" name="default" class="com.opensymphony.xwork2.conversion.impl.XWorkConverter" />
+
+    <bean type="com.opensymphony.xwork2.factory.ActionFactory" name="default" class="com.opensymphony.xwork2.factory.DefaultActionFactory" />
+    <bean type="com.opensymphony.xwork2.factory.ConverterFactory" name="default" class="com.opensymphony.xwork2.factory.DefaultConverterFactory" />
+    <bean type="com.opensymphony.xwork2.factory.ResultFactory" name="default" class="org.apache.struts2.factory.StrutsResultFactory" />
+    <bean type="com.opensymphony.xwork2.factory.UnknownHandlerFactory" name="default" class="com.opensymphony.xwork2.factory.DefaultUnknownHandlerFactory" />
+    <bean type="com.opensymphony.xwork2.factory.ValidatorFactory" name="default" class="com.opensymphony.xwork2.factory.DefaultValidatorFactory" />
+    <bean type="com.opensymphony.xwork2.factory.InterceptorFactory" name="default" class="com.opensymphony.xwork2.factory.DefaultInterceptorFactory" />
+    <bean type="com.opensymphony.xwork2.util.ValueStackFactory" name="default" class="com.opensymphony.xwork2.ognl.OgnlValueStackFactory" />
+    <bean type="com.opensymphony.xwork2.util.reflection.ReflectionProvider" name="default" class="com.opensymphony.xwork2.ognl.OgnlReflectionProvider" />
+
+    <bean type="ognl.MethodAccessor" name="java.lang.Object" class="com.opensymphony.xwork2.ognl.accessor.XWorkMethodAccessor" />
+    <bean type="ognl.MethodAccessor" name="com.opensymphony.xwork2.util.CompoundRoot" class="com.opensymphony.xwork2.ognl.accessor.CompoundRootAccessor" />
+    <bean type="ognl.PropertyAccessor" name="com.opensymphony.xwork2.util.CompoundRoot" class="com.opensymphony.xwork2.ognl.accessor.CompoundRootAccessor" />
+    <bean type="ognl.PropertyAccessor" name="org.apache.struts2.dispatcher.HttpParameters" class="com.opensymphony.xwork2.ognl.accessor.HttpParametersPropertyAccessor" />
+    <bean type="ognl.PropertyAccessor" name="com.opensymphony.xwork2.ognl.ObjectProxy" class="com.opensymphony.xwork2.ognl.accessor.ObjectProxyPropertyAccessor" />
+    <bean type="ognl.PropertyAccessor" name="org.apache.struts2.dispatcher.Parameter" class="com.opensymphony.xwork2.ognl.accessor.ParameterPropertyAccessor" />
+    <bean type="ognl.PropertyAccessor" name="java.util.ArrayList" class="com.opensymphony.xwork2.ognl.accessor.XWorkListPropertyAccessor" />
+    <bean type="ognl.PropertyAccessor" name="java.util.Collection" class="com.opensymphony.xwork2.ognl.accessor.XWorkCollectionPropertyAccessor" />
+    <bean type="ognl.PropertyAccessor" name="java.util.Enumeration" class="com.opensymphony.xwork2.ognl.accessor.XWorkEnumerationAccessor" />
+    <bean type="ognl.PropertyAccessor" name="java.util.HashMap" class="com.opensymphony.xwork2.ognl.accessor.XWorkMapPropertyAccessor" />
+    <bean type="ognl.PropertyAccessor" name="java.util.HashSet" class="com.opensymphony.xwork2.ognl.accessor.XWorkCollectionPropertyAccessor" />
+    <bean type="ognl.PropertyAccessor" name="java.util.Iterator" class="com.opensymphony.xwork2.ognl.accessor.XWorkIteratorPropertyAccessor" />
+    <bean type="ognl.PropertyAccessor" name="java.util.List" class="com.opensymphony.xwork2.ognl.accessor.XWorkListPropertyAccessor" />
+    <bean type="ognl.PropertyAccessor" name="java.util.Map" class="com.opensymphony.xwork2.ognl.accessor.XWorkMapPropertyAccessor" />
+    <bean type="ognl.PropertyAccessor" name="java.lang.Object" class="com.opensymphony.xwork2.ognl.accessor.ObjectAccessor" />
+    <bean type="ognl.PropertyAccessor" name="java.util.Set" class="com.opensymphony.xwork2.ognl.accessor.XWorkCollectionPropertyAccessor" />
+
+</xwork>

--- a/core/src/test/resources/com/opensymphony/xwork2/config/providers/xwork-test-devmode-true.xml
+++ b/core/src/test/resources/com/opensymphony/xwork2/config/providers/xwork-test-devmode-true.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+-->
+<!DOCTYPE xwork PUBLIC
+    "-//Apache Struts//XWork 2.5//EN"
+    "http://struts.apache.org/dtds/xwork-2.5.dtd"
+ >
+
+<xwork>
+
+    <constant name="struts.devMode" value="true" />
+    <constant name="devMode" value="true" />
+    <constant name="struts.i18n.reload" value="false" />
+    <constant name="logMissingProperties" value="false" />
+    <constant name="enableOGNLExpressionCache" value="true" />
+    <constant name="enableOGNLEvalExpression" value="false" />
+    <constant name="reloadXmlConfiguration" value="false" />
+    <constant name="struts.ognl.allowStaticMethodAccess" value="false" />
+    <constant name="struts.enable.DynamicMethodInvocation" value="false" />
+    <constant name="struts.dispatcher.errorHandler" value="struts" />
+
+    <bean class="com.opensymphony.xwork2.ObjectFactory" name="default" />
+    <bean class="org.apache.struts2.views.freemarker.FreemarkerThemeTemplateLoader" />
+    <bean class="org.apache.struts2.views.freemarker.FreemarkerManager" name="default" />
+    <bean class="org.apache.struts2.views.velocity.VelocityManager" name="default" optional="true" />
+    <bean class="org.apache.struts2.components.template.TemplateEngineManager" />
+    <bean class="com.opensymphony.xwork2.conversion.impl.XWorkBasicConverter" />
+    <bean class="com.opensymphony.xwork2.ognl.OgnlUtil" />
+    <bean class="org.apache.struts2.views.jsp.ui.OgnlTool" />
+
+    <bean type="com.opensymphony.xwork2.ActionProxyFactory" name="default" class="org.apache.struts2.factory.StrutsActionProxyFactory"/>
+    <bean type="com.opensymphony.xwork2.FileManager" name="system" class="com.opensymphony.xwork2.util.fs.DefaultFileManager" scope="singleton"/>
+    <bean type="com.opensymphony.xwork2.FileManagerFactory" name="default" class="com.opensymphony.xwork2.util.fs.DefaultFileManagerFactory" scope="singleton"/>
+    <bean type="com.opensymphony.xwork2.LocalizedTextProvider" name="global-only" class="com.opensymphony.xwork2.util.GlobalLocalizedTextProvider" scope="singleton" />
+    <bean type="com.opensymphony.xwork2.LocalizedTextProvider" name="default" class="com.opensymphony.xwork2.util.StrutsLocalizedTextProvider" scope="singleton" />
+    <bean type="com.opensymphony.xwork2.TextProvider" name="system" class="com.opensymphony.xwork2.DefaultTextProvider" scope="singleton" />
+    <bean type="com.opensymphony.xwork2.conversion.ConversionAnnotationProcessor" name="default" class="com.opensymphony.xwork2.conversion.impl.DefaultConversionAnnotationProcessor" />
+    <bean type="com.opensymphony.xwork2.conversion.ConversionFileProcessor" name="default" class="com.opensymphony.xwork2.conversion.impl.DefaultConversionFileProcessor" />
+    <bean type="com.opensymphony.xwork2.conversion.ObjectTypeDeterminer" name="default" class="com.opensymphony.xwork2.conversion.impl.DefaultObjectTypeDeterminer"/>
+    <bean type="com.opensymphony.xwork2.conversion.TypeConverterCreator" name="default" class="com.opensymphony.xwork2.conversion.impl.DefaultTypeConverterCreator" />
+    <bean type="com.opensymphony.xwork2.conversion.TypeConverterHolder" name="default" class="com.opensymphony.xwork2.conversion.impl.DefaultTypeConverterHolder" />
+    <bean type="com.opensymphony.xwork2.conversion.impl.XWorkConverter" name="default" class="com.opensymphony.xwork2.conversion.impl.XWorkConverter" />
+
+    <bean type="com.opensymphony.xwork2.factory.ActionFactory" name="default" class="com.opensymphony.xwork2.factory.DefaultActionFactory" />
+    <bean type="com.opensymphony.xwork2.factory.ConverterFactory" name="default" class="com.opensymphony.xwork2.factory.DefaultConverterFactory" />
+    <bean type="com.opensymphony.xwork2.factory.ResultFactory" name="default" class="org.apache.struts2.factory.StrutsResultFactory" />
+    <bean type="com.opensymphony.xwork2.factory.UnknownHandlerFactory" name="default" class="com.opensymphony.xwork2.factory.DefaultUnknownHandlerFactory" />
+    <bean type="com.opensymphony.xwork2.factory.ValidatorFactory" name="default" class="com.opensymphony.xwork2.factory.DefaultValidatorFactory" />
+    <bean type="com.opensymphony.xwork2.factory.InterceptorFactory" name="default" class="com.opensymphony.xwork2.factory.DefaultInterceptorFactory" />
+    <bean type="com.opensymphony.xwork2.util.ValueStackFactory" name="default" class="com.opensymphony.xwork2.ognl.OgnlValueStackFactory" />
+    <bean type="com.opensymphony.xwork2.util.reflection.ReflectionProvider" name="default" class="com.opensymphony.xwork2.ognl.OgnlReflectionProvider" />
+
+    <bean type="ognl.MethodAccessor" name="java.lang.Object" class="com.opensymphony.xwork2.ognl.accessor.XWorkMethodAccessor" />
+    <bean type="ognl.MethodAccessor" name="com.opensymphony.xwork2.util.CompoundRoot" class="com.opensymphony.xwork2.ognl.accessor.CompoundRootAccessor" />
+    <bean type="ognl.PropertyAccessor" name="com.opensymphony.xwork2.util.CompoundRoot" class="com.opensymphony.xwork2.ognl.accessor.CompoundRootAccessor" />
+    <bean type="ognl.PropertyAccessor" name="org.apache.struts2.dispatcher.HttpParameters" class="com.opensymphony.xwork2.ognl.accessor.HttpParametersPropertyAccessor" />
+    <bean type="ognl.PropertyAccessor" name="com.opensymphony.xwork2.ognl.ObjectProxy" class="com.opensymphony.xwork2.ognl.accessor.ObjectProxyPropertyAccessor" />
+    <bean type="ognl.PropertyAccessor" name="org.apache.struts2.dispatcher.Parameter" class="com.opensymphony.xwork2.ognl.accessor.ParameterPropertyAccessor" />
+    <bean type="ognl.PropertyAccessor" name="java.util.ArrayList" class="com.opensymphony.xwork2.ognl.accessor.XWorkListPropertyAccessor" />
+    <bean type="ognl.PropertyAccessor" name="java.util.Collection" class="com.opensymphony.xwork2.ognl.accessor.XWorkCollectionPropertyAccessor" />
+    <bean type="ognl.PropertyAccessor" name="java.util.Enumeration" class="com.opensymphony.xwork2.ognl.accessor.XWorkEnumerationAccessor" />
+    <bean type="ognl.PropertyAccessor" name="java.util.HashMap" class="com.opensymphony.xwork2.ognl.accessor.XWorkMapPropertyAccessor" />
+    <bean type="ognl.PropertyAccessor" name="java.util.HashSet" class="com.opensymphony.xwork2.ognl.accessor.XWorkCollectionPropertyAccessor" />
+    <bean type="ognl.PropertyAccessor" name="java.util.Iterator" class="com.opensymphony.xwork2.ognl.accessor.XWorkIteratorPropertyAccessor" />
+    <bean type="ognl.PropertyAccessor" name="java.util.List" class="com.opensymphony.xwork2.ognl.accessor.XWorkListPropertyAccessor" />
+    <bean type="ognl.PropertyAccessor" name="java.util.Map" class="com.opensymphony.xwork2.ognl.accessor.XWorkMapPropertyAccessor" />
+    <bean type="ognl.PropertyAccessor" name="java.lang.Object" class="com.opensymphony.xwork2.ognl.accessor.ObjectAccessor" />
+    <bean type="ognl.PropertyAccessor" name="java.util.Set" class="com.opensymphony.xwork2.ognl.accessor.XWorkCollectionPropertyAccessor" />
+
+</xwork>


### PR DESCRIPTION
Updates and cleanup for some configuration-related items.
- Made several attributes final.
- Added limiter logic to the setting of certain configuration elements, and increased logging around them.
- Updated unit tests impacted by the limiter logic, including minor typo fixes and locale consistency.
- Minor cleanup while making the changes.