### PR TITLE
Add common .gitignore patterns from gitignore.io

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@
 .metadata/
 Servers/
 
+# Java annotation processor (APT)
+.factorypath
+
 #VSCode
 .vscode
 
@@ -24,42 +27,19 @@ Servers/
 .java-version
 
 # Maven
+target/
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+release.properties
+dependency-reduced-pom.xml
+buildNumber.properties
+.mvn/timing.properties
 .mvn/wrapper/maven-wrapper.jar
-core/target
-plugins/convention/target
-plugins/embeddedjsp/target
-plugins/osgi/target
-plugins/cdi/target
-plugins/spring/target
-plugins/jfreechart/target
-apps/rest-showcase/target
-apps/mailreader/target
-apps/portlet/target
-apps/blank/target
-apps/jboss-blank/target
-apps/mailreader/target
-apps/portlet/target
-apps/showcase/target
-apps/target
-bundles/admin/target
-plugins/config-browser/target
-plugins/jasperreports/target
-plugins/json/target
-plugins/portlet-tiles/target
-plugins/portlet/target
-plugins/sitemesh/target
-plugins/javatemplates/target
-bundles/demo/target
-plugins/rest/target
-plugins/plexus/target
-plugins/testng/target
-plugins/dwr/target
-plugins/gxp/target
-plugins/oval/target
-plugins/junit/target
-plugins/tiles/target
-bundles/target
-plugins/target
-target
+
 plugins/testng/test-output
 test-output
+
+# Sonar
+/.sonar/


### PR DESCRIPTION
Ignore .factorypath b/c it gets generated during maven compile.

Don't need to ignore every single target folder.
Instead use target/ pattern and add more common maven files.

Ignore .sonar folder for local sonar scanning.