### PR TITLE
Fix incorrect encoding strings in FileUploadInterceptorTest (cherry-pick fix for 2.6.x)

### DIFF
--- a/core/src/test/java/org/apache/struts2/interceptor/FileUploadInterceptorTest.java
+++ b/core/src/test/java/org/apache/struts2/interceptor/FileUploadInterceptorTest.java
@@ -40,6 +40,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -244,7 +245,7 @@ public class FileUploadInterceptorTest extends StrutsInternalTestCase {
     public void testNoContentMultipartRequest() throws Exception {
         MockHttpServletRequest req = new MockHttpServletRequest();
 
-        req.setCharacterEncoding("text/html");
+        req.setCharacterEncoding(StandardCharsets.UTF_8.name());
         req.setMethod("post");
         req.addHeader("Content-type", "multipart/form-data");
         req.setContent(null); // there is no content
@@ -265,7 +266,7 @@ public class FileUploadInterceptorTest extends StrutsInternalTestCase {
 
     public void testSuccessUploadOfATextFileMultipartRequest() throws Exception {
         MockHttpServletRequest req = new MockHttpServletRequest();
-        req.setCharacterEncoding("text/html");
+        req.setCharacterEncoding(StandardCharsets.UTF_8.name());
         req.setMethod("post");
         req.addHeader("Content-type", "multipart/form-data; boundary=---1234");
 
@@ -322,7 +323,7 @@ public class FileUploadInterceptorTest extends StrutsInternalTestCase {
         final String endline = "\r\n";
 
         MockHttpServletRequest req = new MockHttpServletRequest();
-        req.setCharacterEncoding("text/html");
+        req.setCharacterEncoding(StandardCharsets.UTF_8.name());
         req.setMethod("POST");
         req.addHeader("Content-type", "multipart/form-data; boundary=" + bondary);
         StringBuilder content = new StringBuilder(128);
@@ -371,7 +372,7 @@ public class FileUploadInterceptorTest extends StrutsInternalTestCase {
 
     public void testMultipartRequestLocalizedError() throws Exception {
         MockHttpServletRequest req = new MockHttpServletRequest();
-        req.setCharacterEncoding("text/html");
+        req.setCharacterEncoding(StandardCharsets.UTF_8.name());
         req.setMethod("post");
         req.addHeader("Content-type", "multipart/form-data; boundary=---1234");
 


### PR DESCRIPTION
Fix incorrect encoding strings in FileUploadInterceptorTest (cherry-pick fix for 2.6.x)

Merge pull request #385 from JCgH4164838Gh792C124B5/local_25x_TstFix1
Fix incorrect encoding strings in FileUploadInterceptorTest

(cherry picked from commit 47c87bc62cd41c668146e18c1b06d49ecec7fd0a)