### PR TITLE
Fix 2.6 Showcase bean-validator Java 11 failures.

### DIFF
--- a/apps/showcase/pom.xml
+++ b/apps/showcase/pom.xml
@@ -158,7 +158,7 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-validator</artifactId>
-            <version>5.1.3.Final</version>
+            <version>5.4.3.Final</version>
         </dependency>
 
         <!-- The Servlet API mocks in Spring Framework 4.x only supports Servlet 3.0 and higher.

--- a/plugins/bean-validation/pom.xml
+++ b/plugins/bean-validation/pom.xml
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-validator</artifactId>
-            <version>5.4.1.Final</version>
+            <version>5.4.3.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
The 2.6 Showcase application is throwing JAXB-classloading-related failures when deployed to a container running Java 11.
The stacktrace indicates the issues relate to the bean-validator and Hibernate-Validator (but no issues with Java 8).
Upgrade `Hibernate-Validator` version to resolve failure:
1) Showcase upgrade 5.1.3.Final to 5.4.3.Final (most recent available).
2) bean-validator upgrade 5.4.1-Final to 5.4.3.Final (to match versions).