### PR TITLE
Equivalent to PR#309, but for the master (2.6.x) branch.

### DIFF
--- a/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlUtil.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlUtil.java
@@ -83,10 +83,6 @@ public class OgnlUtil {
     @Inject(StrutsConstants.STRUTS_DEVMODE)
     protected void setDevMode(String mode) {
         this.devMode = BooleanUtils.toBoolean(mode);
-        if (this.devMode) {
-            LOG.warn("Setting development mode [{}] affects the safety of your application!",
-                        this.devMode);
-        }
     }
 
     @Inject(StrutsConstants.STRUTS_ENABLE_OGNL_EXPRESSION_CACHE)
@@ -177,20 +173,11 @@ public class OgnlUtil {
     @Inject(value = StrutsConstants.STRUTS_ALLOW_STATIC_METHOD_ACCESS, required = false)
     protected void setAllowStaticMethodAccess(String allowStaticMethodAccess) {
         this.allowStaticMethodAccess = BooleanUtils.toBoolean(allowStaticMethodAccess);
-        if (this.allowStaticMethodAccess) {
-            LOG.warn("Setting allow static method access [{}] affects the safety of your application!",
-                        this.allowStaticMethodAccess);
-        }
     }
 
     @Inject(value = StrutsConstants.STRUTS_DISALLOW_PROXY_MEMBER_ACCESS, required = false)
     protected void setDisallowProxyMemberAccess(String disallowProxyMemberAccess) {
-
         this.disallowProxyMemberAccess = Boolean.parseBoolean(disallowProxyMemberAccess);
-        if (this.disallowProxyMemberAccess == false) {
-            LOG.warn("Setting disallow proxy member access [{}] should only be done intentionally!",
-                        this.disallowProxyMemberAccess);
-        }
     }
 
     public boolean isDisallowProxyMemberAccess() {

--- a/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlValueStack.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlValueStack.java
@@ -103,10 +103,6 @@ public class OgnlValueStack implements Serializable, ValueStack, ClearableValueS
     @Inject(StrutsConstants.STRUTS_DEVMODE)
     protected void setDevMode(String mode) {
         this.devMode = BooleanUtils.toBoolean(mode);
-        if (this.devMode) {
-            LOG.warn("Setting development mode [{}] affects the safety of your application!",
-                        this.devMode);
-        }
     }
 
     @Inject(value = "logMissingProperties", required = false)
@@ -159,8 +155,6 @@ public class OgnlValueStack implements Serializable, ValueStack, ClearableValueS
     public void setParameter(String expr, Object value) {
         setValue(expr, value, devMode);
     }
-
-    /**
 
     /**
      * @see com.opensymphony.xwork2.util.ValueStack#setValue(java.lang.String, java.lang.Object)

--- a/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlValueStackFactory.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlValueStackFactory.java
@@ -64,10 +64,6 @@ public class OgnlValueStackFactory implements ValueStackFactory {
     @Inject(value="allowStaticMethodAccess", required=false)
     protected void setAllowStaticMethodAccess(String allowStaticMethodAccess) {
         this.allowStaticMethodAccess = BooleanUtils.toBoolean(allowStaticMethodAccess);
-        if (this.allowStaticMethodAccess) {
-            LOG.warn("Setting allow static method access [{}] affects the safety of your application!",
-                        this.allowStaticMethodAccess);
-        }
     }
 
     public ValueStack createValueStack() {

--- a/core/src/main/java/com/opensymphony/xwork2/ognl/accessor/CompoundRootAccessor.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/accessor/CompoundRootAccessor.java
@@ -68,10 +68,6 @@ public class CompoundRootAccessor implements PropertyAccessor, MethodAccessor, C
     @Inject(StrutsConstants.STRUTS_DEVMODE)
     protected void setDevMode(String mode) {
         this.devMode = BooleanUtils.toBoolean(mode);
-        if (this.devMode) {
-            LOG.warn("Setting development mode [{}] affects the safety of your application!",
-                        this.devMode);
-        }
     }
 
     public void setProperty(Map context, Object target, Object name, Object value) throws OgnlException {

--- a/core/src/main/java/com/opensymphony/xwork2/security/DefaultAcceptedPatternsChecker.java
+++ b/core/src/main/java/com/opensymphony/xwork2/security/DefaultAcceptedPatternsChecker.java
@@ -73,8 +73,7 @@ public class DefaultAcceptedPatternsChecker implements AcceptedPatternsChecker {
         if (acceptedPatterns == null) {
             // Limit unwanted log entries (for 1st call, acceptedPatterns null)
             LOG.debug("Sets accepted patterns to [{}], note this impacts the safety of your application!", patterns);
-        }
-        else {
+        } else {
             LOG.warn("Replacing accepted patterns [{}] with [{}], be aware that this affects all instances and safety of your application!",
                         acceptedPatterns, patterns);
         }

--- a/core/src/main/java/com/opensymphony/xwork2/security/DefaultExcludedPatternsChecker.java
+++ b/core/src/main/java/com/opensymphony/xwork2/security/DefaultExcludedPatternsChecker.java
@@ -50,8 +50,7 @@ public class DefaultExcludedPatternsChecker implements ExcludedPatternsChecker {
         if (excludedPatterns != null && excludedPatterns.size() > 0) {
             LOG.warn("Overriding excluded patterns [{}] with [{}], be aware that this affects all instances and safety of your application!",
                         excludedPatterns, excludePatterns);
-        }
-        else {
+        } else {
             // Limit unwanted log entries (when excludedPatterns null/empty - usually 1st call)
             LOG.debug("Overriding excluded patterns with [{}]", excludePatterns);
         }
@@ -75,9 +74,6 @@ public class DefaultExcludedPatternsChecker implements ExcludedPatternsChecker {
             LOG.debug("DMI is disabled, adding DMI related excluded patterns");
             setAdditionalExcludePatterns("^(action|method):.*");
         }
-        else {
-            LOG.warn("DMI is enabled, *NOT* adding DMI related excluded patterns");
-        }
     }
 
     public void setExcludedPatterns(String commaDelimitedPatterns) {
@@ -92,8 +88,7 @@ public class DefaultExcludedPatternsChecker implements ExcludedPatternsChecker {
         if (excludedPatterns != null && excludedPatterns.size() > 0) {
             LOG.warn("Replacing excluded patterns [{}] with [{}], be aware that this affects all instances and safety of your application!",
                         excludedPatterns, patterns);
-        }
-        else {
+        } else {
             // Limit unwanted log entries (when excludedPatterns null/empty - usually 1st call)
             LOG.debug("Sets excluded patterns to [{}]", patterns);
         }


### PR DESCRIPTION
Equivalent to PR#309 (for 2.5.x), but this one is for the master (2.6.x) branch.
- Removed most of the logging added in PR#292.
- Left the added logging for the `setExcludedPatterns `and `setAcceptedPatterns `methods in their respective modules (please see PR#309 for justification).  Made the if-else blocks consistent with preferred styling for the log blocks.
- Removed a dangling "/\*\*" start comment tag with no proper close (and the whitespace between it and the next "/\*\*") in the `OgnlValueStack `module.