### PR TITLE
Remove duplicate attribute

### DIFF
--- a/core/src/site/confluence/ww-template-autoexport.html
+++ b/core/src/site/confluence/ww-template-autoexport.html
@@ -92,7 +92,7 @@ under the License.
   <body onload="init()">
     <table border="0" cellpadding="2" cellspacing="0" width="100%">
       <tr class="topBar">
-        <td align="left" valign="middle" class="topBarDiv" align="left" nowrap>
+        <td align="left" valign="middle" class="topBarDiv" nowrap>
           &nbsp;$autoexport.breadcrumbs($page)
         </td>
         <td align="right" valign="middle" nowrap>


### PR DESCRIPTION
Remove duplicate attributes in an HTML file at the confluence directory.


Signed-off-by: Lucca Scarano <lucca.scarano@hotmail.com>