### PR TITLE
Disable expressionMaxLength by default for Struts 2.5.x.

### DIFF
--- a/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlUtil.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlUtil.java
@@ -52,7 +52,6 @@ import java.util.regex.Pattern;
  */
 public class OgnlUtil {
 
-    protected static final int MININUM_OGNL_EXPRESSION_MAXLENGTH = 128;  // Minimum permitted value for STRUTS_OGNL_EXPRESSION_MAX_LENGTH
     private static final Logger LOG = LogManager.getLogger(OgnlUtil.class);
 
     private final ConcurrentMap<String, Object> expressions = new ConcurrentHashMap<>();
@@ -195,14 +194,10 @@ public class OgnlUtil {
                 // user is going to disable this functionality
                 Ognl.applyExpressionMaxLength(null);
             } else {
-                final Integer maxLengthInteger = Integer.parseInt(maxLength);
-                if (maxLengthInteger < MININUM_OGNL_EXPRESSION_MAXLENGTH) {
-                    throw new IllegalArgumentException("OGNL Expression Max Length less than " + MININUM_OGNL_EXPRESSION_MAXLENGTH + " not permitted.");
-                }
-                Ognl.applyExpressionMaxLength(maxLengthInteger);
+                Ognl.applyExpressionMaxLength(Integer.parseInt(maxLength));
             }
         } catch (Exception ex) {
-            LOG.warn("Unable to set OGNL Expression Max Length {}.", maxLength);  // Help configuration debugging.
+            LOG.error("Unable to set OGNL Expression Max Length {}.", maxLength);  // Help configuration debugging.
             throw ex;
         }
     }

