### PR TITLE
include ref in path as WW-5011 workaround

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,12 @@ jdk:
   - oraclejdk11
 
 install: true
-script: mvn test -DskipAssembly
+script: mvn test -DskipAssembly -B
 
 after_success:
   # TODO delete following if statement after fix of https://github.com/cobertura/cobertura/issues/271
   - if [ "$TRAVIS_JDK_VERSION" == "openjdk8" ] || [ "$TRAVIS_JDK_VERSION" == "oraclejdk8" ]; then
-      mvn cobertura:cobertura org.eluder.coveralls:coveralls-maven-plugin:report com.updateimpact:updateimpact-maven-plugin:submit -Ptravis-coveralls,update-impact -DskipAssembly;
+      mvn cobertura:cobertura org.eluder.coveralls:coveralls-maven-plugin:report com.updateimpact:updateimpact-maven-plugin:submit -Ptravis-coveralls,update-impact -DskipAssembly -B;
     else
       echo "Not reporting coverage for $TRAVIS_JDK_VERSION due to incompatibility or to save performance";
     fi;

--- a/core/src/test/resources/log4j2.xml
+++ b/core/src/test/resources/log4j2.xml
@@ -29,6 +29,5 @@
         <Root level="info">
             <AppenderRef ref="STDOUT"/>
         </Root>
-        <Logger name="org.apache.struts2.views.xslt" level="debug"/>
     </Loggers>
 </Configuration>

--- a/plugins/tiles/src/main/java/org/apache/struts2/tiles/StrutsWildcardServletApplicationContext.java
+++ b/plugins/tiles/src/main/java/org/apache/struts2/tiles/StrutsWildcardServletApplicationContext.java
@@ -120,11 +120,7 @@ public class StrutsWildcardServletApplicationContext extends ServletApplicationC
 
         for (Map.Entry<String, URL> entry : matches.entrySet()) {
             if (pattern.matcher(entry.getKey()).matches()) {
-                try {
-                    resources.add(new StrutsApplicationResource(entry.getValue()));
-                } catch (MalformedURLException e) {
-                    LOG.warn("Cannot access [{}]", entry.getValue(), e);
-                }
+                resources.add(new StrutsApplicationResource(entry.getValue()));
             }
         }
 

--- a/plugins/tiles/src/main/java/org/apache/struts2/tiles/StrutsWildcardServletApplicationContext.java
+++ b/plugins/tiles/src/main/java/org/apache/struts2/tiles/StrutsWildcardServletApplicationContext.java
@@ -120,7 +120,11 @@ public class StrutsWildcardServletApplicationContext extends ServletApplicationC
 
         for (Map.Entry<String, URL> entry : matches.entrySet()) {
             if (pattern.matcher(entry.getKey()).matches()) {
-                resources.add(new StrutsApplicationResource(entry.getValue()));
+                try {
+                    resources.add(new StrutsApplicationResource(entry.getValue()));
+                } catch (MalformedURLException e) {
+                    LOG.warn("Cannot access [{}]", entry.getValue(), e);
+                }
             }
         }
 

--- a/plugins/tiles/src/test/java/org/apache/struts2/tiles/StrutsApplicationResourceTest.java
+++ b/plugins/tiles/src/test/java/org/apache/struts2/tiles/StrutsApplicationResourceTest.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.struts2.tiles;
+
+import org.apache.tiles.request.ApplicationResource;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.net.URL;
+
+public class StrutsApplicationResourceTest {
+
+    @Test
+    public void testWW5011workaround() throws Exception {
+        URL resource = getClass().getClassLoader().getResource("emptyTiles.xml");
+        ApplicationResource ar = new StrutsApplicationResource(resource);
+        Assert.assertNotEquals(0, ar.getLastModified());
+
+        resource = getClass().getClassLoader().getResource("emptyTiles###2.xml");
+        ar = new StrutsApplicationResource(resource);
+        Assert.assertNotEquals(0, ar.getLastModified());
+
+        resource = getClass().getClassLoader().getResource("emptyTiles.xml");
+        ar = new StrutsApplicationResource(new URL(resource + "#ref1"));
+        Assert.assertNotEquals(0, ar.getLastModified());
+    }
+}

--- a/plugins/tiles/src/test/java/org/apache/struts2/tiles/StrutsApplicationResourceTest.java
+++ b/plugins/tiles/src/test/java/org/apache/struts2/tiles/StrutsApplicationResourceTest.java
@@ -27,7 +27,7 @@ import java.net.URL;
 public class StrutsApplicationResourceTest {
 
     @Test
-    public void testWW5011workaround() throws Exception {
+    public void testWW5011fix() throws Exception {
         URL resource = getClass().getClassLoader().getResource("emptyTiles.xml");
         ApplicationResource ar = new StrutsApplicationResource(resource);
         Assert.assertNotEquals(0, ar.getLastModified());

--- a/plugins/tiles/src/test/resources/emptyTiles###2.xml
+++ b/plugins/tiles/src/test/resources/emptyTiles###2.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+-->
+<tiles-definitions></tiles-definitions>

--- a/plugins/tiles/src/test/resources/emptyTiles.xml
+++ b/plugins/tiles/src/test/resources/emptyTiles.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+-->
+<tiles-definitions></tiles-definitions>


### PR DESCRIPTION
include ref in path for StrutsApplicationResource as WW-5011 workaround (when real path or filename contains "#" character)