### PR TITLE
Back-port WW-5012 improvements from PR#323 to 2.5.x:

### DIFF
--- a/core/src/main/java/com/opensymphony/xwork2/ognl/SecurityMemberAccess.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/SecurityMemberAccess.java
@@ -58,13 +58,20 @@ public class SecurityMemberAccess extends DefaultMemberAccess {
         this.allowStaticMethodAccess = allowStaticMethodAccess;
     }
 
-    public boolean getAllowStaticMethodAccess() {
+    public final boolean getAllowStaticMethodAccess() {
         return allowStaticMethodAccess;
     }
 
     @Override
     public boolean isAccessible(Map context, Object target, Member member, String propertyName) {
         LOG.debug("Checking access for [target: {}, member: {}, property: {}]", target, member, propertyName);
+
+        final int memberModifiers = member.getModifiers();
+
+        if (!checkPublicMemberAccess(memberModifiers)) {
+            LOG.trace("Access to non-public [{}] is blocked!", member);
+            return false;
+        }
 
         final Class memberClass = member.getDeclaringClass();
         Class targetClass = (target != null ? target.getClass() : memberClass);  // Note: target,propertyName may be null (static field checks OGNL 3.1.19+)
@@ -74,11 +81,19 @@ public class SecurityMemberAccess extends DefaultMemberAccess {
             return true;
         }
 
-        if (Modifier.isStatic(member.getModifiers()) && allowStaticMethodAccess) {
-            LOG.debug("Support for accessing static methods [target: {}, targetClass: {}, member: {}, property: {}] is deprecated!",
-                    target, targetClass, member, propertyName);
-            if (!isClassExcluded(memberClass)) {
-                targetClass = memberClass;
+        if (!checkStaticMethodAccess(member, memberModifiers)) {
+            LOG.warn("Access to static method [{}] is blocked!", member);
+            return false;
+        }
+
+        if (isClassExcluded(memberClass)) {
+            LOG.warn("Declaring class of member type [{}] is excluded!", member);
+            return false;
+        } else {
+            if (Modifier.isStatic(memberModifiers) && allowStaticMethodAccess) {
+                LOG.trace("Support for accessing static methods [target: {}, targetClass: {}, member: {}, property: {}] is deprecated!",
+                        target, targetClass, member, propertyName);
+                targetClass = memberClass;  // Check above guarantees !isClassExcluded(memberClass) true
             }
         }
 
@@ -93,24 +108,8 @@ public class SecurityMemberAccess extends DefaultMemberAccess {
             return false;
         }
 
-        if (isClassExcluded(memberClass)) {
-            LOG.warn("Declaring class of member type [{}] is excluded!", member);
-            return false;
-        }
-
         if (disallowProxyMemberAccess && ProxyUtil.isProxyMember(member, target)) {
             LOG.warn("Access to proxy is blocked! Target class [{}] of target [{}], member [{}]", targetClass, target, member);
-            return false;
-        }
-
-        boolean allow = true;
-        if (!checkStaticMethodAccess(member)) {
-            LOG.warn("Access to static [{}] is blocked!", member);
-            allow = false;
-        }
-
-        //failed static test
-        if (!allow) {
             return false;
         }
 
@@ -118,13 +117,38 @@ public class SecurityMemberAccess extends DefaultMemberAccess {
         return super.isAccessible(context, target, member, propertyName) && isAcceptableProperty(propertyName);
     }
 
-    protected boolean checkStaticMethodAccess(Member member) {
-        int modifiers = member.getModifiers();
-        if (Modifier.isStatic(modifiers)) {
+    /**
+     * Check access for static method (via modifiers).
+     * 
+     * Note: For non-static members, the result is always true.
+     * 
+     * @param member
+     * @param memberModifiers
+     * 
+     * @return
+     */
+    protected boolean checkStaticMethodAccess(Member member, int memberModifiers) {
+        if (Modifier.isStatic(memberModifiers) && !(member instanceof Field)) {
+            if (allowStaticMethodAccess) {
+                LOG.debug("Support for accessing static methods [member: {}] is deprecated!", member);
+            }
             return allowStaticMethodAccess;
         } else {
             return true;
         }
+    }
+
+    /**
+     * Check access for public members (via modifiers)
+     * 
+     * Returns true if-and-only-if the member is public.
+     * 
+     * @param memberModifiers
+     * 
+     * @return
+     */
+    protected boolean checkPublicMemberAccess(int memberModifiers) {
+        return Modifier.isPublic(memberModifiers);
     }
 
     protected boolean checkEnumAccess(Object target, Member member) {


### PR DESCRIPTION
Back-port WW-5012 improvements from PR#323 to 2.5.x:
- Back-port improvements from PR#323:
  - Re-order SecurityMemberAccess to make public access check the 1st check.
  - Improvements to checkStaticMethodAccess().
- Back-port improvements from PR#320 that aligned with PR#323's enhancement:
  - Make one public getter final.
  - Brought additional ordering improvements that align and make 2.5.x's implementation easier to maintain.
- Two improvements resulted directly from the back-porting:
  - Eliminated unnecessary boolean allow flag within the access check.
  - Eliminated a redundant call to !isClassExcluded(memberClass), implicitly possible due to re-ordering.