### PR TITLE
Minor config fixes for the Showcase Application in 2.5.x:

### DIFF
--- a/apps/showcase/src/main/resources/struts-fileupload.xml
+++ b/apps/showcase/src/main/resources/struts-fileupload.xml
@@ -40,6 +40,7 @@
 		</action>
 		
 		<action name="doMultipleUploadUsingList" class="org.apache.struts2.showcase.fileupload.MultipleFileUploadUsingListAction" method="upload">
+                        <result name="input">/WEB-INF/fileupload/multipleUploadUsingList.jsp</result>
 			<result>/WEB-INF/fileupload/multiple-success.jsp</result>
 		</action>
 
@@ -49,6 +50,7 @@
 		</action>
 
 		<action name="doMultipleUploadUsingArray" class="org.apache.struts2.showcase.fileupload.MultipleFileUploadUsingArrayAction" method="upload">
+                        <result name="input">/WEB-INF/fileupload/multipleUploadUsingArray.jsp</result>
 			<result>/WEB-INF/fileupload/multiple-success.jsp</result>
 		</action>
 

--- a/apps/showcase/src/main/resources/struts-token.xml
+++ b/apps/showcase/src/main/resources/struts-token.xml
@@ -48,7 +48,7 @@
             <interceptor-ref name="defaultStack"/>
             <interceptor-ref name="token"/>
             <result name="invalid.token">/WEB-INF/token/doublePost.jsp</result>
-            <result name="success" type="redirect">/WEB-INF/token/transferDone.jsp</result>
+            <result name="success">/WEB-INF/token/transferDone.jsp</result>
         </action>
 
 
@@ -62,7 +62,7 @@
             <interceptor-ref name="defaultStack"/>
             <interceptor-ref name="tokenSession"/>
             <result name="invalid.token">/WEB-INF/token/doublePost.jsp</result>
-            <result name="success" type="redirect">/WEB-INF/token/transferDone.jsp</result>
+            <result name="success">/WEB-INF/token/transferDone.jsp</result>
         </action>
 
 

--- a/apps/showcase/src/main/resources/struts-validation.xml
+++ b/apps/showcase/src/main/resources/struts-validation.xml
@@ -34,28 +34,28 @@
 
 	<package name="validation" extends="json-default" namespace="/validation">
         <action name="index">
-            <result>/WEB-INF/validation/index.jsp</result>
+            <result>index.jsp</result>
         </action>
 
 	    <action name="quizBasic" class="org.apache.struts2.showcase.validation.QuizAction">
-            <result name="input">quiz-basic.jsp</result>
-            <result>quiz-success.jsp</result>
+            <result name="input">/WEB-INF/validation/quiz-basic.jsp</result>
+            <result>/WEB-INF/validation/quiz-success.jsp</result>
         </action>
 
         <action name="quizClient" class="org.apache.struts2.showcase.validation.QuizAction">
-            <result name="input">quiz-client.jsp</result>
-            <result>quiz-success.jsp</result>
+            <result name="input">/WEB-INF/validation/quiz-client.jsp</result>
+            <result>/WEB-INF/validation/quiz-success.jsp</result>
         </action>
 
         <action name="quizClientCss" class="org.apache.struts2.showcase.validation.QuizAction">
-            <result name="input">quiz-client-css.jsp</result>
-            <result>quiz-success.jsp</result>
+            <result name="input">/WEB-INF/validation/quiz-client-css.jsp</result>
+            <result>/WEB-INF/validation/quiz-success.jsp</result>
         </action>
 
         <action name="quizAjax" class="org.apache.struts2.showcase.validation.QuizAction">
             <interceptor-ref name="jsonValidationWorkflowStack"/>
-            <result name="input">quiz-ajax.jsp</result>
-            <result>quiz-success.jsp</result>
+            <result name="input">/WEB-INF/validation/quiz-ajax.jsp</result>
+            <result>/WEB-INF/validation/quiz-success.jsp</result>
         </action>
 
 		<!-- =========================================== -->

