### PR TITLE
Improved logging for DefaultDispatcherErrorHandler, DefaultStaticContentLoader

### DIFF
--- a/core/src/main/java/org/apache/struts2/dispatcher/DefaultDispatcherErrorHandler.java
+++ b/core/src/main/java/org/apache/struts2/dispatcher/DefaultDispatcherErrorHandler.java
@@ -97,10 +97,10 @@ public class DefaultDispatcherErrorHandler implements DispatcherErrorHandler {
             response.sendError(code, e.getMessage());
         } catch (IOException e1) {
             // we're already sending an error, not much else we can do if more stuff breaks
-            LOG.info("Unable to send error response, code: " + code + "! (IOException): " + e1);
+            LOG.warn("Unable to send error response, code: {}! (IOException): {}", code, e1.toString());
         } catch (IllegalStateException ise) {
             // Log illegalstate instead of passing unrecoverable exception to calling thread
-            LOG.info("Unable to send error response, code: " + code + "! isCommited: " + response.isCommitted() + " (IllegalStateException): " + ise);
+            LOG.warn("Unable to send error response, code: {}! isCommited: {}. (IllegalStateException): {}", code, response.isCommitted(), ise.toString());
         }
     }
 
@@ -126,10 +126,10 @@ public class DefaultDispatcherErrorHandler implements DispatcherErrorHandler {
                 response.sendError(code, "Unable to show problem report:\n" + exp + "\n\n" + LocationUtils.getLocation(exp));
             } catch (IOException ex) {
                 // we're already sending an error, not much else we can do if more stuff breaks
-                LOG.info("Unable to send error response, code: " + code + "! (IOException): ", ex);  // Stacktrace with DevMode
+                LOG.warn("Unable to send error response, code: {}! (IOException): {}", code, ex);  // Stacktrace with DevMode
             } catch (IllegalStateException ise) {
                 // Log illegalstate instead of passing unrecoverable exception to calling thread
-                LOG.info("Unable to send error response, code: " + code + "! isCommited: " + response.isCommitted() + " (IllegalStateException): ", ise);  // Stacktrace with DevMode
+                LOG.warn("Unable to send error response, code: {}! isCommited: {}. (IllegalStateException): {}", code, response.isCommitted(), ise);  // Stacktrace with DevMode
             }
         }
     }

--- a/core/src/main/java/org/apache/struts2/dispatcher/DefaultDispatcherErrorHandler.java
+++ b/core/src/main/java/org/apache/struts2/dispatcher/DefaultDispatcherErrorHandler.java
@@ -97,6 +97,10 @@ public class DefaultDispatcherErrorHandler implements DispatcherErrorHandler {
             response.sendError(code, e.getMessage());
         } catch (IOException e1) {
             // we're already sending an error, not much else we can do if more stuff breaks
+            LOG.info("Unable to send error response, code: " + code + "! (IOException): " + e1);
+        } catch (IllegalStateException ise) {
+            // Log illegalstate instead of passing unrecoverable exception to calling thread
+            LOG.info("Unable to send error response, code: " + code + "! isCommited: " + response.isCommitted() + " (IllegalStateException): " + ise);
         }
     }
 
@@ -122,6 +126,10 @@ public class DefaultDispatcherErrorHandler implements DispatcherErrorHandler {
                 response.sendError(code, "Unable to show problem report:\n" + exp + "\n\n" + LocationUtils.getLocation(exp));
             } catch (IOException ex) {
                 // we're already sending an error, not much else we can do if more stuff breaks
+                LOG.info("Unable to send error response, code: " + code + "! (IOException): ", ex);  // Stacktrace with DevMode
+            } catch (IllegalStateException ise) {
+                // Log illegalstate instead of passing unrecoverable exception to calling thread
+                LOG.info("Unable to send error response, code: " + code + "! isCommited: " + response.isCommitted() + " (IllegalStateException): ", ise);  // Stacktrace with DevMode
             }
         }
     }

