### PR TITLE
Proposed fix for WW-5028 for the 2.5.x branch:

### DIFF
--- a/core/src/main/java/org/apache/struts2/dispatcher/Dispatcher.java
+++ b/core/src/main/java/org/apache/struts2/dispatcher/Dispatcher.java
@@ -582,8 +582,10 @@ public class Dispatcher {
             logConfigurationException(request, e);
             sendError(request, response, HttpServletResponse.SC_NOT_FOUND, e);
         } catch (Exception e) {
-            e.printStackTrace();
             if (handleException || devMode) {
+                if (devMode) {
+                    LOG.debug("Dispatcher serviceAction failed", e);
+                }
                 sendError(request, response, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e);
             } else {
                 throw new ServletException(e);

--- a/core/src/test/java/org/apache/struts2/dispatcher/DispatcherTest.java
+++ b/core/src/test/java/org/apache/struts2/dispatcher/DispatcherTest.java
@@ -321,6 +321,38 @@ public class DispatcherTest extends StrutsInternalTestCase {
         assertTrue(du.isMultipartRequest(req));
     }
 
+    /**
+     * Verify proper default (true) handleExceptionState for Dispatcher and that
+     * it properly reflects a manually configured change to false.
+     * 
+     * @throws Exception 
+     */
+    public void testHandleException() throws Exception {
+        Dispatcher du = initDispatcher(new HashMap<String, String>());
+        assertTrue("Default Dispatcher handleException state not true ?", du.isHandleException());
+
+        Dispatcher du2 = initDispatcher(new HashMap<String, String>() {{
+            put(StrutsConstants.STRUTS_HANDLE_EXCEPTION, "false");
+        }});
+        assertFalse("Modified Dispatcher handleException state not false ?", du2.isHandleException());
+    }
+
+    /**
+     * Verify proper default (false) devMode for Dispatcher and that
+     * it properly reflects a manually configured change to true.
+     * 
+     * @throws Exception 
+     */
+    public void testDevMode() throws Exception {
+        Dispatcher du = initDispatcher(new HashMap<String, String>());
+        assertFalse("Default Dispatcher devMode state not false ?", du.isDevMode());
+
+        Dispatcher du2 = initDispatcher(new HashMap<String, String>() {{
+            put(StrutsConstants.STRUTS_DEVMODE, "true");
+        }});
+        assertTrue("Modified Dispatcher devMode state not true ?", du2.isDevMode());
+    }
+
     class InternalConfigurationManager extends ConfigurationManager {
     	public boolean destroyConfiguration = false;
 


### PR DESCRIPTION
Proposed fix for WW-5028 for the 2.5.x branch:
- Disable printing stacktrace on exceptions by the Dispatcher by default.
- Printing stacktrace on exception can be re-enabled by configuration.
- Now prints stacktrace on exception using LOG, as suggested by A. Mashchenko and the the JIRA reporter.