### PR TITLE
Proposed fix for WW-5011 for the 2.5.x branch

### DIFF
--- a/plugins/tiles/src/main/java/org/apache/struts2/tiles/StrutsApplicationResourceAlternate.java
+++ b/plugins/tiles/src/main/java/org/apache/struts2/tiles/StrutsApplicationResourceAlternate.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.struts2.tiles;
+
+import org.apache.tiles.request.locale.PostfixedApplicationResource;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+
+public class StrutsApplicationResourceAlternate extends PostfixedApplicationResource {
+
+    private static final String URL_FILE_PROTOCOL = "file";
+
+    private final URL url;
+
+    /**
+     * Generate an alternate localePath parameter string (external form) for any
+     * URL that uses a file protocol,  For any other protocol, it simply returns the
+     * url Path.
+     * 
+     * For a file url, the alternate file localePath supports a full path including
+     * a sub-context (e.g. Some_Path#SomeSubcontext).
+     * 
+     * @param url
+     * 
+     * @return 
+     */
+    public static String alternateFileLocalePath(URL url) {
+        final String result;
+        final String urlProtocol = url.getProtocol();
+
+        if (URL_FILE_PROTOCOL.equalsIgnoreCase(urlProtocol)) {
+            final String urlExternalForm = url.toExternalForm();
+            if (urlExternalForm != null && urlExternalForm.startsWith(urlProtocol + ':')) {
+                result = urlExternalForm.substring(urlProtocol.length() + 1);
+            } else {
+                result = url.getPath();
+            }
+        } else {
+            result = url.getPath();
+        }
+
+        return result;
+    }
+
+    /**
+     * Construct a StrutsApplicationResourceAlternate that uses
+     * alternate file protocol resource handling logic (for sub-contexts).
+     * 
+     * For non-file url protocols, behaves the same as {@link StrutsApplicationResource}.
+     * 
+     * @param url
+     */
+    public StrutsApplicationResourceAlternate(URL url) {
+        super(alternateFileLocalePath(url));
+        this.url = url;
+    }
+
+    @Override
+    public InputStream getInputStream() throws IOException {
+        return url.openStream();
+    }
+
+    @Override
+    public long getLastModified() throws IOException {
+        File file = new File(alternateFileLocalePath(url));
+        if (file.exists()) {
+            return file.lastModified();
+        }
+        return 0;
+    }
+
+    @Override
+    public String toString() {
+        return "Resource " + getLocalePath() + " at " + url.toString();
+    }
+}

--- a/plugins/tiles/src/main/java/org/apache/struts2/tiles/StrutsTilesInitializer.java
+++ b/plugins/tiles/src/main/java/org/apache/struts2/tiles/StrutsTilesInitializer.java
@@ -30,11 +30,21 @@ import javax.servlet.ServletContext;
 
 public class StrutsTilesInitializer extends AbstractTilesInitializer {
 
+    public static final String STRUTS_TILES_ALTERNATE_FILERESOURCEHANDLING = "struts.tiles.alternatefileresourcehandling";
+
     private static final Logger LOG = LogManager.getLogger(StrutsTilesInitializer.class);
 
     @Override
     protected ApplicationContext createTilesApplicationContext(ApplicationContext preliminaryContext) {
         ServletContext servletContext = (ServletContext) preliminaryContext.getContext();
+
+        // Opt-in alternate file resource handling for WW-5011
+        if (Boolean.parseBoolean(servletContext.getInitParameter(STRUTS_TILES_ALTERNATE_FILERESOURCEHANDLING))) {
+            StrutsWildcardServletApplicationContext.setUseAlternateFileResourceHandling(true);
+        } else {
+            StrutsWildcardServletApplicationContext.setUseAlternateFileResourceHandling(false);
+        }
+        LOG.trace("Tiles alternate file resourcehandling: " + StrutsWildcardServletApplicationContext.isUseAlternateFileResourceHandling());
 
         if (servletContext.getInitParameter(DefinitionsFactory.DEFINITIONS_CONFIG) != null) {
             LOG.trace("Found definitions config in web.xml, using standard Servlet support ....");

--- a/plugins/tiles/src/main/java/org/apache/struts2/tiles/StrutsTilesInitializer.java
+++ b/plugins/tiles/src/main/java/org/apache/struts2/tiles/StrutsTilesInitializer.java
@@ -30,7 +30,7 @@ import javax.servlet.ServletContext;
 
 public class StrutsTilesInitializer extends AbstractTilesInitializer {
 
-    public static final String STRUTS_TILES_ALTERNATE_FILERESOURCEHANDLING = "struts.tiles.alternatefileresourcehandling";
+    public static final String STRUTS_TILES_ALTERNATE_FILERESOURCEHANDLING = "struts.tiles.alternateFileResourceHandling";
 
     private static final Logger LOG = LogManager.getLogger(StrutsTilesInitializer.class);
 


### PR DESCRIPTION
Proposed fixes for WW-5011 and WW-5028 for the 2.5.x branch:
- NOTE: If the PR is accepted please credit Jason Pyeron for the WW-5011 portion of this change
        as he found the issue, proposed a fix and opened the WW-5011 JIRA.
- For WW-5028:
  - Disable printing stacktrace on exceptions by the Dispatcher by default.
  - It can be re-enabled by configuration.
- For WW-5011:
  - Provide an "opt-in" alternate file resource handler for the Tiles plugin.
  - It can be enabled via "context-param" in web.xml