--- a/apps/showcase/src/main/webapp/WEB-INF/fileupload/multiple-success.jsp
+++ b/apps/showcase/src/main/webapp/WEB-INF/fileupload/multiple-success.jsp
@@ -1,0 +1,65 @@
+<!--
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*  http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+-->
+<%@ page
+	language="java" 
+	contentType="text/html; charset=UTF-8"
+    pageEncoding="UTF-8"%>
+<%@ taglib prefix="s" uri="/struts-tags" %>
+<html>
+<head>
+	<title>Struts2 Showcase - Fileupload sample - Multiple fileupload</title>
+</head>
+
+<body>
+<div class="page-header">
+	<h1>Fileupload sample - Multiple fileupload</h1>
+</div>
+
+<div class="container-fluid">
+<s:iterator var="counter" begin="1" end="3">
+	<!-- Mechanism for display to work with upload both as an array and list in a single JSP (a bit ugly).
+	     Note: Output "index" doesn't always match if the input is "sparse". --> 
+	<s:if test="%{#counter <= upload.length}">
+		<s:set var="displayContent" value="true" />
+	</s:if>
+	<s:elseif test="%{#counter <= upload.size}">
+		<s:set var="displayContent" value="true" />
+	</s:elseif>
+	<s:else>
+		<s:set var="displayContent" value="false" />
+	</s:else>
+	<s:if test="%{#displayContent == true}">
+	<div class="row">
+		<div class="col-md-12">
+			<b>File (<s:property value="#counter" />):</b>
+			<ul>
+		        <li>ContentType: <s:property value="uploadContentType[#counter - 1]" /></li>
+		        <li>FileName: <s:property value="uploadFileName[#counter -1]" /></li>
+		        <li>File: <s:property value="upload[#counter - 1]" /></li>
+	        </ul>
+		</div>
+	</div>
+	</s:if>
+</s:iterator>
+</div>
+
+</body>
+</html>

--- a/apps/showcase/src/main/webapp/WEB-INF/tags/non-ui/ifTag/testIf.jsp
+++ b/apps/showcase/src/main/webapp/WEB-INF/tags/non-ui/ifTag/testIf.jsp
@@ -18,6 +18,7 @@
 * under the License.
 */
 -->
+<%@page import="org.apache.struts2.showcase.hangman.HangmanConstants" %>
 <%@taglib prefix="s" uri="/struts-tags" %>
 <html>
 <head>
@@ -634,6 +635,19 @@
 				</s:else>
 		</div>
 	</div>
+</div>
+<br>
+<br>
+    <p>
+        A secondary test for this JSP visually verifies expression access to a public constant.
+        A direct access to the same public constant via scriptlet provides secondary verification.
+    </p>
+<br>
+<div>
+    Test public static (constant) access (expression).  Value: <s:property default="unavailable" value="@org.apache.struts2.showcase.hangman.HangmanConstants@HANGMAN_SESSION_KEY" />
+</div>
+<div>
+    Test public static (constant) access (scriptlet).  Value: <%=org.apache.struts2.showcase.hangman.HangmanConstants.HANGMAN_SESSION_KEY%>
 </div>
 </body>
 </html>

--- a/apps/showcase/src/main/webapp/WEB-INF/token/example4.ftl
+++ b/apps/showcase/src/main/webapp/WEB-INF/token/example4.ftl
@@ -50,7 +50,7 @@
 
 		<@s.form action="transfer4">
 			<@s.token/>
-			<@s.textfield label="Amount" name="amount" required="true" value="400"/>
+			<@s.textfield label="Amount" name="amount" required=true value="400"/>
 			<@s.submit value="Transfer money" cssClass="btn btn-primary"/>
 		</@s.form>
 		</div>


### PR DESCRIPTION
Minor config fixes for the Showcase Application in 2.5.x:
1) Token examples. Examples 2 and 3 previously resulted in 403's upon submit (config issue).
2) Token examples. Example 4 resulted in error 500 when selected from the menu (FTL param type issue).
3) Validation examples.  Examples quizBasic, quizClient and quizClientCss resulted in 404's when selected from menu (config issue).
4) File upload examples.  Multiple file upload missing result page (list and array), added missing JSP.  Added missing input results in configuration.
Similar to `PR#255` for 2.6.x.


