### PR TITLE
fix multipart request RegEx (relates to WW-4958)

### DIFF
--- a/core/src/main/java/org/apache/struts2/dispatcher/Dispatcher.java
+++ b/core/src/main/java/org/apache/struts2/dispatcher/Dispatcher.java
@@ -85,7 +85,7 @@ public class Dispatcher {
      */
     public static final String REQUEST_POST_METHOD = "POST";
 
-    public static final String MULTIPART_FORM_DATA_REGEX = "^multipart/form-data(?:\\s*;\\s*boundary\\s?=[0-9a-zA-Z'()+_,\\-./:=?]{1,70})?(?:\\s*;\\s*charset\\s?=\\s?[a-zA-Z\\-0-9]{3,14})?";
+    public static final String MULTIPART_FORM_DATA_REGEX = "^multipart/form-data(?:\\s*;\\s*boundary=[0-9a-zA-Z'()+_,\\-./:=?]{1,70})?(?:\\s*;\\s*charset=[a-zA-Z\\-0-9]{3,14})?";
 
     /**
      * Provide a thread local instance.

--- a/core/src/test/java/org/apache/struts2/dispatcher/DispatcherTest.java
+++ b/core/src/test/java/org/apache/struts2/dispatcher/DispatcherTest.java
@@ -323,18 +323,6 @@ public class DispatcherTest extends StrutsInternalTestCase {
         req.setContentType("multipart/form-data;boundary=---------------------------207103069210263;charset=UTF-16LE");
         assertTrue(du.isMultipartRequest(req));
 
-        req.setContentType("multipart/form-data;boundary=---------------------------207103069210263 ; charset = UTF-16LE");
-        assertTrue(du.isMultipartRequest(req));
-
-        req.setContentType("multipart/form-data;boundary=---------------------------207103069210263;charset = UTF-16LE");
-        assertTrue(du.isMultipartRequest(req));
-
-        req.setContentType("multipart/form-data;boundary=---------------------------207103069210263;charset= UTF-16LE");
-        assertTrue(du.isMultipartRequest(req));
-
-        req.setContentType("multipart/form-data;boundary=---------------------------207103069210263;charset =UTF-16LE");
-        assertTrue(du.isMultipartRequest(req));
-
         req.setContentType("multipart/form-data;boundary=---------------------------207103069210263; charset=UTF-16LE");
         assertTrue(du.isMultipartRequest(req));
 
@@ -348,9 +336,6 @@ public class DispatcherTest extends StrutsInternalTestCase {
         assertTrue(du.isMultipartRequest(req));
 
         req.setContentType("multipart/form-data ; boundary=---------------------------207103069210263;charset=UTF-16LE");
-        assertTrue(du.isMultipartRequest(req));
-
-        req.setContentType("multipart/form-data;boundary =---------------------------207103069210263;charset=UTF-16LE");
         assertTrue(du.isMultipartRequest(req));
 
         req.setContentType("Multipart/Form-Data ; boundary=---------------------------207103069210263;charset=UTF-16LE");


### PR DESCRIPTION
parameter      = token "=" ( token / **quoted-string** )
      Note: Unlike some similar constructs in other header fields, media
      type parameters **do not allow whitespace (even "bad" whitespace)
      around the "=" character.**

Reference: https://tools.ietf.org/html/rfc7231#section-3.1.1.1