--- a/core/src/main/java/org/apache/struts2/dispatcher/DefaultDispatcherErrorHandler.java
+++ b/core/src/main/java/org/apache/struts2/dispatcher/DefaultDispatcherErrorHandler.java
@@ -97,10 +97,10 @@ public class DefaultDispatcherErrorHandler implements DispatcherErrorHandler {
             response.sendError(code, e.getMessage());
         } catch (IOException e1) {
             // we're already sending an error, not much else we can do if more stuff breaks
-            LOG.warn("Unable to send error response, code: {}! (IOException): {}", code, e1.toString());
+            LOG.warn("Unable to send error response, code: {};", code, e1);
         } catch (IllegalStateException ise) {
             // Log illegalstate instead of passing unrecoverable exception to calling thread
-            LOG.warn("Unable to send error response, code: {}! isCommited: {}. (IllegalStateException): {}", code, response.isCommitted(), ise.toString());
+            LOG.warn("Unable to send error response, code: {}; isCommited: {};", code, response.isCommitted(), ise);
         }
     }
 
@@ -126,10 +126,10 @@ public class DefaultDispatcherErrorHandler implements DispatcherErrorHandler {
                 response.sendError(code, "Unable to show problem report:\n" + exp + "\n\n" + LocationUtils.getLocation(exp));
             } catch (IOException ex) {
                 // we're already sending an error, not much else we can do if more stuff breaks
-                LOG.warn("Unable to send error response, code: {}! (IOException): {}", code, ex);  // Stacktrace with DevMode
+                LOG.warn("Unable to send error response, code: {};", code, ex);
             } catch (IllegalStateException ise) {
                 // Log illegalstate instead of passing unrecoverable exception to calling thread
-                LOG.warn("Unable to send error response, code: {}! isCommited: {}. (IllegalStateException): {}", code, response.isCommitted(), ise);  // Stacktrace with DevMode
+                LOG.warn("Unable to send error response, code: {}; isCommited: {};", code, response.isCommitted(), ise);
             }
         }
     }

--- a/core/src/main/java/org/apache/struts2/dispatcher/DefaultStaticContentLoader.java
+++ b/core/src/main/java/org/apache/struts2/dispatcher/DefaultStaticContentLoader.java
@@ -222,10 +222,10 @@ public class DefaultStaticContentLoader implements StaticContentLoader {
             response.sendError(HttpServletResponse.SC_NOT_FOUND);
         } catch (IOException e1) {
             // we're already sending an error, not much else we can do if more stuff breaks
-            LOG.info("Unable to send error response, code: " + HttpServletResponse.SC_NOT_FOUND + "! (IOException): " + e1);
+            LOG.warn("Unable to send error response, code: {}! (IOException): {}", HttpServletResponse.SC_NOT_FOUND, e1.toString());
         } catch (IllegalStateException ise) {
             // Log illegalstate instead of passing unrecoverable exception to calling thread
-            LOG.info("Unable to send error response, code: " + HttpServletResponse.SC_NOT_FOUND + "! isCommited: " + response.isCommitted() + " (IllegalStateException): " + ise);
+            LOG.warn("Unable to send error response, code: {}! isCommited: {}. (IllegalStateException): {}", HttpServletResponse.SC_NOT_FOUND, response.isCommitted(), ise.toString());
         }
     }
 

--- a/core/src/main/java/org/apache/struts2/dispatcher/DefaultStaticContentLoader.java
+++ b/core/src/main/java/org/apache/struts2/dispatcher/DefaultStaticContentLoader.java
@@ -222,10 +222,10 @@ public class DefaultStaticContentLoader implements StaticContentLoader {
             response.sendError(HttpServletResponse.SC_NOT_FOUND);
         } catch (IOException e1) {
             // we're already sending an error, not much else we can do if more stuff breaks
-            LOG.warn("Unable to send error response, code: {}! (IOException): {}", HttpServletResponse.SC_NOT_FOUND, e1.toString());
+            LOG.warn("Unable to send error response, code: {};", HttpServletResponse.SC_NOT_FOUND, e1);
         } catch (IllegalStateException ise) {
             // Log illegalstate instead of passing unrecoverable exception to calling thread
-            LOG.warn("Unable to send error response, code: {}! isCommited: {}. (IllegalStateException): {}", HttpServletResponse.SC_NOT_FOUND, response.isCommitted(), ise.toString());
+            LOG.warn("Unable to send error response, code: {}; isCommited: {};", HttpServletResponse.SC_NOT_FOUND, response.isCommitted(), ise);
         }
     }
 

--- a/core/src/main/java/org/apache/struts2/dispatcher/DefaultStaticContentLoader.java
+++ b/core/src/main/java/org/apache/struts2/dispatcher/DefaultStaticContentLoader.java
@@ -218,7 +218,15 @@ public class DefaultStaticContentLoader implements StaticContentLoader {
             }
         }
 
