### PR TITLE
Update Struts 2.5.19 to use latest OGNL 3.1.x release available.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <spring.platformVersion>4.3.20.RELEASE</spring.platformVersion>
-        <ognl.version>3.1.18</ognl.version>
+        <ognl.version>3.1.21</ognl.version>
         <asm.version>5.2</asm.version>
         <tiles.version>3.0.8</tiles.version>
         <tiles-request.version>1.0.7</tiles-request.version>


### PR DESCRIPTION
Update Struts 2.5.19 to use latest OGNL 3.1.x release available.

Refers [WW-4993](https://issues.apache.org/jira/browse/WW-4993)