### PR TITLE
Proposed fix for WW-5026 (TokenSessionStoreInterceptor double-submit failure)

### DIFF
--- a/core/src/main/java/org/apache/struts2/interceptor/TokenSessionStoreInterceptor.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/TokenSessionStoreInterceptor.java
@@ -126,11 +126,12 @@ public class TokenSessionStoreInterceptor extends TokenInterceptor {
             params.remove(tokenName);
             params.remove(TokenHelper.TOKEN_NAME_FIELD);
 
-			String sessionTokenName = TokenHelper.buildTokenSessionAttributeName(tokenName);
+            String sessionTokenName = TokenHelper.buildTokenSessionAttributeName(tokenName);
             ActionInvocation savedInvocation = InvocationSessionStore.loadInvocation(sessionTokenName, token);
 
             if (savedInvocation != null) {
                 // set the valuestack to the request scope
+                // Note: loadInvocation() restored invocation's PageContext (as savedInvocation's will already be closed)
                 ValueStack stack = savedInvocation.getStack();
                 request.setAttribute(ServletActionContext.STRUTS_VALUESTACK_KEY, stack);
 
@@ -158,8 +159,8 @@ public class TokenSessionStoreInterceptor extends TokenInterceptor {
         // we know the token name and token must be there
         String key = TokenHelper.getTokenName();
         String token = TokenHelper.getToken(key);
-		String sessionTokenName = TokenHelper.buildTokenSessionAttributeName(key);
-		InvocationSessionStore.storeInvocation(sessionTokenName, token, invocation);
+        String sessionTokenName = TokenHelper.buildTokenSessionAttributeName(key);
+        InvocationSessionStore.storeInvocation(sessionTokenName, token, invocation);
 
         return invocation.invoke();
     }

--- a/core/src/main/java/org/apache/struts2/interceptor/TokenSessionStoreInterceptor.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/TokenSessionStoreInterceptor.java
@@ -112,6 +112,20 @@ public class TokenSessionStoreInterceptor extends TokenInterceptor {
         }
     }
 
+    /**
+     * Handles processing of invalid tokens.  If a previously stored invocation is
+     * available, the method will attempt to return and render its result.  Otherwise
+     * it will return INVALID_TOKEN_CODE.
+     * 
+     * Note: Because a stored (previously completed) invocation's PageContext will be closed,
+     *   this method must replace the stored PageContext with the current invocation's one (or a null).
+     *   See {@link org.apache.struts2.util.InvocationSessionStore#loadInvocation(String key, String token)} for details.
+     * 
+     * @param invocation
+     * 
+     * @return
+     * @throws Exception 
+     */
     @Override
     protected String handleInvalidToken(ActionInvocation invocation) throws Exception {
         ActionContext ac = invocation.getInvocationContext();
@@ -130,8 +144,7 @@ public class TokenSessionStoreInterceptor extends TokenInterceptor {
             ActionInvocation savedInvocation = InvocationSessionStore.loadInvocation(sessionTokenName, token);
 
             if (savedInvocation != null) {
-                // set the valuestack to the request scope
-                // Note: loadInvocation() restored invocation's PageContext (as savedInvocation's will already be closed)
+                // set the savedInvocation's valuestack to the request scope
                 ValueStack stack = savedInvocation.getStack();
                 request.setAttribute(ServletActionContext.STRUTS_VALUESTACK_KEY, stack);
 
@@ -154,6 +167,16 @@ public class TokenSessionStoreInterceptor extends TokenInterceptor {
         return INVALID_TOKEN_CODE;
     }
 
+    /**
+     * Handles processing of valid tokens.  Stores the current invocation for
+     * later use by {@link handleInvalidToken}.
+     * See {@link org.apache.struts2.util.InvocationSessionStore#storeInvocation(String key, String token, ActionInvocation invocation)} for details.
+     * 
+     * @param invocation
+     * 
+     * @return
+     * @throws Exception 
+     */
     @Override
     protected String handleValidToken(ActionInvocation invocation) throws Exception {
         // we know the token name and token must be there

--- a/core/src/main/java/org/apache/struts2/util/InvocationSessionStore.java
+++ b/core/src/main/java/org/apache/struts2/util/InvocationSessionStore.java
@@ -56,18 +56,14 @@ public class InvocationSessionStore {
             return null;
         }
 
-        ActionInvocation savedInvocation = null;
-        if (invocationContext.invocation != null) {
+        final ActionInvocation savedInvocation = invocationContext.invocation;
+        if (savedInvocation != null) {
             // WW-5026 - Preserve the previous PageContext (even if null) and restore it to the
             // ActionContext after loading the savedInvocation context.  The saved context's PageContext
             // would already be closed at this point (causing failures if used for output).
-            final ActionContext savedActionContext;
-            final ActionContext previousActionContext;
-            savedInvocation = invocationContext.invocation;
-            savedActionContext = savedInvocation.getInvocationContext();
-            previousActionContext = ActionContext.getContext();
+            final ActionContext savedActionContext = savedInvocation.getInvocationContext();
+            final ActionContext previousActionContext = ActionContext.getContext();
             ActionContext.setContext(savedActionContext);
-            savedActionContext.setValueStack(savedInvocation.getStack());
             savedActionContext.setValueStack(savedInvocation.getStack());
             if (previousActionContext != null) {
                 savedActionContext.put(ServletActionContext.PAGE_CONTEXT, previousActionContext.get(ServletActionContext.PAGE_CONTEXT));


### PR DESCRIPTION
Fix issue introduced with earlier WW-4873 fix:
- Fixes error 500 processing failures for double-submit results with TokenSessionStoreInterceptor processing
- Fix to InvocationSessionStore, new unit test confirming fix in InvocationSessionStoreTest
- Minor whitespace fix to TokenSessionStoreInterceptor
