### PR TITLE
fix logMissingProperties (WW-4999)

### DIFF
--- a/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlValueStack.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlValueStack.java
@@ -340,7 +340,8 @@ public class OgnlValueStack implements Serializable, ValueStack, ClearableValueS
     }
 
     protected boolean shouldLogMissingPropertyWarning(OgnlException e) {
-        return (e instanceof NoSuchPropertyException || e instanceof MethodFailedException)
+        return (e instanceof NoSuchPropertyException ||
+                (e instanceof MethodFailedException && e.getReason() instanceof NoSuchMethodException))
         		&& devMode && logMissingProperties;
     }
 

--- a/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlValueStack.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlValueStack.java
@@ -182,8 +182,7 @@ public class OgnlValueStack implements Serializable, ValueStack, ClearableValueS
 
     private void trySetValue(String expr, Object value, boolean throwExceptionOnFailure, Map<String, Object> context) throws OgnlException {
         context.put(XWorkConverter.CONVERSION_PROPERTY_FULLNAME, expr);
-        context.put(REPORT_ERRORS_ON_NO_PROP, throwExceptionOnFailure || (devMode && logMissingProperties)
-                ? Boolean.TRUE : Boolean.FALSE);
+        context.put(REPORT_ERRORS_ON_NO_PROP, throwExceptionOnFailure || logMissingProperties ? Boolean.TRUE : Boolean.FALSE);
         ognlUtil.setValue(expr, context, root, value);
     }
 