-        response.sendError(HttpServletResponse.SC_NOT_FOUND);
+        try {
+            response.sendError(HttpServletResponse.SC_NOT_FOUND);
+        } catch (IOException e1) {
+            // we're already sending an error, not much else we can do if more stuff breaks
+            LOG.info("Unable to send error response, code: " + HttpServletResponse.SC_NOT_FOUND + "! (IOException): " + e1);
+        } catch (IllegalStateException ise) {
+            // Log illegalstate instead of passing unrecoverable exception to calling thread
+            LOG.info("Unable to send error response, code: " + HttpServletResponse.SC_NOT_FOUND + "! isCommited: " + response.isCommitted() + " (IllegalStateException): " + ise);
+        }
     }
 
     protected void process(InputStream is, String path, HttpServletRequest request, HttpServletResponse response) throws IOException {

--- a/core/src/test/java/org/apache/struts2/dispatcher/DefaultDispatcherErrorHandlerTest.java
+++ b/core/src/test/java/org/apache/struts2/dispatcher/DefaultDispatcherErrorHandlerTest.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.struts2.dispatcher;
+
+import java.io.IOException;
+import java.util.Collections;
+import org.apache.struts2.StrutsInternalTestCase;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.apache.struts2.views.freemarker.FreemarkerManager;
+import static org.easymock.EasyMock.anyInt;
+import static org.easymock.EasyMock.anyString;
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.expectLastCall;
+import static org.easymock.EasyMock.replay;
+
+public class DefaultDispatcherErrorHandlerTest extends StrutsInternalTestCase {
+    private HttpServletRequest requestMock;
+    private HttpServletResponse responseMock;
+
+    /**
+     * Test to exercise the code path and prove handleError() will output 
+     * the desired log warning when an IOException is thrown with devMode false.
+     */
+    public void testHandleErrorIOException() {
+        DefaultDispatcherErrorHandler defaultDispatcherErrorHandler = new DefaultDispatcherErrorHandler();
+        defaultDispatcherErrorHandler.setDevMode("false");
+        defaultDispatcherErrorHandler.setFreemarkerManager(dispatcher.getContainer().getInstance(FreemarkerManager.class));
+        defaultDispatcherErrorHandler.init(dispatcher.servletContext);
+        Exception fakeException = new Exception("Fake Exception, devMode false");
+        try {
+            requestMock.setAttribute("javax.servlet.error.exception", fakeException);
+            expectLastCall();
+            requestMock.setAttribute("javax.servlet.jsp.jspException", fakeException);
+            expectLastCall();
+            responseMock.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, fakeException.getMessage());
+            expectLastCall().andStubThrow(new IOException("Fake IO Exception (SC_INTERNAL_SERVER_ERROR, devMode false)"));
+            replay(responseMock);
+        } catch (IOException ioe) {
+            fail("Mock sendError call setup failed.  Ex: " + ioe);
+        }
+        defaultDispatcherErrorHandler.handleError(requestMock, responseMock, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, fakeException);
+    }
+
+    /**
+     * Test to exercise the code path and prove handleError() will output 
+     * the desired log warning when an IOException is thrown with devMode true.
+     */
+    public void testHandleErrorIOExceptionDevMode() {
+        DefaultDispatcherErrorHandler defaultDispatcherErrorHandler = new DefaultDispatcherErrorHandler();
+        defaultDispatcherErrorHandler.setDevMode("true");
+        defaultDispatcherErrorHandler.setFreemarkerManager(dispatcher.getContainer().getInstance(FreemarkerManager.class));
+        defaultDispatcherErrorHandler.init(dispatcher.servletContext);
+        Exception fakeException = new Exception("Fake Exception, devMode true");
+        try {
+            responseMock.setContentType("text/html");
+            expectLastCall().andStubThrow(new IllegalStateException("Fake IllegalState Exception (report write)"));  // Fake error during report write
+            responseMock.sendError(anyInt(), anyString());
+            expectLastCall().andStubThrow(new IOException("Fake IO Exception (SC_INTERNAL_SERVER_ERROR, devMode true)"));
+            replay(responseMock);
+        } catch (IOException ioe) {
+            fail("Mock sendError call setup failed.  Ex: " + ioe);
+        }
+        defaultDispatcherErrorHandler.handleError(requestMock, responseMock, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, fakeException);
+    }
+
+    /**
+     * Test to exercise the code path and prove handleError() will output 
+     * the desired log warning when an IllegalStateException is thrown with devMode false.
+     */
+    public void testHandleErrorIllegalStateException() {
+        DefaultDispatcherErrorHandler defaultDispatcherErrorHandler = new DefaultDispatcherErrorHandler();
+        defaultDispatcherErrorHandler.setDevMode("false");
+        defaultDispatcherErrorHandler.setFreemarkerManager(dispatcher.getContainer().getInstance(FreemarkerManager.class));
+        defaultDispatcherErrorHandler.init(dispatcher.servletContext);
+        Exception fakeException = new Exception("Fake Exception, devMode false");
+        try {
+            requestMock.setAttribute("javax.servlet.error.exception", fakeException);
+            expectLastCall();
+            requestMock.setAttribute("javax.servlet.jsp.jspException", fakeException);
+            expectLastCall();
+            expect(responseMock.isCommitted()).andStubReturn(Boolean.TRUE);
+            responseMock.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, fakeException.getMessage());
+            expectLastCall().andStubThrow(new IllegalStateException("Fake IllegalState Exception (SC_INTERNAL_SERVER_ERROR, devMode false)"));
+            replay(responseMock);
+        } catch (IOException ioe) {
+            fail("Mock sendError call setup failed.  Ex: " + ioe);
+        }
+        defaultDispatcherErrorHandler.handleError(requestMock, responseMock, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, fakeException);
+    }
+
+    /**
+     * Test to exercise the code path and prove handleError() will output 
+     * the desired log warning when an IllegalStateException is thrown with devMode true.
+     */
+    public void testHandleErrorIllegalStateExceptionDevMode() {
+        DefaultDispatcherErrorHandler defaultDispatcherErrorHandler = new DefaultDispatcherErrorHandler();
+        defaultDispatcherErrorHandler.setDevMode("true");
+        defaultDispatcherErrorHandler.setFreemarkerManager(dispatcher.getContainer().getInstance(FreemarkerManager.class));
+        defaultDispatcherErrorHandler.init(dispatcher.servletContext);
+        Exception fakeException = new Exception("Fake Exception, devMode true");
+        try {
+            expect(responseMock.isCommitted()).andStubReturn(Boolean.TRUE);
+            responseMock.setContentType("text/html");
+            expectLastCall().andStubThrow(new IllegalStateException("Fake IllegalState Exception (report write)"));  // Fake error during report write
+            responseMock.sendError(anyInt(), anyString());
+            expectLastCall().andStubThrow(new IllegalStateException("Fake IllegalState Exception (SC_INTERNAL_SERVER_ERROR, devMode true)"));
+            replay(responseMock);
+        } catch (IOException ioe) {
+            fail("Mock sendError call setup failed.  Ex: " + ioe);
+        }
+        defaultDispatcherErrorHandler.handleError(requestMock, responseMock, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, fakeException);
+    }
+
+    protected void setUp() {
+        requestMock = (HttpServletRequest) createMock(HttpServletRequest.class);
+        responseMock = (HttpServletResponse) createMock(HttpServletResponse.class);
+        dispatcher = initDispatcher(Collections.<String, String>emptyMap());
+    }
+}


### PR DESCRIPTION
Improved logging for DefaultDispatcherErrorHandler and DefaultStaticContentLoader.

Provide informational logging for the processing of the two dispatcher classes when an http sendError fails for the two known failure types (IOException, IllegalStateException).

In both circumstances it is beneficial to have the developer aware of the failures via the logs.  These are not events that should be happening on a regular basis, so there is little risk of a log flood.

DefaultStaticContentLoader didn't catch either exception type previously, so changing it to make handling the same as DefaultDispatcherErrorHandler.

For DefaultDispatcherErrorHandler the IOException was caught with no notice of failure previously.  Now there will be an info level log output.
Previously the IllegalStateException was not caught, which resulted in the unrecoverable exception being thrown up to the calling thread, usually resulting in an ugly stacktrace to stdout/stderr.  Now there will be an info level log output instead.

If devMode is true, the info log outputs will include the exception parameter to the log, so a stacktrace can be viewed for more details.  If devMode is false (production mode), then only the exception's tostring() output will be produced.