### PR TITLE
Taking action invocation out of synchronized block on TokenSessionStoreInterceptor to reduce contention on the session id

### DIFF
--- a/core/src/main/java/org/apache/struts2/interceptor/TokenSessionStoreInterceptor.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/TokenSessionStoreInterceptor.java
@@ -108,8 +108,13 @@ public class TokenSessionStoreInterceptor extends TokenInterceptor {
             if (!TokenHelper.validToken()) {
                 return handleInvalidToken(invocation);
             }
-            return handleValidToken(invocation);
+            // we know the token name and token must be there
+            String key = TokenHelper.getTokenName();
+            String token = TokenHelper.getToken(key);
+            String sessionTokenName = TokenHelper.buildTokenSessionAttributeName(key);
+            InvocationSessionStore.storeInvocation(sessionTokenName, token, invocation);
         }
+        return handleValidToken(invocation);
     }
 
     @Override
@@ -155,12 +160,6 @@ public class TokenSessionStoreInterceptor extends TokenInterceptor {
 
     @Override
     protected String handleValidToken(ActionInvocation invocation) throws Exception {
-        // we know the token name and token must be there
-        String key = TokenHelper.getTokenName();
-        String token = TokenHelper.getToken(key);
-		String sessionTokenName = TokenHelper.buildTokenSessionAttributeName(key);
-		InvocationSessionStore.storeInvocation(sessionTokenName, token, invocation);
-
         return invocation.invoke();
     }
 


### PR DESCRIPTION
We recently ran into an issue with the TokenSessionStoreInterceptor due to it's synchronized block holding until the action invocation returns.

If a different action requires to check something related with the same session key, then this action must wait until the Interceptor releases the lock.

We believe the invocation should not be part of the synchronized block