### PR TITLE
Update multiple Struts 2.5.x libraries to more recent versions.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
         <tiles.version>3.0.8</tiles.version>
         <tiles-request.version>1.0.7</tiles-request.version>
         <log4j2.version>2.12.1</log4j2.version>
-        <jackson.version>2.9.10</jackson.version>  <!-- 2.9.10 contains the 2.9.9.x jackson-databind fixes -->
+        <jackson.version>2.9.10</jackson.version>
 
         <!-- Site generation -->
         <fluido-skin.version>1.8</fluido-skin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -97,18 +97,16 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <spring.platformVersion>4.3.24.RELEASE</spring.platformVersion>
+        <spring.platformVersion>4.3.25.RELEASE</spring.platformVersion>
         <ognl.version>3.1.23</ognl.version>
         <asm.version>7.1</asm.version>
         <tiles.version>3.0.8</tiles.version>
         <tiles-request.version>1.0.7</tiles-request.version>
-        <log4j2.version>2.11.2</log4j2.version>
-        <jackson.version>2.9.9</jackson.version>
-        <!-- FIXME: drop once a new 2.9.10 will be out and all packages will be in sync -->
-        <jackson-databind.version>2.9.9.3</jackson-databind.version>
+        <log4j2.version>2.12.1</log4j2.version>
+        <jackson.version>2.9.10</jackson.version>  <!-- 2.9.10 contains the 2.9.9.x jackson-databind fixes -->
 
         <!-- Site generation -->
-        <fluido-skin.version>1.7</fluido-skin.version>
+        <fluido-skin.version>1.8</fluido-skin.version>
 
         <!-- Sonar -->
         <sonar.host.url>https://builds.apache.org/analysis/</sonar.host.url>
@@ -1003,12 +1001,12 @@
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
-                <version>1.7.26</version>
+                <version>1.7.28</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-simple</artifactId>
-                <version>1.7.26</version>
+                <version>1.7.28</version>
             </dependency>
 
             <dependency>
@@ -1082,7 +1080,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>${jackson-databind.version}</version>
+                <version>${jackson.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.dataformat</groupId>
@@ -1095,7 +1093,7 @@
             <dependency>
                 <groupId>org.codehaus.woodstox</groupId>
                 <artifactId>stax2-api</artifactId>
-                <version>4.1</version>
+                <version>4.2</version>
             </dependency>
 
             <!-- CDI & Weld -->


### PR DESCRIPTION
Update multiple Struts 2.5.x libraries to more recent versions.
Relates to WW-5033 and PRs: #356, #362.  Updated libraries:

Spring Platform 4.3.24 -> 4.3.25
Log4j2 2.11.2 -> 2.12.1
Jackson 2.9.9 -> 2.9.10 (allows removal of jackson 2.9.9.3 "micro patch" entry, taking care of pom.xml FIXME).
stax2-api 4.1 -> 4.2 (noted during Jackson update)
Fluido Skin 1.7 -> 1.8
SLF4J 1.7.26 -> 1.7.28