### PR TITLE
Address devMode log flooding concern raised by Greg Huber (on Dev List)

### DIFF
--- a/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlUtil.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlUtil.java
@@ -84,10 +84,6 @@ public class OgnlUtil {
     @Inject(XWorkConstants.DEV_MODE)
     protected void setDevMode(String mode) {
         this.devMode = BooleanUtils.toBoolean(mode);
-        if (this.devMode) {
-            LOG.warn("Setting development mode [{}] affects the safety of your application!",
-                        this.devMode);
-        }
     }
 
     @Inject(XWorkConstants.ENABLE_OGNL_EXPRESSION_CACHE)
@@ -178,20 +174,11 @@ public class OgnlUtil {
     @Inject(value = XWorkConstants.ALLOW_STATIC_METHOD_ACCESS, required = false)
     protected void setAllowStaticMethodAccess(String allowStaticMethodAccess) {
         this.allowStaticMethodAccess = BooleanUtils.toBoolean(allowStaticMethodAccess);
-        if (this.allowStaticMethodAccess) {
-            LOG.warn("Setting allow static method access [{}] affects the safety of your application!",
-                        this.allowStaticMethodAccess);
-        }
     }
 
     @Inject(value = StrutsConstants.STRUTS_DISALLOW_PROXY_MEMBER_ACCESS, required = false)
     protected void setDisallowProxyMemberAccess(String disallowProxyMemberAccess) {
-
         this.disallowProxyMemberAccess = Boolean.parseBoolean(disallowProxyMemberAccess);
-        if (this.disallowProxyMemberAccess == false) {
-            LOG.warn("Setting disallow proxy member access [{}] should only be done intentionally!",
-                        this.disallowProxyMemberAccess);
-        }
     }
 
     public boolean isDisallowProxyMemberAccess() {

--- a/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlValueStack.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlValueStack.java
@@ -40,7 +40,6 @@ import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Pattern;
 
 /**
@@ -61,12 +60,6 @@ public class OgnlValueStack implements Serializable, ValueStack, ClearableValueS
     private static final long serialVersionUID = 370737852934925530L;
 
     private static final String MAP_IDENTIFIER_KEY = "com.opensymphony.xwork2.util.OgnlValueStack.MAP_IDENTIFIER_KEY";
-
-    private static final String EXCEPTION_EVALUATING_EXPRESSION_STR = "Caught an exception while evaluating expression '{}' against value stack";
-
-    private static final String DEVMODE_SAFETY_STR = "Setting development mode [{}] affects the safety of your application!";
-
-    private static final AtomicBoolean INITIAL_WARNING_FOR_DEV_MODE = new AtomicBoolean(true);
 
     protected CompoundRoot root;
     protected transient Map<String, Object> context;
@@ -111,15 +104,6 @@ public class OgnlValueStack implements Serializable, ValueStack, ClearableValueS
     @Inject(XWorkConstants.DEV_MODE)
     protected void setDevMode(String mode) {
         this.devMode = BooleanUtils.toBoolean(mode);
-        if (this.devMode) {
-            final boolean initialWarningForDevMode = INITIAL_WARNING_FOR_DEV_MODE.get();
-            if (initialWarningForDevMode) {
-                INITIAL_WARNING_FOR_DEV_MODE.set(false);
-                LOG.warn(DEVMODE_SAFETY_STR, this.devMode);
-            } else {
-                LOG.trace(DEVMODE_SAFETY_STR, this.devMode);
-            }
-        }
     }
 
     @Inject(value = "logMissingProperties", required = false)
@@ -172,8 +156,6 @@ public class OgnlValueStack implements Serializable, ValueStack, ClearableValueS
     public void setParameter(String expr, Object value) {
         setValue(expr, value, devMode);
     }
-
-    /**
 
     /**
      * @see com.opensymphony.xwork2.util.ValueStack#setValue(java.lang.String, java.lang.Object)
@@ -396,10 +378,10 @@ public class OgnlValueStack implements Serializable, ValueStack, ClearableValueS
      */
     private void logLookupFailure(String expr, Exception e) {
         if (devMode) {
-            LOG.warn(EXCEPTION_EVALUATING_EXPRESSION_STR, expr, e);
+            LOG.warn("Caught an exception while evaluating expression '{}' against value stack", expr, e);
             LOG.warn("NOTE: Previous warning message was issued due to devMode set to true.");
         } else {
-            LOG.debug(EXCEPTION_EVALUATING_EXPRESSION_STR, expr, e);
+            LOG.debug("Caught an exception while evaluating expression '{}' against value stack", expr, e);
         }
     }
 

--- a/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlValueStackFactory.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlValueStackFactory.java
@@ -64,10 +64,6 @@ public class OgnlValueStackFactory implements ValueStackFactory {
     @Inject(value="allowStaticMethodAccess", required=false)
     protected void setAllowStaticMethodAccess(String allowStaticMethodAccess) {
         this.allowStaticMethodAccess = BooleanUtils.toBoolean(allowStaticMethodAccess);
-        if (this.allowStaticMethodAccess) {
-            LOG.warn("Setting allow static method access [{}] affects the safety of your application!",
-                        this.allowStaticMethodAccess);
-        }
     }
 
     public ValueStack createValueStack() {

--- a/core/src/main/java/com/opensymphony/xwork2/ognl/accessor/CompoundRootAccessor.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/accessor/CompoundRootAccessor.java
@@ -68,10 +68,6 @@ public class CompoundRootAccessor implements PropertyAccessor, MethodAccessor, C
     @Inject(XWorkConstants.DEV_MODE)
     protected void setDevMode(String mode) {
         this.devMode = BooleanUtils.toBoolean(mode);
-        if (this.devMode) {
-            LOG.warn("Setting development mode [{}] affects the safety of your application!",
-                        this.devMode);
-        }
     }
 
     public void setProperty(Map context, Object target, Object name, Object value) throws OgnlException {

--- a/core/src/main/java/com/opensymphony/xwork2/security/DefaultAcceptedPatternsChecker.java
+++ b/core/src/main/java/com/opensymphony/xwork2/security/DefaultAcceptedPatternsChecker.java
@@ -73,8 +73,7 @@ public class DefaultAcceptedPatternsChecker implements AcceptedPatternsChecker {
         if (acceptedPatterns == null) {
             // Limit unwanted log entries (for 1st call, acceptedPatterns null)
             LOG.debug("Sets accepted patterns to [{}], note this impacts the safety of your application!", patterns);
-        }
-        else {
+        } else {
             LOG.warn("Replacing accepted patterns [{}] with [{}], be aware that this affects all instances and safety of your application!",
                         acceptedPatterns, patterns);
         }

--- a/core/src/main/java/com/opensymphony/xwork2/security/DefaultExcludedPatternsChecker.java
+++ b/core/src/main/java/com/opensymphony/xwork2/security/DefaultExcludedPatternsChecker.java
@@ -51,8 +51,7 @@ public class DefaultExcludedPatternsChecker implements ExcludedPatternsChecker {
         if (excludedPatterns != null && excludedPatterns.size() > 0) {
             LOG.warn("Overriding excluded patterns [{}] with [{}], be aware that this affects all instances and safety of your application!",
                         excludedPatterns, excludePatterns);
-        }
-        else {
+        } else {
             // Limit unwanted log entries (when excludedPatterns null/empty - usually 1st call)
             LOG.debug("Overriding excluded patterns with [{}]", excludePatterns);
         }
@@ -76,9 +75,6 @@ public class DefaultExcludedPatternsChecker implements ExcludedPatternsChecker {
             LOG.debug("DMI is disabled, adding DMI related excluded patterns");
             setAdditionalExcludePatterns("^(action|method):.*");
         }
-        else {
-            LOG.warn("DMI is enabled, *NOT* adding DMI related excluded patterns");
-        }
     }
 
     public void setExcludedPatterns(String commaDelimitedPatterns) {
@@ -93,8 +89,7 @@ public class DefaultExcludedPatternsChecker implements ExcludedPatternsChecker {
         if (excludedPatterns != null && excludedPatterns.size() > 0) {
             LOG.warn("Replacing excluded patterns [{}] with [{}], be aware that this affects all instances and safety of your application!",
                         excludedPatterns, patterns);
-        }
-        else {
+        } else {
             // Limit unwanted log entries (when excludedPatterns null/empty - usually 1st call)
             LOG.debug("Sets excluded patterns to [{}]", patterns);
         }


### PR DESCRIPTION
Address `devMode` log flooding concern raised by Greg Huber in the Struts Dev List review of the 2.5.19 test build.
Changes:
- Introduce a static count-limiter for the `devMode` set warning in `OgnlValueStack`.  It _limits the total number of log warnings produced to 250 total_, after which it switches to trace level logs to avoid log flooding.

This is a single change which should be safe enough to include in a revised 2.5.19 build (and cherry-picked into the 2.6 master branch as well).  Since the log flooding could be somewhat annoying to developers, a compromise like this might be a reasonable response.