### PR TITLE
Minor follow-up changes to PR #371

### DIFF
--- a/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlUtil.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlUtil.java
@@ -189,11 +189,16 @@ public class OgnlUtil {
      */
     @Inject(value = StrutsConstants.STRUTS_OGNL_EXPRESSION_MAX_LENGTH, required = false)
     protected void applyExpressionMaxLength(String maxLength) {
-        if (maxLength == null || maxLength.isEmpty()) {
-            // user is going to disable this functionality
-            Ognl.applyExpressionMaxLength(null);
-        } else {
-            Ognl.applyExpressionMaxLength(Integer.parseInt(maxLength));
+        try {
+            if (maxLength == null || maxLength.isEmpty()) {
+                // user is going to disable this functionality
+                Ognl.applyExpressionMaxLength(null);
+            } else {
+                Ognl.applyExpressionMaxLength(Integer.parseInt(maxLength));
+            }
+        } catch (Exception ex) {
+            LOG.warn("Unable to set OGNL Expression Max Length {}.", maxLength);  // Help configuration debugging.
+            throw ex;
         }
     }
 

--- a/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlValueStack.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlValueStack.java
@@ -204,7 +204,7 @@ public class OgnlValueStack implements Serializable, ValueStack, ClearableValueS
     }
 
     protected void handleOgnlException(String expr, Object value, boolean throwExceptionOnFailure, OgnlException e) {
-        if (e.getReason() instanceof SecurityException) {
+        if (e != null && e.getReason() instanceof SecurityException) {
             LOG.warn("Could not evaluate this expression due to security constraints: [{}]", expr, e);
         }
     	boolean shouldLog = shouldLogMissingPropertyWarning(e);
@@ -330,7 +330,7 @@ public class OgnlValueStack implements Serializable, ValueStack, ClearableValueS
 
     protected Object handleOgnlException(String expr, boolean throwExceptionOnFailure, OgnlException e) {
         Object ret = null;
-        if (e.getReason() instanceof SecurityException) {
+        if (e != null && e.getReason() instanceof SecurityException) {
             LOG.warn("Could not evaluate this expression due to security constraints: [{}]", expr, e);
         } else {
             ret = findInContext(expr);

--- a/core/src/main/resources/struts-default.xml
+++ b/core/src/main/resources/struts-default.xml
@@ -45,6 +45,7 @@
                 java.lang.ClassLoader,
                 java.lang.Shutdown,
                 java.lang.ProcessBuilder,
+                sun.misc.Unsafe,
                 com.opensymphony.xwork2.ActionContext" />
 
     <!-- this must be valid regex, each '.' in package name must be escaped! -->
@@ -56,11 +57,14 @@
               value="
                 ognl.,
                 java.io.,
+                java.net.,
+                java.nio.,
                 javax.,
                 freemarker.core.,
                 freemarker.template.,
                 freemarker.ext.jsp.,
                 freemarker.ext.rhino.,
+                sun.misc.,
                 sun.reflect.,
                 javassist.,
                 org.apache.velocity.,

--- a/core/src/test/java/com/opensymphony/xwork2/ognl/OgnlUtilTest.java
+++ b/core/src/test/java/com/opensymphony/xwork2/ognl/OgnlUtilTest.java
@@ -1232,6 +1232,40 @@ public class OgnlUtilTest extends XWorkTestCase {
         }
     }
 
+    /**
+     * Test OGNL Expression Max Length feature setting via OgnlUtil.
+     * 
+     * @since 2.5.21
+     */
+    public void testApplyExpressionMaxLength() {
+        try {
+            ognlUtil.applyExpressionMaxLength(null);
+        } catch (Exception ex) {
+            fail ("applyExpressionMaxLength did not accept null maxlength string ?");
+        }
+        try {
+            ognlUtil.applyExpressionMaxLength("");
+        } catch (Exception ex) {
+            fail ("applyExpressionMaxLength did not accept empty maxlength string ?");
+        }
+        try {
+            ognlUtil.applyExpressionMaxLength("-1");
+            fail ("applyExpressionMaxLength accepted negative maxlength string ?");
+        } catch (IllegalArgumentException iae) {
+            // Expected rejection of -ive length.
+        }
+        try {
+            ognlUtil.applyExpressionMaxLength("0");
+        } catch (Exception ex) {
+            fail ("applyExpressionMaxLength did not accept maxlength string 0 ?");
+        }
+        try {
+            ognlUtil.applyExpressionMaxLength(Integer.toString(Integer.MAX_VALUE, 10));
+        } catch (Exception ex) {
+            fail ("applyExpressionMaxLength did not accept MAX_VALUE maxlength string ?");
+        }
+    }
+
     private void internalTestInitialEmptyOgnlUtilExclusions(OgnlUtil ognlUtilParam) throws Exception {
         Set<Class<?>> excludedClasses = ognlUtilParam.getExcludedClasses();
         assertNotNull("parameter (default) exluded classes null?", excludedClasses);


### PR DESCRIPTION
Minor follow-up changes to PR #371
- added some additional exclusions in struts-default.xml.
- added log warning that specifies the value of maxLength involved if applyExpressionMaxLength(maxLength) fails.
- added null guards to two handleOgnlException() methods that could result in an NPE with #371 changes (a null OgnlException parameter was permissible previously, correct or not).