### PR TITLE
WW-5005 upgrade to ASM 7

### DIFF
--- a/plugins/convention/src/main/java/org/apache/struts2/convention/DefaultClassFinder.java
+++ b/plugins/convention/src/main/java/org/apache/struts2/convention/DefaultClassFinder.java
@@ -475,7 +475,7 @@ public class DefaultClassFinder implements ClassFinder {
         private ClassFinder classFinder;
 
         public InfoBuildingVisitor(ClassFinder classFinder) {
-            super(Opcodes.ASM5);
+            super(Opcodes.ASM7);
             this.classFinder = classFinder;
         }
 
@@ -556,7 +556,7 @@ public class DefaultClassFinder implements ClassFinder {
         private Info info;
 
         public InfoBuildingMethodVisitor() {
-            super(Opcodes.ASM5);
+            super(Opcodes.ASM7);
         }
 
         public InfoBuildingMethodVisitor(Info info) {

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
 
         <spring.platformVersion>4.3.20.RELEASE</spring.platformVersion>
         <ognl.version>3.1.21</ognl.version>
-        <asm.version>5.2</asm.version>
+        <asm.version>7.0</asm.version>
         <tiles.version>3.0.8</tiles.version>
         <tiles-request.version>1.0.7</tiles-request.version>
         <log4j2.version>2.11.1</log4j2.version>


### PR DESCRIPTION
fixes WW-5005

According to ASM7's source codes, it seems it uses passed `api` version only to check if it should throw an unsupported exception or not (i.e. doesn't have any effect on functionality and somehow is just a validation). So, as we upgrade to asm.version=7.0 for default then I think it's OK to upgrade `Opcodes.ASM5` to `Opcodes.ASM7` as well. It only breaks when user manually exclude ASM7 dependency with an older version which is not usually expected.