@@ -247,7 +246,7 @@ public class OgnlValueStack implements Serializable, ValueStack, ClearableValueS
     }
 
     protected void setupExceptionOnFailure(boolean throwExceptionOnFailure) {
-        if (throwExceptionOnFailure || (devMode && logMissingProperties)) {
+        if (throwExceptionOnFailure || logMissingProperties) {
             context.put(THROW_EXCEPTION_ON_FAILURE, true);
         }
     }
@@ -342,7 +341,7 @@ public class OgnlValueStack implements Serializable, ValueStack, ClearableValueS
     protected boolean shouldLogMissingPropertyWarning(OgnlException e) {
         return (e instanceof NoSuchPropertyException ||
                 (e instanceof MethodFailedException && e.getReason() instanceof NoSuchMethodException))
-        		&& devMode && logMissingProperties;
+        		&& logMissingProperties;
     }
 
     private Object tryFindValue(String expr, Class asType) throws OgnlException {

--- a/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlValueStack.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlValueStack.java
@@ -182,7 +182,8 @@ public class OgnlValueStack implements Serializable, ValueStack, ClearableValueS
 
     private void trySetValue(String expr, Object value, boolean throwExceptionOnFailure, Map<String, Object> context) throws OgnlException {
         context.put(XWorkConverter.CONVERSION_PROPERTY_FULLNAME, expr);
-        context.put(REPORT_ERRORS_ON_NO_PROP, (throwExceptionOnFailure) ? Boolean.TRUE : Boolean.FALSE);
+        context.put(REPORT_ERRORS_ON_NO_PROP, throwExceptionOnFailure || (devMode && logMissingProperties)
+                ? Boolean.TRUE : Boolean.FALSE);
         ognlUtil.setValue(expr, context, root, value);
     }
 
@@ -246,7 +247,7 @@ public class OgnlValueStack implements Serializable, ValueStack, ClearableValueS
     }
 
     protected void setupExceptionOnFailure(boolean throwExceptionOnFailure) {
-        if (throwExceptionOnFailure) {
+        if (throwExceptionOnFailure || (devMode && logMissingProperties)) {
             context.put(THROW_EXCEPTION_ON_FAILURE, true);
         }
     }

--- a/core/src/main/java/com/opensymphony/xwork2/ognl/accessor/CompoundRootAccessor.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/accessor/CompoundRootAccessor.java
@@ -218,13 +218,13 @@ public class CompoundRootAccessor implements PropertyAccessor, MethodAccessor, C
         }
 
         Throwable reason = null;
+        Class[] argTypes = getArgTypes(objects);
         for (Object o : root) {
             if (o == null) {
                 continue;
             }
 
             Class clazz = o.getClass();
-            Class[] argTypes = getArgTypes(objects);
 
             MethodCall mc = null;
 
@@ -236,12 +236,17 @@ public class CompoundRootAccessor implements PropertyAccessor, MethodAccessor, C
                 try {
                     return OgnlRuntime.callMethod((OgnlContext) context, o, name, objects);
                 } catch (OgnlException e) {
-                    // try the next one
                     reason = e.getReason();
 
-                    if ((mc != null) && (reason != null) && (reason.getClass() == NoSuchMethodException.class)) {
+                    if (reason != null && !(reason instanceof NoSuchMethodException)) {
+                        // method has found but thrown an exception
+                        break;
+                    }
+
+                    if ((mc != null) && (reason != null)) {
                         invalidMethods.put(mc, Boolean.TRUE);
                     }
+                    // continue and try the next one
                 }
             }
         }

--- a/core/src/test/java/com/opensymphony/xwork2/ognl/OgnlValueStackTest.java
+++ b/core/src/test/java/com/opensymphony/xwork2/ognl/OgnlValueStackTest.java
@@ -954,6 +954,33 @@ public class OgnlValueStackTest extends XWorkTestCase {
         assertNull(vs.findValue("@com.nothing.here.Nothing@BLAH"));
     }
 
+    /**
+     * Fails on 2.5.20 and earlier - tested on 2.5 (5/5/2016) and failed
+     * @since 2.5.21
+     */
+    public void testNotThrowExceptionOnTopMissingProperty() {
+        OgnlValueStack vs = createValueStack();
+
+        Dog dog = new Dog();
+        dog.setName("Rover");
+        vs.push(dog);
+
+        Cat cat = new Cat();
+        vs.push(cat);
+
+        vs.setValue("age", 12, true);
+
+        assertEquals(12, vs.findValue("age", true));
+        assertEquals(12, vs.findValue("age", Integer.class, true));
+        assertEquals(12, vs.findValue("getAge()", true));
+        assertEquals(12, vs.findValue("getAge()", Integer.class, true));
+
+        assertNull(vs.findValue("name", true));
+        assertNull(vs.findValue("name", String.class, true));
+        assertNull(vs.findValue("getName()", true));
+        assertNull(vs.findValue("getName()", String.class, true));
+    }
+
     public void testTop() {
         OgnlValueStack vs = createValueStack();
 

--- a/core/src/test/java/com/opensymphony/xwork2/ognl/OgnlValueStackTest.java
+++ b/core/src/test/java/com/opensymphony/xwork2/ognl/OgnlValueStackTest.java
@@ -247,7 +247,6 @@ public class OgnlValueStackTest extends XWorkTestCase {
 
     public void testLogMissingProperties() {
         OgnlValueStack vs = createValueStack();
-        vs.setDevMode("true");
         vs.setLogMissingProperties("true");
 
         Dog dog = new Dog();
@@ -278,7 +277,6 @@ public class OgnlValueStackTest extends XWorkTestCase {
 
     public void testNotLogUserExceptionsAsMissingProperties() {
         OgnlValueStack vs = createValueStack();
-        vs.setDevMode("true");
         vs.setLogMissingProperties("true");
 
         Dog dog = new Dog();
@@ -300,13 +298,7 @@ public class OgnlValueStackTest extends XWorkTestCase {
             vs.findValue("getBite()", false);
             vs.findValue("getBite()", void.class, false);
 
-            assertEquals(8, testAppender.logEvents.size());
-            for (int i = 0; i < testAppender.logEvents.size(); i += 2) {
-                assertTrue(testAppender.logEvents.get(i).getMessage().getFormattedMessage()
-                        .startsWith("Caught an exception while evaluating expression '"));
-                assertEquals("NOTE: Previous warning message was issued due to devMode set to true.",
-                        testAppender.logEvents.get(i + 1).getMessage().getFormattedMessage());
-            }
+            assertEquals(0, testAppender.logEvents.size());
         } finally {
             testAppender.stop();
             logger.removeAppender(testAppender);

--- a/core/src/test/java/com/opensymphony/xwork2/ognl/OgnlValueStackTest.java
+++ b/core/src/test/java/com/opensymphony/xwork2/ognl/OgnlValueStackTest.java
@@ -276,6 +276,43 @@ public class OgnlValueStackTest extends XWorkTestCase {
         }
     }
 
+    public void testNotLogUserExceptionsAsMissingProperties() {
+        OgnlValueStack vs = createValueStack();
+        vs.setDevMode("true");
+        vs.setLogMissingProperties("true");
+
+        Dog dog = new Dog();
+        vs.push(dog);
+
+        TestAppender testAppender = new TestAppender();
+        Logger logger = (Logger) LogManager.getLogger(OgnlValueStack.class);
+        logger.addAppender(testAppender);
+        testAppender.start();
+
+        try {
+            vs.setValue("exception", "exceptionValue", false);
+            vs.findValue("exception", false);
+            vs.findValue("exception", String.class, false);
+            vs.findValue("getException()", false);
+            vs.findValue("getException()", String.class, false);
+            vs.findValue("bite", false);
+            vs.findValue("bite", void.class, false);
+            vs.findValue("getBite()", false);
+            vs.findValue("getBite()", void.class, false);
+
+            assertEquals(8, testAppender.logEvents.size());
+            for (int i = 0; i < testAppender.logEvents.size(); i += 2) {
+                assertTrue(testAppender.logEvents.get(i).getMessage().getFormattedMessage()
+                        .startsWith("Caught an exception while evaluating expression '"));
+                assertEquals("NOTE: Previous warning message was issued due to devMode set to true.",
+                        testAppender.logEvents.get(i + 1).getMessage().getFormattedMessage());
+            }
+        } finally {
+            testAppender.stop();
+            logger.removeAppender(testAppender);
+        }
+    }
+
     public void testFailOnMissingMethod() {
         OgnlValueStack vs = createValueStack();
 


### PR DESCRIPTION
Moves checking OgnlValueStack.THROW_EXCEPTION_ON_FAILURE outside loop because it shouldn't throw exception on first failure while is trying all root objects.

Returns on first successful call because it's not rational and is confusing user to skip when user method successfully returns null as an actual result.

Fixes WW-4999 via honoring (devMode && logMissingProperties) for OgnlValueStack.THROW_EXCEPTION_ON_FAILURE and REPORT_ERRORS_ON_NO_PROP.