### PR TITLE
Forward-port fix for WW-5026 to 2.6

### DIFF
--- a/core/src/main/java/org/apache/struts2/interceptor/TokenSessionStoreInterceptor.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/TokenSessionStoreInterceptor.java
@@ -112,6 +112,20 @@ public class TokenSessionStoreInterceptor extends TokenInterceptor {
         }
     }
 
+    /**
+     * Handles processing of invalid tokens.  If a previously stored invocation is
+     * available, the method will attempt to return and render its result.  Otherwise
+     * it will return INVALID_TOKEN_CODE.
+     * 
+     * Note: Because a stored (previously completed) invocation's PageContext will be closed,
+     *   this method must replace the stored PageContext with the current invocation's one (or a null).
+     *   See {@link org.apache.struts2.util.InvocationSessionStore#loadInvocation(String key, String token)} for details.
+     * 
+     * @param invocation
+     * 
+     * @return
+     * @throws Exception 
+     */
     @Override
     protected String handleInvalidToken(ActionInvocation invocation) throws Exception {
         ActionContext ac = invocation.getInvocationContext();
@@ -130,7 +144,7 @@ public class TokenSessionStoreInterceptor extends TokenInterceptor {
             ActionInvocation savedInvocation = InvocationSessionStore.loadInvocation(sessionTokenName, token);
 
             if (savedInvocation != null) {
-                // set the valuestack to the request scope
+                // set the savedInvocation's valuestack to the request scope
                 ValueStack stack = savedInvocation.getStack();
                 request.setAttribute(ServletActionContext.STRUTS_VALUESTACK_KEY, stack);
 
@@ -153,6 +167,16 @@ public class TokenSessionStoreInterceptor extends TokenInterceptor {
         return INVALID_TOKEN_CODE;
     }
 
+    /**
+     * Handles processing of valid tokens.  Stores the current invocation for
+     * later use by {@link handleInvalidToken}.
+     * See {@link org.apache.struts2.util.InvocationSessionStore#storeInvocation(String key, String token, ActionInvocation invocation)} for details.
+     * 
+     * @param invocation
+     * 
+     * @return
+     * @throws Exception 
+     */
     @Override
     protected String handleValidToken(ActionInvocation invocation) throws Exception {
         // we know the token name and token must be there

--- a/core/src/main/java/org/apache/struts2/util/InvocationSessionStore.java
+++ b/core/src/main/java/org/apache/struts2/util/InvocationSessionStore.java
@@ -20,6 +20,7 @@ package org.apache.struts2.util;
 
 import com.opensymphony.xwork2.ActionContext;
 import com.opensymphony.xwork2.ActionInvocation;
+import org.apache.struts2.ServletActionContext;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -55,11 +56,20 @@ public class InvocationSessionStore {
             return null;
         }
 
-        ActionInvocation savedInvocation = null;
-        if (invocationContext.invocation != null) {
-            savedInvocation = invocationContext.invocation;
-            ActionContext.setContext(savedInvocation.getInvocationContext());
-            ActionContext.getContext().setValueStack(savedInvocation.getStack());
+        final ActionInvocation savedInvocation = invocationContext.invocation;
+        if (savedInvocation != null) {
+            // WW-5026 - Preserve the previous PageContext (even if null) and restore it to the
+            // ActionContext after loading the savedInvocation context.  The saved context's PageContext
+            // would already be closed at this point (causing failures if used for output).
+            final ActionContext savedActionContext = savedInvocation.getInvocationContext();
+            final ActionContext previousActionContext = ActionContext.getContext();
+            ActionContext.setContext(savedActionContext);
+            savedActionContext.setValueStack(savedInvocation.getStack());
+            if (previousActionContext != null) {
+                savedActionContext.put(ServletActionContext.PAGE_CONTEXT, previousActionContext.get(ServletActionContext.PAGE_CONTEXT));
+            } else {
+                savedActionContext.put(ServletActionContext.PAGE_CONTEXT, null);
+            }
         }
 
         return savedInvocation;


### PR DESCRIPTION
Forward-port fix for WW-5026 to 2.6
- Equivalent to PR#342 for 2.5.x, fixes double-submit error 500 failure with
- Fixes error 500 processing failures for double-submit results with TokenSessionStoreInterceptor processing
- Fix to InvocationSessionStore, new unit test confirming fix in InvocationSessionStoreTest
- Minor whitespace fix to TokenSessionStoreInterceptor