### PR TITLE
Update Three Struts 2.5.x dependencies to latest versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,12 +98,12 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <spring.platformVersion>4.3.20.RELEASE</spring.platformVersion>
-        <ognl.version>3.1.22</ognl.version>
+        <ognl.version>3.1.23</ognl.version>
         <asm.version>7.0</asm.version>
         <tiles.version>3.0.8</tiles.version>
         <tiles-request.version>1.0.7</tiles-request.version>
-        <log4j2.version>2.11.1</log4j2.version>
-        <jackson.version>2.9.8</jackson.version>
+        <log4j2.version>2.11.2</log4j2.version>
+        <jackson.version>2.9.9</jackson.version>
 
         <!-- Site generation -->
         <fluido-skin.version>1.7</fluido-skin.version>


### PR DESCRIPTION
Update Three Struts 2.5.x dependencies to latest versions:
- Jackson 2.9.8 -> 2.9.9
- Log4j2 2.11.1 -> 2.11.2
- OGNL 3.1.22 -> 3.1.23
Struts 2.5.21-SNAPSHOT builds successfully with these versions.