### PR TITLE
Fix incorrect encoding strings in FileUploadInterceptorTest

### DIFF
--- a/core/src/test/java/org/apache/struts2/interceptor/FileUploadInterceptorTest.java
+++ b/core/src/test/java/org/apache/struts2/interceptor/FileUploadInterceptorTest.java
@@ -40,6 +40,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -244,7 +245,7 @@ public class FileUploadInterceptorTest extends StrutsInternalTestCase {
     public void testNoContentMultipartRequest() throws Exception {
         MockHttpServletRequest req = new MockHttpServletRequest();
 
-        req.setCharacterEncoding("text/html");
+        req.setCharacterEncoding(StandardCharsets.UTF_8.name());
         req.setMethod("post");
         req.addHeader("Content-type", "multipart/form-data");
         req.setContent(null); // there is no content
@@ -265,7 +266,7 @@ public class FileUploadInterceptorTest extends StrutsInternalTestCase {
 
     public void testSuccessUploadOfATextFileMultipartRequest() throws Exception {
         MockHttpServletRequest req = new MockHttpServletRequest();
-        req.setCharacterEncoding("text/html");
+        req.setCharacterEncoding(StandardCharsets.UTF_8.name());
         req.setMethod("post");
         req.addHeader("Content-type", "multipart/form-data; boundary=---1234");
 
@@ -322,7 +323,7 @@ public class FileUploadInterceptorTest extends StrutsInternalTestCase {
         final String endline = "\r\n";
 
         MockHttpServletRequest req = new MockHttpServletRequest();
-        req.setCharacterEncoding("text/html");
+        req.setCharacterEncoding(StandardCharsets.UTF_8.name());
         req.setMethod("POST");
         req.addHeader("Content-type", "multipart/form-data; boundary=" + bondary);
         StringBuilder content = new StringBuilder(128);
@@ -371,7 +372,7 @@ public class FileUploadInterceptorTest extends StrutsInternalTestCase {
 
     public void testMultipartRequestLocalizedError() throws Exception {
         MockHttpServletRequest req = new MockHttpServletRequest();
-        req.setCharacterEncoding("text/html");
+        req.setCharacterEncoding(StandardCharsets.UTF_8.name());
         req.setMethod("post");
         req.addHeader("Content-type", "multipart/form-data; boundary=---1234");
 


### PR DESCRIPTION
Fix incorrect encoding strings provided in FileUploadInterceptorTest
- Tests were using "text/html" which is not a valid character encoding. No impact currently, but the tests could fail in the future if this is not corrected.  If the code is re-used elsewhere for a test of an action a
valid encoding will be needed.
- Switch to a predefined constant Charset to get the string instead.