### PR TITLE
Forward-port PR#354 from 2.5.x to 2.6.x (cherry-pick)

### DIFF
--- a/core/src/main/java/com/opensymphony/xwork2/config/providers/XmlConfigurationProvider.java
+++ b/core/src/main/java/com/opensymphony/xwork2/config/providers/XmlConfigurationProvider.java
@@ -93,12 +93,12 @@ public class XmlConfigurationProvider implements ConfigurationProvider {
     private String configFileName;
     private ObjectFactory objectFactory;
 
-    private Set<String> loadedFileUrls = new HashSet<>();
+    private final Set<String> loadedFileUrls = new HashSet<>();
     private boolean errorIfMissing;
     private Map<String, String> dtdMappings;
     private Configuration configuration;
     private boolean throwExceptionOnDuplicateBeans = true;
-    private Map<String, Element> declaredPackages = new HashMap<>();
+    private final Map<String, Element> declaredPackages = new HashMap<>();
 
     private FileManager fileManager;
     private ValueSubstitutor valueSubstitutor;
@@ -881,10 +881,12 @@ public class XmlConfigurationProvider implements ConfigurationProvider {
                 final StringBuilder allowedMethodsSB = new StringBuilder();
                 for (int i = 0; i < allowedMethodsChildren.getLength(); i++) {
                     Node allowedMethodsChildNode = allowedMethodsChildren.item(i);
-                    String childNodeValue = (allowedMethodsChildNode != null ? allowedMethodsChildNode.getNodeValue() : "");
-                    childNodeValue = (childNodeValue != null ? childNodeValue.trim() : "");
-                    if (childNodeValue.length() > 0) {
-                        allowedMethodsSB.append(childNodeValue);
+                    if (allowedMethodsChildNode != null && allowedMethodsChildNode.getNodeType() == Node.TEXT_NODE) {
+                        String childNodeValue = allowedMethodsChildNode.getNodeValue();
+                        childNodeValue = (childNodeValue != null ? childNodeValue.trim() : "");
+                        if (childNodeValue.length() > 0) {
+                            allowedMethodsSB.append(childNodeValue);
+                        }
                     }
                 }
                 if (allowedMethodsSB.length() > 0) {
@@ -951,10 +953,12 @@ public class XmlConfigurationProvider implements ConfigurationProvider {
                 final StringBuilder globalAllowedMethodsSB = new StringBuilder();
                 for (int i = 0; i < globaAllowedMethodsChildren.getLength(); i++) {
                     Node globalAllowedMethodsChildNode = globaAllowedMethodsChildren.item(i);
-                    String childNodeValue = (globalAllowedMethodsChildNode != null ? globalAllowedMethodsChildNode.getNodeValue() : "");
-                    childNodeValue = (childNodeValue != null ? childNodeValue.trim() : "");
-                    if (childNodeValue.length() > 0) {
-                        globalAllowedMethodsSB.append(childNodeValue);
+                    if (globalAllowedMethodsChildNode != null && globalAllowedMethodsChildNode.getNodeType() == Node.TEXT_NODE) {
+                        String childNodeValue = globalAllowedMethodsChildNode.getNodeValue();
+                        childNodeValue = (childNodeValue != null ? childNodeValue.trim() : "");
+                        if (childNodeValue.length() > 0) {
+                            globalAllowedMethodsSB.append(childNodeValue);
+                        }
                     }
                 }
                 if (globalAllowedMethodsSB.length() > 0) {


### PR DESCRIPTION
Hello Apache Struts Team.

This PR is a cherry-pick of a change, PR#354, that was missed for 2.6.x.  The change for PR#347 was previously cherry-picked into master, but PR#354 provided an update to that logic.

Merge pull request #354 from JCgH4164838Gh792C124B5/localS2_25x_B10

Minor consistency update correction for WW-5029 fix to the 2.5.x branch

(cherry picked from commit bb9ce7582b5b8e021eb458527777db07594e5739)