### PR TITLE
Enhancement for s:set tag to allow better tag body whitespace control.

### DIFF
--- a/core/src/main/java/org/apache/struts2/components/Set.java
+++ b/core/src/main/java/org/apache/struts2/components/Set.java
@@ -83,6 +83,7 @@ import com.opensymphony.xwork2.util.ValueStack;
 public class Set extends ContextBean {
     protected String scope;
     protected String value;
+    protected boolean trimBody = true;
 
     public Set(ValueStack stack) {
         super(stack);
@@ -134,6 +135,11 @@ public class Set extends ContextBean {
     @StrutsTagAttribute(description="The value that is assigned to the variable named <i>name</i>")
     public void setValue(String value) {
         this.value = value;
+    }
+
+    @StrutsTagAttribute(description="Set to false to prevent the default whitespace-trim of this tag's body content", type="Boolean", defaultValue="true")
+    public void setTrimBody(boolean trimBody) {
+        this.trimBody = trimBody;
     }
 
     @Override

--- a/core/src/main/java/org/apache/struts2/views/jsp/SetTag.java
+++ b/core/src/main/java/org/apache/struts2/views/jsp/SetTag.java
@@ -35,6 +35,7 @@ public class SetTag extends ContextBeanTag {
 
     protected String scope;
     protected String value;
+    protected boolean trimBody = true;
 
     public Component getBean(ValueStack stack, HttpServletRequest req, HttpServletResponse res) {
         return new Set(stack);
@@ -58,5 +59,18 @@ public class SetTag extends ContextBeanTag {
 
     public void setValue(String value) {
         this.value = value;
+    }
+
+    public void setTrimBody(boolean trimBody) {
+        this.trimBody = trimBody;
+}
+
+    @Override
+    protected String getBody() {
+        if (trimBody) {
+            return super.getBody();
+        } else {
+            return (bodyContent == null ? "" : bodyContent.getString());
+        }
     }
 }

--- a/core/src/test/java/org/apache/struts2/views/jsp/SetTagTest.java
+++ b/core/src/test/java/org/apache/struts2/views/jsp/SetTagTest.java
@@ -18,6 +18,8 @@
  */
 package org.apache.struts2.views.jsp;
 
+import com.mockobjects.servlet.MockJspWriter;
+import java.io.IOException;
 import javax.servlet.jsp.JspException;
 
 
@@ -81,6 +83,42 @@ public class SetTagTest extends AbstractUITagTest {
         tag.doStartTag();
         tag.doEndTag();
         assertEquals(chewie, context.get("chewie"));
+    }
+
+    public void testSetTrimBody() throws JspException, IOException {
+        final String beginEndSpaceString = "  Preceding and trailing spaces.  ";
+        final String trimmedBeginEndSpaceString = beginEndSpaceString.trim();
+        StrutsMockBodyContent mockBodyContent;
+
+        tag.setName("foo");
+        tag.setValue(null);
+        // Do not set any value - default for tag should be true
+        mockBodyContent = new StrutsMockBodyContent(new MockJspWriter());
+        mockBodyContent.setString(beginEndSpaceString);
+        tag.setBodyContent(mockBodyContent);
+        tag.doStartTag();
+        tag.doEndTag();
+        assertEquals(trimmedBeginEndSpaceString, context.get("foo"));
+
+        tag.setName("foo");
+        tag.setValue(null);
+        tag.setTrimBody(true);
+        mockBodyContent = new StrutsMockBodyContent(new MockJspWriter());
+        mockBodyContent.setString(beginEndSpaceString);
+        tag.setBodyContent(mockBodyContent);
+        tag.doStartTag();
+        tag.doEndTag();
+        assertEquals(trimmedBeginEndSpaceString, context.get("foo"));
+
+        tag.setName("foo");
+        tag.setValue(null);
+        tag.setTrimBody(false);
+        mockBodyContent = new StrutsMockBodyContent(new MockJspWriter());
+        mockBodyContent.setString(beginEndSpaceString);
+        tag.setBodyContent(mockBodyContent);
+        tag.doStartTag();
+        tag.doEndTag();
+        assertEquals(beginEndSpaceString, context.get("foo"));
     }
 
     protected void setUp() throws Exception {


### PR DESCRIPTION
Enhancement for `s:set` tag to allow better tag body whitespace control.
- Allow disabling of the default body whitespace trim behaviour.  
- Forward port change from PR #296 for WW-4995 into master (2.6)