--- a/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlUtil.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlUtil.java
@@ -52,6 +52,7 @@ import java.util.regex.Pattern;
  */
 public class OgnlUtil {
 
+    protected static final int MININUM_OGNL_EXPRESSION_MAXLENGTH = 128;  // Minimum permitted value for STRUTS_OGNL_EXPRESSION_MAX_LENGTH
     private static final Logger LOG = LogManager.getLogger(OgnlUtil.class);
 
     private final ConcurrentMap<String, Object> expressions = new ConcurrentHashMap<>();
@@ -194,7 +195,11 @@ public class OgnlUtil {
                 // user is going to disable this functionality
                 Ognl.applyExpressionMaxLength(null);
             } else {
-                Ognl.applyExpressionMaxLength(Integer.parseInt(maxLength));
+                final Integer maxLengthInteger = Integer.parseInt(maxLength);
+                if (maxLengthInteger < MININUM_OGNL_EXPRESSION_MAXLENGTH) {
+                    throw new IllegalArgumentException("OGNL Expression Max Length less than " + MININUM_OGNL_EXPRESSION_MAXLENGTH + " not permitted.");
+                }
+                Ognl.applyExpressionMaxLength(maxLengthInteger);
             }
         } catch (Exception ex) {
             LOG.warn("Unable to set OGNL Expression Max Length {}.", maxLength);  // Help configuration debugging.

--- a/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlValueStack.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlValueStack.java
@@ -205,7 +205,7 @@ public class OgnlValueStack implements Serializable, ValueStack, ClearableValueS
 
     protected void handleOgnlException(String expr, Object value, boolean throwExceptionOnFailure, OgnlException e) {
         if (e != null && e.getReason() instanceof SecurityException) {
-            LOG.warn("Could not evaluate this expression due to security constraints: [{}]", expr, e);
+            LOG.error("Could not evaluate this expression due to security constraints: [{}]", expr, e);
         }
     	boolean shouldLog = shouldLogMissingPropertyWarning(e);
     	String msg = null;
@@ -331,7 +331,7 @@ public class OgnlValueStack implements Serializable, ValueStack, ClearableValueS
     protected Object handleOgnlException(String expr, boolean throwExceptionOnFailure, OgnlException e) {
         Object ret = null;
         if (e != null && e.getReason() instanceof SecurityException) {
-            LOG.warn("Could not evaluate this expression due to security constraints: [{}]", expr, e);
+            LOG.error("Could not evaluate this expression due to security constraints: [{}]", expr, e);
         } else {
             ret = findInContext(expr);
         }

--- a/core/src/main/resources/org/apache/struts2/default.properties
+++ b/core/src/main/resources/org/apache/struts2/default.properties
@@ -220,7 +220,14 @@ struts.ognl.enableExpressionCache=true
 ### or simply rethrow it as a ServletException to allow future processing by other frameworks like Spring Security
 struts.handle.exception=true
 
-### applies maximum length allowed on OGNL expressions for security enhancement
-struts.ognl.expressionMaxLength=200
+### Applies maximum length allowed on OGNL expressions for security enhancement (optional)
+###
+### **WARNING**: If developers enable this option (by configuration) they should make sure that they understand the implications of setting 
+###   struts.ognl.expressionMaxLength.  They must choose a value large enough to permit ALL valid OGNL expressions used within the application.
+###   Values larger than the 200-400 range have diminishing security value (at which point it is really only a "style guard" for long OGNL
+###   expressions in an application.  Setting a value of null or "" will also disable the feature.
+###
+### NOTE: The sample line below is *INTENTIONALLY* commented out, as this feature is disabled by default.
+# struts.ognl.expressionMaxLength=256
 
 ### END SNIPPET: complete_file

--- a/core/src/test/java/com/opensymphony/xwork2/ognl/OgnlUtilTest.java
+++ b/core/src/test/java/com/opensymphony/xwork2/ognl/OgnlUtilTest.java
@@ -1277,25 +1277,9 @@ public class OgnlUtilTest extends XWorkTestCase {
                 // Expected rejection of -ive length.
             }
             try {
-                assertTrue(OgnlUtil.MININUM_OGNL_EXPRESSION_MAXLENGTH + " is not > 0 ?", OgnlUtil.MININUM_OGNL_EXPRESSION_MAXLENGTH > 0);
                 ognlUtil.applyExpressionMaxLength("0");
-                fail ("applyExpressionMaxLength accepted maxlength string 0 when minimum maxlength is " + OgnlUtil.MININUM_OGNL_EXPRESSION_MAXLENGTH + " ?");
             } catch (Exception ex) {
-                // Expected rejection of length 0 < MININUM_OGNL_EXPRESSION_MAXLENGTH
-            }
-            try {
-                assertTrue(OgnlUtil.MININUM_OGNL_EXPRESSION_MAXLENGTH + " is not > " + (OgnlUtil.MININUM_OGNL_EXPRESSION_MAXLENGTH - 1) + " ?",
-                        OgnlUtil.MININUM_OGNL_EXPRESSION_MAXLENGTH > (OgnlUtil.MININUM_OGNL_EXPRESSION_MAXLENGTH - 1));
-                ognlUtil.applyExpressionMaxLength(Integer.valueOf(OgnlUtil.MININUM_OGNL_EXPRESSION_MAXLENGTH - 1).toString());
-                fail ("applyExpressionMaxLength accepted maxlength string " + (OgnlUtil.MININUM_OGNL_EXPRESSION_MAXLENGTH - 1) + " when minimum maxlength is " +
-                        OgnlUtil.MININUM_OGNL_EXPRESSION_MAXLENGTH + " ?");
-            } catch (Exception ex) {
-                // Expected rejection of length (MININUM_OGNL_EXPRESSION_MAXLENGTH - 1) < MININUM_OGNL_EXPRESSION_MAXLENGTH
-            }
-            try {
-                ognlUtil.applyExpressionMaxLength(Integer.valueOf(OgnlUtil.MININUM_OGNL_EXPRESSION_MAXLENGTH).toString());
-            } catch (Exception ex) {
-                fail ("applyExpressionMaxLength did not accept maxlength string " + OgnlUtil.MININUM_OGNL_EXPRESSION_MAXLENGTH + " ?");
+                fail ("applyExpressionMaxLength did not accept maxlength string 0 ?");
             }
             try {
                 ognlUtil.applyExpressionMaxLength(Integer.toString(Integer.MAX_VALUE, 10));

--- a/core/src/test/java/com/opensymphony/xwork2/ognl/OgnlUtilTest.java
+++ b/core/src/test/java/com/opensymphony/xwork2/ognl/OgnlUtilTest.java
@@ -1233,6 +1233,27 @@ public class OgnlUtilTest extends XWorkTestCase {
     }
 
     /**
+     * Test OGNL Expression Max Length feature setting via OgnlUtil is disabled by default (in default.properties).
+     * 
+     * @since 2.5.21
+     */
+    public void testDefaultExpressionMaxLengthDisabled() {
+        final String LONG_OGNL_EXPRESSION = "true == ThisIsAReallyLongOGNLExpressionOfRepeatedGarbageText." + new String(new char[65535]).replace('\0', 'A');  // Expression larger than 64KB.
+        try {
+            Object compileResult = ognlUtil.compile(LONG_OGNL_EXPRESSION);
+            assertNotNull("Long OGNL expression compilation produced a null result ?", compileResult);
+        } catch (OgnlException oex) {
+             if (oex.getReason() instanceof SecurityException) {
+                 fail ("Unable to compile expression (unexpected).  'struts.ognl.expressionMaxLength' may have accidentally been enabled by default.  Exception: " + oex);
+             } else {
+                 fail ("Unable to compile expression (unexpected).  Exception: " + oex);
+             }
+        } catch (Exception ex) {
+            fail ("Unable to compile expression (unexpected).  Exception: " + ex);
+        }
+    }
+
+    /**
      * Test OGNL Expression Max Length feature setting via OgnlUtil.
      * 
      * @since 2.5.21
@@ -1241,12 +1262,12 @@ public class OgnlUtilTest extends XWorkTestCase {
         try {
             ognlUtil.applyExpressionMaxLength(null);
         } catch (Exception ex) {
-            fail ("applyExpressionMaxLength did not accept null maxlength string ?");
+            fail ("applyExpressionMaxLength did not accept null maxlength string (disable feature) ?");
         }
         try {
             ognlUtil.applyExpressionMaxLength("");
         } catch (Exception ex) {
-            fail ("applyExpressionMaxLength did not accept empty maxlength string ?");
+            fail ("applyExpressionMaxLength did not accept empty maxlength string (disable feature) ?");
         }
         try {
             ognlUtil.applyExpressionMaxLength("-1");
@@ -1263,6 +1284,12 @@ public class OgnlUtilTest extends XWorkTestCase {
             ognlUtil.applyExpressionMaxLength(Integer.toString(Integer.MAX_VALUE, 10));
         } catch (Exception ex) {
             fail ("applyExpressionMaxLength did not accept MAX_VALUE maxlength string ?");
+        }
+        // Reset expressionMaxLength value to default (disabled)
+        try {
+            ognlUtil.applyExpressionMaxLength(null);
+        } catch (Exception ex) {
+            fail ("applyExpressionMaxLength did not accept null maxlength string (disable feature) ?");
         }
     }
 

--- a/core/src/test/java/com/opensymphony/xwork2/ognl/OgnlUtilTest.java
+++ b/core/src/test/java/com/opensymphony/xwork2/ognl/OgnlUtilTest.java
@@ -1260,36 +1260,51 @@ public class OgnlUtilTest extends XWorkTestCase {
      */
     public void testApplyExpressionMaxLength() {
         try {
+            try {
+                ognlUtil.applyExpressionMaxLength(null);
+            } catch (Exception ex) {
+                fail ("applyExpressionMaxLength did not accept null maxlength string (disable feature) ?");
+            }
+            try {
+                ognlUtil.applyExpressionMaxLength("");
+            } catch (Exception ex) {
+                fail ("applyExpressionMaxLength did not accept empty maxlength string (disable feature) ?");
+            }
+            try {
+                ognlUtil.applyExpressionMaxLength("-1");
+                fail ("applyExpressionMaxLength accepted negative maxlength string ?");
+            } catch (IllegalArgumentException iae) {
+                // Expected rejection of -ive length.
+            }
+            try {
+                assertTrue(OgnlUtil.MININUM_OGNL_EXPRESSION_MAXLENGTH + " is not > 0 ?", OgnlUtil.MININUM_OGNL_EXPRESSION_MAXLENGTH > 0);
+                ognlUtil.applyExpressionMaxLength("0");
+                fail ("applyExpressionMaxLength accepted maxlength string 0 when minimum maxlength is " + OgnlUtil.MININUM_OGNL_EXPRESSION_MAXLENGTH + " ?");
+            } catch (Exception ex) {
+                // Expected rejection of length 0 < MININUM_OGNL_EXPRESSION_MAXLENGTH
+            }
+            try {
+                assertTrue(OgnlUtil.MININUM_OGNL_EXPRESSION_MAXLENGTH + " is not > " + (OgnlUtil.MININUM_OGNL_EXPRESSION_MAXLENGTH - 1) + " ?",
+                        OgnlUtil.MININUM_OGNL_EXPRESSION_MAXLENGTH > (OgnlUtil.MININUM_OGNL_EXPRESSION_MAXLENGTH - 1));
+                ognlUtil.applyExpressionMaxLength(Integer.valueOf(OgnlUtil.MININUM_OGNL_EXPRESSION_MAXLENGTH - 1).toString());
+                fail ("applyExpressionMaxLength accepted maxlength string " + (OgnlUtil.MININUM_OGNL_EXPRESSION_MAXLENGTH - 1) + " when minimum maxlength is " +
+                        OgnlUtil.MININUM_OGNL_EXPRESSION_MAXLENGTH + " ?");
+            } catch (Exception ex) {
+                // Expected rejection of length (MININUM_OGNL_EXPRESSION_MAXLENGTH - 1) < MININUM_OGNL_EXPRESSION_MAXLENGTH
+            }
+            try {
+                ognlUtil.applyExpressionMaxLength(Integer.valueOf(OgnlUtil.MININUM_OGNL_EXPRESSION_MAXLENGTH).toString());
+            } catch (Exception ex) {
+                fail ("applyExpressionMaxLength did not accept maxlength string " + OgnlUtil.MININUM_OGNL_EXPRESSION_MAXLENGTH + " ?");
+            }
+            try {
+                ognlUtil.applyExpressionMaxLength(Integer.toString(Integer.MAX_VALUE, 10));
+            } catch (Exception ex) {
+                fail ("applyExpressionMaxLength did not accept MAX_VALUE maxlength string ?");
+            }
+        } finally {
+            // Reset expressionMaxLength value to default (disabled)
             ognlUtil.applyExpressionMaxLength(null);
-        } catch (Exception ex) {
-            fail ("applyExpressionMaxLength did not accept null maxlength string (disable feature) ?");
-        }
-        try {
-            ognlUtil.applyExpressionMaxLength("");
-        } catch (Exception ex) {
-            fail ("applyExpressionMaxLength did not accept empty maxlength string (disable feature) ?");
-        }
-        try {
-            ognlUtil.applyExpressionMaxLength("-1");
-            fail ("applyExpressionMaxLength accepted negative maxlength string ?");
-        } catch (IllegalArgumentException iae) {
-            // Expected rejection of -ive length.
-        }
-        try {
-            ognlUtil.applyExpressionMaxLength("0");
-        } catch (Exception ex) {
-            fail ("applyExpressionMaxLength did not accept maxlength string 0 ?");
-        }
-        try {
-            ognlUtil.applyExpressionMaxLength(Integer.toString(Integer.MAX_VALUE, 10));
-        } catch (Exception ex) {
-            fail ("applyExpressionMaxLength did not accept MAX_VALUE maxlength string ?");
-        }
-        // Reset expressionMaxLength value to default (disabled)
-        try {
-            ognlUtil.applyExpressionMaxLength(null);
-        } catch (Exception ex) {
-            fail ("applyExpressionMaxLength did not accept null maxlength string (disable feature) ?");
         }
     }
 

--- a/core/src/test/java/com/opensymphony/xwork2/ognl/OgnlValueStackTest.java
+++ b/core/src/test/java/com/opensymphony/xwork2/ognl/OgnlValueStackTest.java
@@ -351,6 +351,32 @@ public class OgnlValueStackTest extends XWorkTestCase {
         }
     }
 
+    public void testFailOnTooLongExpressionLongerThan192_ViaOverriddenProperty() {
+        try {
+            loadConfigurationProviders(new StubConfigurationProvider() {
+                @Override
+                public void register(ContainerBuilder builder,
+                                     LocatableProperties props) throws ConfigurationException {
+                    props.setProperty(StrutsConstants.STRUTS_OGNL_EXPRESSION_MAX_LENGTH, "192");
+                }
+            });
+            Integer repeat = Integer.parseInt(
+                    container.getInstance(String.class, StrutsConstants.STRUTS_OGNL_EXPRESSION_MAX_LENGTH));
+
+            OgnlValueStack vs = createValueStack();
+            try {
+                vs.findValue(StringUtils.repeat('.', repeat + 1), true);
+                fail("Failed to throw exception on too long expression");
+            } catch (Exception ex) {
+                assertTrue(ex.getCause() instanceof OgnlException);
+                assertTrue(((OgnlException) ex.getCause()).getReason() instanceof SecurityException);
+            }
+        } finally {
+            // Reset expressionMaxLength value to default (disabled)
+            ognlUtil.applyExpressionMaxLength(null);
+        }
+    }
+
     public void testNotFailOnTooLongExpressionWithDefaultProperties() {
         loadConfigurationProviders(new DefaultPropertiesProvider());
 
@@ -378,42 +404,40 @@ public class OgnlValueStackTest extends XWorkTestCase {
     }
 
     public void testNotFailOnTooLongValueWithDefaultProperties() {
-        loadConfigurationProviders(new DefaultPropertiesProvider());
-
-        Object defaultMaxLengthFromConfiguration = container.getInstance(String.class, StrutsConstants.STRUTS_OGNL_EXPRESSION_MAX_LENGTH);
-        if (defaultMaxLengthFromConfiguration != null) {
-            assertTrue("non-null defaultMaxLengthFromConfiguration not a String ?", defaultMaxLengthFromConfiguration instanceof String);
-            assertTrue("non-null defaultMaxLengthFromConfiguration not empty string by default ?", ((String) defaultMaxLengthFromConfiguration).length() == 0);
-        } else {
-            assertNull("defaultMaxLengthFromConfiguration not null ?", defaultMaxLengthFromConfiguration);
-        }
-        // Original test logic is unchanged (testing that values can be larger than maximum expression length), but since the feature is disabled by
-        // default we will now have to enable it with an arbitrary value, test, and reset it to disabled.
-        Integer repeat = Integer.valueOf(256);  // Since maxlength is disabled by default, just choose an arbitrary value for test
-
-        // Apply a non-default value for expressionMaxLength (as it should be disabled by default)
         try {
-            ognlUtil.applyExpressionMaxLength(repeat.toString(10));
-        } catch (Exception ex) {
-            fail ("applyExpressionMaxLength did not accept maxlength string " + repeat.toString() + " ?");
-        }
+            loadConfigurationProviders(new DefaultPropertiesProvider());
 
-        OgnlValueStack vs = createValueStack();
+            Object defaultMaxLengthFromConfiguration = container.getInstance(String.class, StrutsConstants.STRUTS_OGNL_EXPRESSION_MAX_LENGTH);
+            if (defaultMaxLengthFromConfiguration != null) {
+                assertTrue("non-null defaultMaxLengthFromConfiguration not a String ?", defaultMaxLengthFromConfiguration instanceof String);
+                assertTrue("non-null defaultMaxLengthFromConfiguration not empty string by default ?", ((String) defaultMaxLengthFromConfiguration).length() == 0);
+            } else {
+                assertNull("defaultMaxLengthFromConfiguration not null ?", defaultMaxLengthFromConfiguration);
+            }
+            // Original test logic is unchanged (testing that values can be larger than maximum expression length), but since the feature is disabled by
+            // default we will now have to enable it with an arbitrary value, test, and reset it to disabled.
+            Integer repeat = Integer.valueOf(256);  // Since maxlength is disabled by default, just choose an arbitrary value for test
 
-        Dog dog = new Dog();
-        vs.push(dog);
+            // Apply a non-default value for expressionMaxLength (as it should be disabled by default)
+            try {
+                ognlUtil.applyExpressionMaxLength(repeat.toString());
+            } catch (Exception ex) {
+                fail ("applyExpressionMaxLength did not accept maxlength string " + repeat.toString() + " ?");
+            }
 
-        String value = StringUtils.repeat('.', repeat + 1);
+            OgnlValueStack vs = createValueStack();
 
-        vs.setValue("name", value);
+            Dog dog = new Dog();
+            vs.push(dog);
 
-        assertEquals(value, dog.getName());
+            String value = StringUtils.repeat('.', repeat + 1);
 
-        // Reset expressionMaxLength value to default (disabled)
-        try {
+            vs.setValue("name", value);
+
+            assertEquals(value, dog.getName());
+        } finally {
+            // Reset expressionMaxLength value to default (disabled)
             ognlUtil.applyExpressionMaxLength(null);
-        } catch (Exception ex) {
-            fail ("applyExpressionMaxLength did not accept null maxlength string (disable feature) ?");
         }
     }
 

--- a/core/src/test/java/com/opensymphony/xwork2/ognl/OgnlValueStackTest.java
+++ b/core/src/test/java/com/opensymphony/xwork2/ognl/OgnlValueStackTest.java
@@ -40,6 +40,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import ognl.ParseException;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
@@ -350,25 +351,52 @@ public class OgnlValueStackTest extends XWorkTestCase {
         }
     }
 
-    public void testFailOnTooLongExpressionWithDefaultProperties() {
+    public void testNotFailOnTooLongExpressionWithDefaultProperties() {
         loadConfigurationProviders(new DefaultPropertiesProvider());
-        Integer repeat = Integer.parseInt(
-                container.getInstance(String.class, StrutsConstants.STRUTS_OGNL_EXPRESSION_MAX_LENGTH));
+
+        Object defaultMaxLengthFromConfiguration = container.getInstance(String.class, StrutsConstants.STRUTS_OGNL_EXPRESSION_MAX_LENGTH);
+        if (defaultMaxLengthFromConfiguration != null) {
+            assertTrue("non-null defaultMaxLengthFromConfiguration not a String ?", defaultMaxLengthFromConfiguration instanceof String);
+            assertTrue("non-null defaultMaxLengthFromConfiguration not empty string by default ?", ((String) defaultMaxLengthFromConfiguration).length() == 0);
+        } else {
+            assertNull("defaultMaxLengthFromConfiguration not null ?", defaultMaxLengthFromConfiguration);
+        }
+        // Original test logic was to confirm failure of exceeding the default value.  Now the feature should be disabled by default,
+        // so this test's expectations are now changed.
+        Integer repeat = Integer.valueOf(256);  // Since maxlength is disabled by default, just choose an arbitrary value for test
 
         OgnlValueStack vs = createValueStack();
         try {
             vs.findValue(StringUtils.repeat('.', repeat + 1), true);
-            fail("Failed to throw exception on too long expression");
+            fail("findValue did not throw any exception (should either fail as invalid expression syntax or security exception) ?");
         } catch (Exception ex) {
+            // If STRUTS_OGNL_EXPRESSION_MAX_LENGTH feature is disabled (default), the parse should fail due to a reason of invalid expression syntax
+            // with ParseException.  Previously when it was enabled the reason for the failure would have been SecurityException.
             assertTrue(ex.getCause() instanceof OgnlException);
-            assertTrue(((OgnlException) ex.getCause()).getReason() instanceof SecurityException);
+            assertTrue(((OgnlException) ex.getCause()).getReason() instanceof ParseException);
         }
     }
 
     public void testNotFailOnTooLongValueWithDefaultProperties() {
         loadConfigurationProviders(new DefaultPropertiesProvider());
-        Integer repeat = Integer.parseInt(
-                container.getInstance(String.class, StrutsConstants.STRUTS_OGNL_EXPRESSION_MAX_LENGTH));
+
+        Object defaultMaxLengthFromConfiguration = container.getInstance(String.class, StrutsConstants.STRUTS_OGNL_EXPRESSION_MAX_LENGTH);
+        if (defaultMaxLengthFromConfiguration != null) {
+            assertTrue("non-null defaultMaxLengthFromConfiguration not a String ?", defaultMaxLengthFromConfiguration instanceof String);
+            assertTrue("non-null defaultMaxLengthFromConfiguration not empty string by default ?", ((String) defaultMaxLengthFromConfiguration).length() == 0);
+        } else {
+            assertNull("defaultMaxLengthFromConfiguration not null ?", defaultMaxLengthFromConfiguration);
+        }
+        // Original test logic is unchanged (testing that values can be larger than maximum expression length), but since the feature is disabled by
+        // default we will now have to enable it with an arbitrary value, test, and reset it to disabled.
+        Integer repeat = Integer.valueOf(256);  // Since maxlength is disabled by default, just choose an arbitrary value for test
+
+        // Apply a non-default value for expressionMaxLength (as it should be disabled by default)
+        try {
+            ognlUtil.applyExpressionMaxLength(repeat.toString(10));
+        } catch (Exception ex) {
+            fail ("applyExpressionMaxLength did not accept maxlength string " + repeat.toString() + " ?");
+        }
 
         OgnlValueStack vs = createValueStack();
 
@@ -380,6 +408,13 @@ public class OgnlValueStackTest extends XWorkTestCase {
         vs.setValue("name", value);
 
         assertEquals(value, dog.getName());
+
+        // Reset expressionMaxLength value to default (disabled)
+        try {
+            ognlUtil.applyExpressionMaxLength(null);
+        } catch (Exception ex) {
+            fail ("applyExpressionMaxLength did not accept null maxlength string (disable feature) ?");
+        }
     }
 
     public void testFailsOnMethodThatThrowsException() {


### PR DESCRIPTION
Disable struts.ognl.expressionMaxLength by default for Struts 2.5.x.
- Commented out struts.ognl.expressionMaxLength line in default.properties and provided in-place comments about its usage.
- Changed OgnlValueStack.handleOgnlException() methods to output error instead of warn for failures to evaluate expressions due to security constraints.
- Updated existing unit tests to compensate for change in default behaviour.
- Added a unit test to confirm default behaviour for struts.ognl.expressionMaxLength is disabled.