### PR TITLE
WW5052 TypeConversionException instead StrutsException

### DIFF
--- a/core/src/main/java/com/opensymphony/xwork2/conversion/impl/DateConverter.java
+++ b/core/src/main/java/com/opensymphony/xwork2/conversion/impl/DateConverter.java
@@ -18,6 +18,7 @@
  */
 package com.opensymphony.xwork2.conversion.impl;
 
+import com.opensymphony.xwork2.conversion.TypeConversionException;
 import org.apache.struts2.StrutsException;
 
 import java.lang.reflect.Constructor;
@@ -90,11 +91,11 @@ public class DateConverter extends DefaultTypeConverter {
                         Constructor constructor = toType.getConstructor(new Class[]{long.class});
                         return constructor.newInstance(new Object[]{Long.valueOf(result.getTime())});
                     } catch (Exception e) {
-                        throw new StrutsException("Couldn't create class " + toType + " using default (long) constructor", e);
+                        throw new TypeConversionException("Couldn't create class " + toType + " using default (long) constructor", e);
                     }
                 }
             } catch (ParseException e) {
-                throw new StrutsException("Could not parse date", e);
+                throw new TypeConversionException("Could not parse date", e);
             }
         } else if (Date.class.isAssignableFrom(value.getClass())) {
             result = (Date) value;

--- a/core/src/main/java/com/opensymphony/xwork2/conversion/impl/DateConverter.java
+++ b/core/src/main/java/com/opensymphony/xwork2/conversion/impl/DateConverter.java
@@ -19,7 +19,6 @@
 package com.opensymphony.xwork2.conversion.impl;
 
 import com.opensymphony.xwork2.conversion.TypeConversionException;
-import org.apache.struts2.StrutsException;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Member;

--- a/core/src/main/java/com/opensymphony/xwork2/conversion/impl/DateConverter.java
+++ b/core/src/main/java/com/opensymphony/xwork2/conversion/impl/DateConverter.java
@@ -18,7 +18,7 @@
  */
 package com.opensymphony.xwork2.conversion.impl;
 
-import com.opensymphony.xwork2.conversion.TypeConversionException;
+import org.apache.struts2.conversion.TypeConversionException;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Member;

--- a/core/src/main/java/com/opensymphony/xwork2/conversion/impl/NumberConverter.java
+++ b/core/src/main/java/com/opensymphony/xwork2/conversion/impl/NumberConverter.java
@@ -18,9 +18,9 @@
  */
 package com.opensymphony.xwork2.conversion.impl;
 
+import com.opensymphony.xwork2.conversion.TypeConversionException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.struts2.StrutsException;
 
 import java.lang.reflect.Member;
 import java.math.BigDecimal;
@@ -51,7 +51,7 @@ public class NumberConverter extends DefaultTypeConverter {
                 Object convertedValue = super.convertValue(context, value, toType);
 
                 if (!isInRange((Number) convertedValue, stringValue, toType))
-                    throw new StrutsException("Overflow or underflow casting: \"" + stringValue + "\" into class " + convertedValue.getClass().getName());
+                    throw new TypeConversionException("Overflow or underflow casting: \"" + stringValue + "\" into class " + convertedValue.getClass().getName());
 
                 return convertedValue;
             } else {
@@ -67,11 +67,11 @@ public class NumberConverter extends DefaultTypeConverter {
                 Number number = numFormat.parse(stringValue, parsePos);
 
                 if (parsePos.getIndex() != stringValue.length()) {
-                    throw new StrutsException("Unparseable number: \"" + stringValue + "\" at position "
+                    throw new TypeConversionException("Unparseable number: \"" + stringValue + "\" at position "
                         + parsePos.getIndex());
                 } else {
                     if (!isInRange(number, stringValue, toType))
-                        throw new StrutsException("Overflow or underflow casting: \"" + stringValue + "\" into class " + number.getClass().getName());
+                        throw new TypeConversionException("Overflow or underflow casting: \"" + stringValue + "\" into class " + number.getClass().getName());
 
                     value = super.convertValue(context, number, toType);
                 }
@@ -103,7 +103,7 @@ public class NumberConverter extends DefaultTypeConverter {
         Number number = format.parse(stringValue, parsePosition);
 
         if (parsePosition.getIndex() != stringValue.length()) {
-            throw new StrutsException("Unparseable number: \"" + stringValue + "\" at position " + parsePosition.getIndex());
+            throw new TypeConversionException("Unparseable number: \"" + stringValue + "\" at position " + parsePosition.getIndex());
         }
 
         return number;
@@ -123,11 +123,11 @@ public class NumberConverter extends DefaultTypeConverter {
         Number number = format.parse(stringValue, parsePosition);
 
         if (parsePosition.getIndex() != stringValue.length()) {
-            throw new StrutsException("Unparseable number: \"" + stringValue + "\" at position " + parsePosition.getIndex());
+            throw new TypeConversionException("Unparseable number: \"" + stringValue + "\" at position " + parsePosition.getIndex());
         }
 
         if (!isInRange(number, stringValue, Double.class)) {
-            throw new StrutsException("Overflow or underflow converting: \"" + stringValue + "\" into class " + number.getClass().getName());
+            throw new TypeConversionException("Overflow or underflow converting: \"" + stringValue + "\" into class " + number.getClass().getName());
         }
 
         if (number != null) {
@@ -151,11 +151,11 @@ public class NumberConverter extends DefaultTypeConverter {
         Number number = format.parse(stringValue, parsePosition);
 
         if (parsePosition.getIndex() != stringValue.length()) {
-            throw new StrutsException("Unparseable number: \"" + stringValue + "\" at position " + parsePosition.getIndex());
+            throw new TypeConversionException("Unparseable number: \"" + stringValue + "\" at position " + parsePosition.getIndex());
         }
 
         if (!isInRange(number, stringValue, Float.class)) {
-            throw new StrutsException("Overflow or underflow converting: \"" + stringValue + "\" into class " + number.getClass().getName());
+            throw new TypeConversionException("Overflow or underflow converting: \"" + stringValue + "\" into class " + number.getClass().getName());
         }
 
         if (number != null) {

--- a/core/src/main/java/com/opensymphony/xwork2/conversion/impl/NumberConverter.java
+++ b/core/src/main/java/com/opensymphony/xwork2/conversion/impl/NumberConverter.java
@@ -18,7 +18,7 @@
  */
 package com.opensymphony.xwork2.conversion.impl;
 
-import com.opensymphony.xwork2.conversion.TypeConversionException;
+import org.apache.struts2.conversion.TypeConversionException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 

--- a/core/src/main/java/com/opensymphony/xwork2/conversion/impl/XWorkBasicConverter.java
+++ b/core/src/main/java/com/opensymphony/xwork2/conversion/impl/XWorkBasicConverter.java
@@ -18,11 +18,11 @@
  */
 package com.opensymphony.xwork2.conversion.impl;
 
+import com.opensymphony.xwork2.conversion.TypeConversionException;
 import com.opensymphony.xwork2.conversion.TypeConverter;
 import com.opensymphony.xwork2.inject.Container;
 import com.opensymphony.xwork2.inject.Inject;
 import org.apache.struts2.StrutsConstants;
-import org.apache.struts2.StrutsException;
 
 import java.lang.reflect.Member;
 import java.util.Calendar;
@@ -130,7 +130,7 @@ public class XWorkBasicConverter extends DefaultTypeConverter {
             }
 
             if (result == null && value != null && !"".equals(value)) {
-                throw new StrutsException("Cannot create type " + toType + " from value " + value);
+                throw new TypeConversionException("Cannot create type " + toType + " from value " + value);
             }
         }
 
@@ -170,7 +170,7 @@ public class XWorkBasicConverter extends DefaultTypeConverter {
             try {
                 clazz = Class.forName((String) value);
             } catch (ClassNotFoundException e) {
-                throw new StrutsException(e.getLocalizedMessage(), e);
+                throw new TypeConversionException(e.getLocalizedMessage(), e);
             }
         }
         return clazz;
@@ -179,7 +179,7 @@ public class XWorkBasicConverter extends DefaultTypeConverter {
     private Object doConvertToCollection(Map<String, Object> context, Object o, Member member, String prop, Object value, Class toType) {
         TypeConverter converter = container.getInstance(CollectionConverter.class);
         if (converter == null) {
-            throw new StrutsException("TypeConverter with name [#0] must be registered first!", StrutsConstants.STRUTS_CONVERTER_COLLECTION);
+            throw new TypeConversionException("TypeConverter with name [#0] must be registered first! Converter: "+ StrutsConstants.STRUTS_CONVERTER_COLLECTION);
         }
         return converter.convertValue(context, o, member, prop, value, toType);
     }
@@ -187,7 +187,7 @@ public class XWorkBasicConverter extends DefaultTypeConverter {
     private Object doConvertToArray(Map<String, Object> context, Object o, Member member, String prop, Object value, Class toType) {
         TypeConverter converter = container.getInstance(ArrayConverter.class);
         if (converter == null) {
-            throw new StrutsException("TypeConverter with name [#0] must be registered first!", StrutsConstants.STRUTS_CONVERTER_ARRAY);
+            throw new TypeConversionException("TypeConverter with name [#0] must be registered first! Converter: "+ StrutsConstants.STRUTS_CONVERTER_ARRAY);
         }
         return converter.convertValue(context, o, member, prop, value, toType);
     }
@@ -195,7 +195,7 @@ public class XWorkBasicConverter extends DefaultTypeConverter {
     private Object doConvertToDate(Map<String, Object> context, Object value, Class toType) {
         TypeConverter converter = container.getInstance(DateConverter.class);
         if (converter == null) {
-            throw new StrutsException("TypeConverter with name [#0] must be registered first!", StrutsConstants.STRUTS_CONVERTER_DATE);
+            throw new TypeConversionException("TypeConverter with name [#0] must be registered first! Converter: "+ StrutsConstants.STRUTS_CONVERTER_DATE);
         }
         return converter.convertValue(context, null, null, null, value, toType);
     }
@@ -203,7 +203,7 @@ public class XWorkBasicConverter extends DefaultTypeConverter {
     private Object doConvertToNumber(Map<String, Object> context, Object value, Class toType) {
         TypeConverter converter = container.getInstance(NumberConverter.class);
         if (converter == null) {
-            throw new StrutsException("TypeConverter with name [#0] must be registered first!", StrutsConstants.STRUTS_CONVERTER_NUMBER);
+            throw new TypeConversionException("TypeConverter with name [#0] must be registered first! Converter: "+ StrutsConstants.STRUTS_CONVERTER_NUMBER);
         }
         return converter.convertValue(context, null, null, null, value, toType);
     }
@@ -211,7 +211,7 @@ public class XWorkBasicConverter extends DefaultTypeConverter {
     private Object doConvertToString(Map<String, Object> context, Object value) {
         TypeConverter converter = container.getInstance(StringConverter.class);
         if (converter == null) {
-            throw new StrutsException("TypeConverter with name [#0] must be registered first!", StrutsConstants.STRUTS_CONVERTER_STRING);
+            throw new TypeConversionException("TypeConverter with name [#0] must be registered first! Converter: "+ StrutsConstants.STRUTS_CONVERTER_STRING);
         }
         return converter.convertValue(context, null, null, null, value, null);
     }

--- a/core/src/main/java/com/opensymphony/xwork2/conversion/impl/XWorkBasicConverter.java
+++ b/core/src/main/java/com/opensymphony/xwork2/conversion/impl/XWorkBasicConverter.java
@@ -18,7 +18,7 @@
  */
 package com.opensymphony.xwork2.conversion.impl;
 
-import com.opensymphony.xwork2.conversion.TypeConversionException;
+import org.apache.struts2.conversion.TypeConversionException;
 import com.opensymphony.xwork2.conversion.TypeConverter;
 import com.opensymphony.xwork2.inject.Container;
 import com.opensymphony.xwork2.inject.Inject;

--- a/core/src/main/java/org/apache/struts2/conversion/TypeConversionException.java
+++ b/core/src/main/java/org/apache/struts2/conversion/TypeConversionException.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package com.opensymphony.xwork2.conversion;
+package org.apache.struts2.conversion;
 
 import org.apache.struts2.StrutsException;
 

--- a/core/src/test/java/com/opensymphony/xwork2/conversion/impl/DateConverterTest.java
+++ b/core/src/test/java/com/opensymphony/xwork2/conversion/impl/DateConverterTest.java
@@ -34,7 +34,7 @@ public class DateConverterTest extends StrutsInternalTestCase {
 	private final static String TIME_00_59_10 = "00:59:10";
 	private final static String TIMESTAMP_STR = "2020-03-20 00:59:10";
 	private final static String DATE_STR = "2020-03-20";
-	private final static String DATE_CONVERTED = "Fri Mar 20 00:00:00 CST 2020";
+	private final static String DATE_CONVERTED = "Fri Mar 20 00:00:00";
 	private final static String INVALID_DATE = "99/99/2010";
 	private final static String MESSAGE_PARSE_ERROR = "Could not parse date";
 	private final static String MESSAGE_DEFAULT_CONSTRUCTOR_ERROR = "Couldn't create class null using default (long) constructor";
@@ -66,7 +66,7 @@ public class DateConverterTest extends StrutsInternalTestCase {
 		context.put(ActionContext.LOCALE, new Locale("es_MX", "MX"));
 		
 		Object value = converter.convertValue(context, null, null, null, DATE_STR, Date.class);
-		assertEquals(DATE_CONVERTED, ((Date) value).toString());
+		assertTrue(((Date) value).toString().startsWith(DATE_CONVERTED));
 	}
 	
 	public void testTypeConversionExceptionWhenParseError() {

--- a/core/src/test/java/com/opensymphony/xwork2/conversion/impl/DateConverterTest.java
+++ b/core/src/test/java/com/opensymphony/xwork2/conversion/impl/DateConverterTest.java
@@ -2,7 +2,6 @@ package com.opensymphony.xwork2.conversion.impl;
 
 import com.opensymphony.xwork2.ActionContext;
 import com.opensymphony.xwork2.conversion.TypeConversionException;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.struts2.StrutsInternalTestCase;
 
 import java.sql.Time;

--- a/core/src/test/java/com/opensymphony/xwork2/conversion/impl/DateConverterTest.java
+++ b/core/src/test/java/com/opensymphony/xwork2/conversion/impl/DateConverterTest.java
@@ -24,6 +24,8 @@ import org.apache.struts2.StrutsInternalTestCase;
 
 import java.sql.Time;
 import java.sql.Timestamp;
+import java.text.DateFormat;
+import java.text.ParseException;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Locale;
@@ -31,8 +33,8 @@ import java.util.Map;
 
 public class DateConverterTest extends StrutsInternalTestCase {
 	
-	private final static String TIME_00_59_10 = "00:59:10";
-	private final static String TIMESTAMP_STR = "2020-03-20 00:59:10";
+	private final static String TIME_01_59_10 = "01:59:10 AM";
+	private final static String TIMESTAMP_STR = "03/03/2020 00:00:00.000";
 	private final static String DATE_STR = "2020-03-20";
 	private final static String DATE_CONVERTED = "Fri Mar 20 00:00:00";
 	private final static String INVALID_DATE = "99/99/2010";
@@ -45,8 +47,8 @@ public class DateConverterTest extends StrutsInternalTestCase {
 		Map<String, Object> context = new HashMap<>();
 		context.put(ActionContext.LOCALE, new Locale("es_MX", "MX"));
 		
-		Object value = converter.convertValue(context, null, null, null, TIME_00_59_10, Time.class);
-		assertEquals(Time.valueOf(TIME_00_59_10), value);
+		Object value = converter.convertValue(context, null, null, null, TIME_01_59_10, Time.class);
+		assertEquals("01:59:10", value.toString());
 	}
 	
 	public void testSqlTimestampType() {
@@ -56,7 +58,7 @@ public class DateConverterTest extends StrutsInternalTestCase {
 		context.put(ActionContext.LOCALE, new Locale("es_MX", "MX"));
 		
 		Object value = converter.convertValue(context, null, null, null, TIMESTAMP_STR, Timestamp.class);
-		assertEquals(Timestamp.valueOf(TIMESTAMP_STR), value);
+		assertEquals("2020-03-03 00:00:00.0", value.toString());
 	}
 	
 	public void testDateType() {
@@ -91,7 +93,7 @@ public class DateConverterTest extends StrutsInternalTestCase {
 		context.put(ActionContext.LOCALE, new Locale("es_MX", "MX"));
 		
 		try {
-			Object value = converter.convertValue(context, null, null, null, "01-10-10", null);
+			Object value = converter.convertValue(context, null, null, null, "03/31/20", null);
 			fail("TypeConversionException expected - Error using default (long) constructor");
 		} catch (Exception ex) {
 			assertEquals(TypeConversionException.class, ex.getClass());

--- a/core/src/test/java/com/opensymphony/xwork2/conversion/impl/DateConverterTest.java
+++ b/core/src/test/java/com/opensymphony/xwork2/conversion/impl/DateConverterTest.java
@@ -19,7 +19,7 @@
 package com.opensymphony.xwork2.conversion.impl;
 
 import com.opensymphony.xwork2.ActionContext;
-import com.opensymphony.xwork2.conversion.TypeConversionException;
+import org.apache.struts2.conversion.TypeConversionException;
 import org.apache.struts2.StrutsInternalTestCase;
 
 import java.sql.Time;

--- a/core/src/test/java/com/opensymphony/xwork2/conversion/impl/DateConverterTest.java
+++ b/core/src/test/java/com/opensymphony/xwork2/conversion/impl/DateConverterTest.java
@@ -21,7 +21,7 @@ public class DateConverterTest extends StrutsInternalTestCase {
 	private final static String MESSAGE_PARSE_ERROR = "Could not parse date";
 	private final static String MESSAGE_DEFAULT_CONSTRUCTOR_ERROR = "Couldn't create class null using default (long) constructor";
 	
-	public void  testSqlTimeType(){
+	public void testSqlTimeType() {
 		DateConverter converter = new DateConverter();
 		
 		Map<String, Object> context = new HashMap<>();
@@ -29,10 +29,9 @@ public class DateConverterTest extends StrutsInternalTestCase {
 		
 		Object value = converter.convertValue(context, null, null, null, TIME_00_59_10, Time.class);
 		assertEquals(Time.valueOf(TIME_00_59_10), value);
-		
 	}
 	
-	public void  testSqlTimestampType(){
+	public void testSqlTimestampType() {
 		DateConverter converter = new DateConverter();
 		
 		Map<String, Object> context = new HashMap<>();
@@ -40,50 +39,46 @@ public class DateConverterTest extends StrutsInternalTestCase {
 		
 		Object value = converter.convertValue(context, null, null, null, TIMESTAMP_STR, Timestamp.class);
 		assertEquals(Timestamp.valueOf(TIMESTAMP_STR), value);
-		
 	}
 	
-	public void  testDateType(){
+	public void testDateType() {
 		DateConverter converter = new DateConverter();
 		
 		Map<String, Object> context = new HashMap<>();
 		context.put(ActionContext.LOCALE, new Locale("es_MX", "MX"));
 		
 		Object value = converter.convertValue(context, null, null, null, DATE_STR, Date.class);
-		assertEquals(DATE_CONVERTED, ((Date)value).toString());
-		
+		assertEquals(DATE_CONVERTED, ((Date) value).toString());
 	}
-
-    public void  testTypeConversionExceptionWhenParseError(){
-    	DateConverter converter = new DateConverter();
 	
-			Map<String, Object> context = new HashMap<>();
-			context.put(ActionContext.LOCALE, new Locale("es_MX", "MX"));
-	
-			try{
-				Object value = converter.convertValue(context, null, null, null, INVALID_DATE, Date.class);
-				fail("TypeConversionException expected - Conversion error occurred");
-			}catch(Exception ex){
-				assertEquals(TypeConversionException.class, ex.getClass());
-				assertEquals(MESSAGE_PARSE_ERROR, ex.getMessage());
-			}
-			
-		}
-	
-	public void  testTypeConversionExceptionWhenUsingLongConstructor(){
+	public void testTypeConversionExceptionWhenParseError() {
 		DateConverter converter = new DateConverter();
 		
 		Map<String, Object> context = new HashMap<>();
 		context.put(ActionContext.LOCALE, new Locale("es_MX", "MX"));
 		
-		try{
+		try {
+			Object value = converter.convertValue(context, null, null, null, INVALID_DATE, Date.class);
+			fail("TypeConversionException expected - Conversion error occurred");
+		} catch (Exception ex) {
+			assertEquals(TypeConversionException.class, ex.getClass());
+			assertEquals(MESSAGE_PARSE_ERROR, ex.getMessage());
+		}
+	}
+	
+	public void testTypeConversionExceptionWhenUsingLongConstructor() {
+		DateConverter converter = new DateConverter();
+		
+		Map<String, Object> context = new HashMap<>();
+		context.put(ActionContext.LOCALE, new Locale("es_MX", "MX"));
+		
+		try {
 			Object value = converter.convertValue(context, null, null, null, "01-10-10", null);
 			fail("TypeConversionException expected - Error using default (long) constructor");
-		}catch(Exception ex){
+		} catch (Exception ex) {
 			assertEquals(TypeConversionException.class, ex.getClass());
 			assertEquals(MESSAGE_DEFAULT_CONSTRUCTOR_ERROR, ex.getMessage());
 		}
-		
 	}
 	
 }

--- a/core/src/test/java/com/opensymphony/xwork2/conversion/impl/DateConverterTest.java
+++ b/core/src/test/java/com/opensymphony/xwork2/conversion/impl/DateConverterTest.java
@@ -25,7 +25,6 @@ import org.apache.struts2.StrutsInternalTestCase;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.text.DateFormat;
-import java.text.ParseException;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Locale;
@@ -33,8 +32,11 @@ import java.util.Map;
 
 public class DateConverterTest extends StrutsInternalTestCase {
 	
+	private String INPUT_TIME_STAMP_STR;
+	private String INPUT_WHEN_LONG_CONSTRUCTOR_STR;
+	private Locale mxLocale = new Locale("es_MX", "MX");
+	private final static String RES_TIME_STAMP_STR = "2020-03-20 00:00:00.0";
 	private final static String TIME_01_59_10 = "01:59:10 AM";
-	private final static String TIMESTAMP_STR = "03/03/2020 00:00:00.000";
 	private final static String DATE_STR = "2020-03-20";
 	private final static String DATE_CONVERTED = "Fri Mar 20 00:00:00";
 	private final static String INVALID_DATE = "99/99/2010";
@@ -53,12 +55,11 @@ public class DateConverterTest extends StrutsInternalTestCase {
 	
 	public void testSqlTimestampType() {
 		DateConverter converter = new DateConverter();
-		
 		Map<String, Object> context = new HashMap<>();
-		context.put(ActionContext.LOCALE, new Locale("es_MX", "MX"));
+		context.put(ActionContext.LOCALE, mxLocale);
 		
-		Object value = converter.convertValue(context, null, null, null, TIMESTAMP_STR, Timestamp.class);
-		assertEquals("2020-03-03 00:00:00.0", value.toString());
+		Object value = converter.convertValue(context, null, null, null, INPUT_TIME_STAMP_STR, Timestamp.class);
+		assertEquals(RES_TIME_STAMP_STR, value.toString());
 	}
 	
 	public void testDateType() {
@@ -93,11 +94,24 @@ public class DateConverterTest extends StrutsInternalTestCase {
 		context.put(ActionContext.LOCALE, new Locale("es_MX", "MX"));
 		
 		try {
-			Object value = converter.convertValue(context, null, null, null, "03/31/20", null);
+			Object value = converter.convertValue(context, null, null, null, INPUT_WHEN_LONG_CONSTRUCTOR_STR, null);
 			fail("TypeConversionException expected - Error using default (long) constructor");
 		} catch (Exception ex) {
 			assertEquals(TypeConversionException.class, ex.getClass());
 			assertEquals(MESSAGE_DEFAULT_CONSTRUCTOR_ERROR, ex.getMessage());
+		}
+	}
+	
+	@Override
+	protected void setUp() {
+		//Due to JEP 252: Use CLDR Locale Data by Default
+		DateFormat dFormat = DateFormat.getDateInstance(DateFormat.SHORT, mxLocale);
+		if(dFormat.format(new Date()).contains("-")){ 			// Format when Java 9 or greater
+			INPUT_TIME_STAMP_STR = "2020-03-20 00:00:00.000";
+			INPUT_WHEN_LONG_CONSTRUCTOR_STR = "2020-03-20";
+		}else{ 																							// Format when Java 8 or lower
+			INPUT_TIME_STAMP_STR = "03/20/2020 00:00:00.000";
+			INPUT_WHEN_LONG_CONSTRUCTOR_STR = "03/31/20";
 		}
 	}
 	

--- a/core/src/test/java/com/opensymphony/xwork2/conversion/impl/DateConverterTest.java
+++ b/core/src/test/java/com/opensymphony/xwork2/conversion/impl/DateConverterTest.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package com.opensymphony.xwork2.conversion.impl;
 
 import com.opensymphony.xwork2.ActionContext;

--- a/core/src/test/java/com/opensymphony/xwork2/conversion/impl/DateConverterTest.java
+++ b/core/src/test/java/com/opensymphony/xwork2/conversion/impl/DateConverterTest.java
@@ -1,0 +1,90 @@
+package com.opensymphony.xwork2.conversion.impl;
+
+import com.opensymphony.xwork2.ActionContext;
+import com.opensymphony.xwork2.conversion.TypeConversionException;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.struts2.StrutsInternalTestCase;
+
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+public class DateConverterTest extends StrutsInternalTestCase {
+	
+	private final static String TIME_00_59_10 = "00:59:10";
+	private final static String TIMESTAMP_STR = "2020-03-20 00:59:10";
+	private final static String DATE_STR = "2020-03-20";
+	private final static String DATE_CONVERTED = "Fri Mar 20 00:00:00 CST 2020";
+	private final static String INVALID_DATE = "99/99/2010";
+	private final static String MESSAGE_PARSE_ERROR = "Could not parse date";
+	private final static String MESSAGE_DEFAULT_CONSTRUCTOR_ERROR = "Couldn't create class null using default (long) constructor";
+	
+	public void  testSqlTimeType(){
+		DateConverter converter = new DateConverter();
+		
+		Map<String, Object> context = new HashMap<>();
+		context.put(ActionContext.LOCALE, new Locale("es_MX", "MX"));
+		
+		Object value = converter.convertValue(context, null, null, null, TIME_00_59_10, Time.class);
+		assertEquals(Time.valueOf(TIME_00_59_10), value);
+		
+	}
+	
+	public void  testSqlTimestampType(){
+		DateConverter converter = new DateConverter();
+		
+		Map<String, Object> context = new HashMap<>();
+		context.put(ActionContext.LOCALE, new Locale("es_MX", "MX"));
+		
+		Object value = converter.convertValue(context, null, null, null, TIMESTAMP_STR, Timestamp.class);
+		assertEquals(Timestamp.valueOf(TIMESTAMP_STR), value);
+		
+	}
+	
+	public void  testDateType(){
+		DateConverter converter = new DateConverter();
+		
+		Map<String, Object> context = new HashMap<>();
+		context.put(ActionContext.LOCALE, new Locale("es_MX", "MX"));
+		
+		Object value = converter.convertValue(context, null, null, null, DATE_STR, Date.class);
+		assertEquals(DATE_CONVERTED, ((Date)value).toString());
+		
+	}
+
+    public void  testTypeConversionExceptionWhenParseError(){
+    	DateConverter converter = new DateConverter();
+	
+			Map<String, Object> context = new HashMap<>();
+			context.put(ActionContext.LOCALE, new Locale("es_MX", "MX"));
+	
+			try{
+				Object value = converter.convertValue(context, null, null, null, INVALID_DATE, Date.class);
+				fail("TypeConversionException expected - Conversion error occurred");
+			}catch(Exception ex){
+				assertEquals(TypeConversionException.class, ex.getClass());
+				assertEquals(MESSAGE_PARSE_ERROR, ex.getMessage());
+			}
+			
+		}
+	
+	public void  testTypeConversionExceptionWhenUsingLongConstructor(){
+		DateConverter converter = new DateConverter();
+		
+		Map<String, Object> context = new HashMap<>();
+		context.put(ActionContext.LOCALE, new Locale("es_MX", "MX"));
+		
+		try{
+			Object value = converter.convertValue(context, null, null, null, "01-10-10", null);
+			fail("TypeConversionException expected - Error using default (long) constructor");
+		}catch(Exception ex){
+			assertEquals(TypeConversionException.class, ex.getClass());
+			assertEquals(MESSAGE_DEFAULT_CONSTRUCTOR_ERROR, ex.getMessage());
+		}
+		
+	}
+	
+}

--- a/core/src/test/java/com/opensymphony/xwork2/conversion/impl/NumberConverterTest.java
+++ b/core/src/test/java/com/opensymphony/xwork2/conversion/impl/NumberConverterTest.java
@@ -21,15 +21,25 @@ package com.opensymphony.xwork2.conversion.impl;
 import com.opensymphony.xwork2.ActionContext;
 import com.opensymphony.xwork2.SimpleFooAction;
 import com.opensymphony.xwork2.XWorkTestCase;
+import com.opensymphony.xwork2.conversion.TypeConversionException;
 import org.apache.commons.lang3.StringUtils;
 
 import java.math.BigDecimal;
-import java.math.BigInteger;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 
 public class NumberConverterTest extends XWorkTestCase {
+    
+    private final static String FLOAT_OUT_OF_RANGE = "3.5028235E38";
+    private final static String DOUBLE_OUT_OF_RANGE = "1.7976931348623157E309";
+    private final static String INTEGER_OUT_OF_RANGE = "2147483648";
+    private final static String MSG_OUT_OF_RANGE_CASTING = "Overflow or underflow casting";
+    private final static String MSG_OUT_OF_RANGE_CONVERTING = "Overflow or underflow converting";
+    private final static String MSG_UNPARSEABLE_NUMBER = "Unparseable number";
+    private final static String MSG_TEST_FAILS_OUT_OF_RANGE = "TypeConversionException expected when OUT OF RANGE";
+    private final static String MSG_TEST_FAILS_UNPARSEABLE_NUMBER = "TypeConversionException expected when UNPARSEABLE NUMBER";
+    private final static Locale LOCALE_MEXICO = new Locale("es_MX", "MX");
 
     public void testStringToNumberConversionPL() throws Exception {
         // given
@@ -169,6 +179,154 @@ public class NumberConverterTest extends XWorkTestCase {
         // then
         assertEquals(1234.4F, value);
     }
-
-
+    
+    public void testExceptionWhenPrimitiveIsOutOfRange(){
+        // given
+        NumberConverter converter = new NumberConverter();
+        Map<String, Object> context = new HashMap<>();
+        context.put(ActionContext.LOCALE, LOCALE_MEXICO);
+        
+        // when
+        try{
+            Object value = converter.convertValue(context, null, null, null, INTEGER_OUT_OF_RANGE, int.class);
+            fail(MSG_TEST_FAILS_OUT_OF_RANGE);
+        }catch(Exception ex){
+            // then
+            assertEquals(TypeConversionException.class, ex.getClass());
+            assertTrue(ex.getMessage().startsWith(MSG_OUT_OF_RANGE_CASTING));
+        }
+        
+    }
+    
+    public void testExceptionWhenANotPrimitiveIsUnparsable(){
+        // given
+        NumberConverter converter = new NumberConverter();
+        Map<String, Object> context = new HashMap<>();
+        String strValue = "1.2";
+        context.put(ActionContext.LOCALE, LOCALE_MEXICO);
+        
+        // when
+        try{
+            Object value = converter.convertValue(context, null, null, null, strValue, Byte.class);
+            fail(MSG_TEST_FAILS_UNPARSEABLE_NUMBER);
+        }catch(Exception ex){
+            // then
+            assertEquals(TypeConversionException.class, ex.getClass());
+            assertTrue(ex.getMessage().startsWith(MSG_UNPARSEABLE_NUMBER));
+        }
+        
+    }
+    
+    public void testExceptionWhenANotPrimitiveIsOutOfRange(){
+        // given
+        NumberConverter converter = new NumberConverter();
+        Map<String, Object> context = new HashMap<>();
+        String strValue = "129";
+        context.put(ActionContext.LOCALE, LOCALE_MEXICO);
+        
+        // when
+        try{
+            Object value = converter.convertValue(context, null, null, null, strValue, Byte.class);
+            fail(MSG_TEST_FAILS_OUT_OF_RANGE);
+        }catch(Exception ex){
+            // then
+            assertEquals(TypeConversionException.class, ex.getClass());
+            assertTrue(ex.getMessage().startsWith(MSG_OUT_OF_RANGE_CASTING));
+        }
+        
+    }
+    
+    public void testExceptionWhenUnparseableInConvertToBigDecimal(){
+        // given
+        NumberConverter converter = new NumberConverter();
+        Map<String, Object> context = new HashMap<>();
+        String strValue = "1-23";
+        context.put(ActionContext.LOCALE, LOCALE_MEXICO);
+        
+        // when
+        try{
+            Object value = converter.convertValue(context, null, null, null, strValue, BigDecimal.class);
+            fail(MSG_TEST_FAILS_UNPARSEABLE_NUMBER);
+        }catch(Exception ex){
+            // then
+            assertEquals(TypeConversionException.class, ex.getClass());
+            assertTrue(ex.getMessage().startsWith(MSG_UNPARSEABLE_NUMBER));
+        }
+        
+    }
+    
+    public void testExceptionWhenUnparseableInConvertToDouble(){
+        // given
+        NumberConverter converter = new NumberConverter();
+        Map<String, Object> context = new HashMap<>();
+        String strValue = "1-23";
+        context.put(ActionContext.LOCALE, LOCALE_MEXICO);
+        
+        // when
+        try{
+            Object value = converter.convertValue(context, null, null, null, strValue, Double.class);
+            fail(MSG_TEST_FAILS_UNPARSEABLE_NUMBER);
+        }catch(Exception ex){
+            // then
+            assertEquals(TypeConversionException.class, ex.getClass());
+            assertTrue(ex.getMessage().startsWith(MSG_UNPARSEABLE_NUMBER));
+        }
+        
+    }
+    
+    public void testExceptionWhenOutOfRangeInConvertToDouble(){
+        // given
+        NumberConverter converter = new NumberConverter();
+        Map<String, Object> context = new HashMap<>();
+        context.put(ActionContext.LOCALE, LOCALE_MEXICO);
+        
+        // when
+        try{
+            Object value = converter.convertValue(context, null, null, null, DOUBLE_OUT_OF_RANGE, Double.class);
+            fail(MSG_TEST_FAILS_OUT_OF_RANGE);
+        }catch(Exception ex){
+            // then
+            assertEquals(TypeConversionException.class, ex.getClass());
+            assertTrue(ex.getMessage().startsWith(MSG_OUT_OF_RANGE_CONVERTING));
+        }
+        
+    }
+    
+    public void testExceptionWhenOutOfRangeInConvertToFloat(){
+        // given
+        NumberConverter converter = new NumberConverter();
+        Map<String, Object> context = new HashMap<>();
+        context.put(ActionContext.LOCALE, LOCALE_MEXICO);
+    
+        // when
+        try{
+            Object value = converter.convertValue(context, null, null, null, FLOAT_OUT_OF_RANGE, Float.class);
+            fail(MSG_TEST_FAILS_OUT_OF_RANGE);
+        }catch(Exception ex){
+            // then
+            assertEquals(TypeConversionException.class, ex.getClass());
+            assertTrue(ex.getMessage().startsWith(MSG_OUT_OF_RANGE_CONVERTING));
+        }
+        
+    }
+    
+    public void testExceptionWhenUnparseableInConvertToFloat(){
+        // given
+        NumberConverter converter = new NumberConverter();
+        Map<String, Object> context = new HashMap<>();
+        String strValue = "1-23";
+        context.put(ActionContext.LOCALE, LOCALE_MEXICO);
+        
+        // when
+        try{
+            Object value = converter.convertValue(context, null, null, null, strValue, Float.class);
+            fail(MSG_TEST_FAILS_UNPARSEABLE_NUMBER);
+        }catch(Exception ex){
+            // then
+            assertEquals(TypeConversionException.class, ex.getClass());
+            assertTrue(ex.getMessage().startsWith(MSG_UNPARSEABLE_NUMBER));
+        }
+        
+    }
+    
 }

--- a/core/src/test/java/com/opensymphony/xwork2/conversion/impl/NumberConverterTest.java
+++ b/core/src/test/java/com/opensymphony/xwork2/conversion/impl/NumberConverterTest.java
@@ -180,25 +180,24 @@ public class NumberConverterTest extends XWorkTestCase {
         assertEquals(1234.4F, value);
     }
     
-    public void testExceptionWhenPrimitiveIsOutOfRange(){
+    public void testExceptionWhenPrimitiveIsOutOfRange() {
         // given
         NumberConverter converter = new NumberConverter();
         Map<String, Object> context = new HashMap<>();
         context.put(ActionContext.LOCALE, LOCALE_MEXICO);
         
         // when
-        try{
+        try {
             Object value = converter.convertValue(context, null, null, null, INTEGER_OUT_OF_RANGE, int.class);
             fail(MSG_TEST_FAILS_OUT_OF_RANGE);
-        }catch(Exception ex){
+        } catch (Exception ex) {
             // then
             assertEquals(TypeConversionException.class, ex.getClass());
             assertTrue(ex.getMessage().startsWith(MSG_OUT_OF_RANGE_CASTING));
         }
-        
     }
     
-    public void testExceptionWhenANotPrimitiveIsUnparsable(){
+    public void testExceptionWhenANotPrimitiveIsUnparsable() {
         // given
         NumberConverter converter = new NumberConverter();
         Map<String, Object> context = new HashMap<>();
@@ -206,18 +205,17 @@ public class NumberConverterTest extends XWorkTestCase {
         context.put(ActionContext.LOCALE, LOCALE_MEXICO);
         
         // when
-        try{
+        try {
             Object value = converter.convertValue(context, null, null, null, strValue, Byte.class);
             fail(MSG_TEST_FAILS_UNPARSEABLE_NUMBER);
-        }catch(Exception ex){
+        } catch (Exception ex) {
             // then
             assertEquals(TypeConversionException.class, ex.getClass());
             assertTrue(ex.getMessage().startsWith(MSG_UNPARSEABLE_NUMBER));
         }
-        
     }
     
-    public void testExceptionWhenANotPrimitiveIsOutOfRange(){
+    public void testExceptionWhenANotPrimitiveIsOutOfRange() {
         // given
         NumberConverter converter = new NumberConverter();
         Map<String, Object> context = new HashMap<>();
@@ -225,18 +223,17 @@ public class NumberConverterTest extends XWorkTestCase {
         context.put(ActionContext.LOCALE, LOCALE_MEXICO);
         
         // when
-        try{
+        try {
             Object value = converter.convertValue(context, null, null, null, strValue, Byte.class);
             fail(MSG_TEST_FAILS_OUT_OF_RANGE);
-        }catch(Exception ex){
+        } catch (Exception ex) {
             // then
             assertEquals(TypeConversionException.class, ex.getClass());
             assertTrue(ex.getMessage().startsWith(MSG_OUT_OF_RANGE_CASTING));
         }
-        
     }
     
-    public void testExceptionWhenUnparseableInConvertToBigDecimal(){
+    public void testExceptionWhenUnparseableInConvertToBigDecimal() {
         // given
         NumberConverter converter = new NumberConverter();
         Map<String, Object> context = new HashMap<>();
@@ -244,18 +241,17 @@ public class NumberConverterTest extends XWorkTestCase {
         context.put(ActionContext.LOCALE, LOCALE_MEXICO);
         
         // when
-        try{
+        try {
             Object value = converter.convertValue(context, null, null, null, strValue, BigDecimal.class);
             fail(MSG_TEST_FAILS_UNPARSEABLE_NUMBER);
-        }catch(Exception ex){
+        } catch (Exception ex) {
             // then
             assertEquals(TypeConversionException.class, ex.getClass());
             assertTrue(ex.getMessage().startsWith(MSG_UNPARSEABLE_NUMBER));
         }
-        
     }
     
-    public void testExceptionWhenUnparseableInConvertToDouble(){
+    public void testExceptionWhenUnparseableInConvertToDouble() {
         // given
         NumberConverter converter = new NumberConverter();
         Map<String, Object> context = new HashMap<>();
@@ -263,54 +259,51 @@ public class NumberConverterTest extends XWorkTestCase {
         context.put(ActionContext.LOCALE, LOCALE_MEXICO);
         
         // when
-        try{
+        try {
             Object value = converter.convertValue(context, null, null, null, strValue, Double.class);
             fail(MSG_TEST_FAILS_UNPARSEABLE_NUMBER);
-        }catch(Exception ex){
+        } catch (Exception ex) {
             // then
             assertEquals(TypeConversionException.class, ex.getClass());
             assertTrue(ex.getMessage().startsWith(MSG_UNPARSEABLE_NUMBER));
         }
-        
     }
     
-    public void testExceptionWhenOutOfRangeInConvertToDouble(){
+    public void testExceptionWhenOutOfRangeInConvertToDouble() {
         // given
         NumberConverter converter = new NumberConverter();
         Map<String, Object> context = new HashMap<>();
         context.put(ActionContext.LOCALE, LOCALE_MEXICO);
         
         // when
-        try{
+        try {
             Object value = converter.convertValue(context, null, null, null, DOUBLE_OUT_OF_RANGE, Double.class);
             fail(MSG_TEST_FAILS_OUT_OF_RANGE);
-        }catch(Exception ex){
+        } catch (Exception ex) {
             // then
             assertEquals(TypeConversionException.class, ex.getClass());
             assertTrue(ex.getMessage().startsWith(MSG_OUT_OF_RANGE_CONVERTING));
         }
-        
     }
     
-    public void testExceptionWhenOutOfRangeInConvertToFloat(){
+    public void testExceptionWhenOutOfRangeInConvertToFloat() {
         // given
         NumberConverter converter = new NumberConverter();
         Map<String, Object> context = new HashMap<>();
         context.put(ActionContext.LOCALE, LOCALE_MEXICO);
-    
+        
         // when
-        try{
+        try {
             Object value = converter.convertValue(context, null, null, null, FLOAT_OUT_OF_RANGE, Float.class);
             fail(MSG_TEST_FAILS_OUT_OF_RANGE);
-        }catch(Exception ex){
+        } catch (Exception ex) {
             // then
             assertEquals(TypeConversionException.class, ex.getClass());
             assertTrue(ex.getMessage().startsWith(MSG_OUT_OF_RANGE_CONVERTING));
         }
-        
     }
     
-    public void testExceptionWhenUnparseableInConvertToFloat(){
+    public void testExceptionWhenUnparseableInConvertToFloat() {
         // given
         NumberConverter converter = new NumberConverter();
         Map<String, Object> context = new HashMap<>();
@@ -318,15 +311,14 @@ public class NumberConverterTest extends XWorkTestCase {
         context.put(ActionContext.LOCALE, LOCALE_MEXICO);
         
         // when
-        try{
+        try {
             Object value = converter.convertValue(context, null, null, null, strValue, Float.class);
             fail(MSG_TEST_FAILS_UNPARSEABLE_NUMBER);
-        }catch(Exception ex){
+        } catch (Exception ex) {
             // then
             assertEquals(TypeConversionException.class, ex.getClass());
             assertTrue(ex.getMessage().startsWith(MSG_UNPARSEABLE_NUMBER));
         }
-        
     }
     
 }

--- a/core/src/test/java/com/opensymphony/xwork2/conversion/impl/NumberConverterTest.java
+++ b/core/src/test/java/com/opensymphony/xwork2/conversion/impl/NumberConverterTest.java
@@ -21,7 +21,7 @@ package com.opensymphony.xwork2.conversion.impl;
 import com.opensymphony.xwork2.ActionContext;
 import com.opensymphony.xwork2.SimpleFooAction;
 import com.opensymphony.xwork2.XWorkTestCase;
-import com.opensymphony.xwork2.conversion.TypeConversionException;
+import org.apache.struts2.conversion.TypeConversionException;
 import org.apache.commons.lang3.StringUtils;
 
 import java.math.BigDecimal;

--- a/core/src/test/java/com/opensymphony/xwork2/conversion/impl/XWorkBasicConverterTest.java
+++ b/core/src/test/java/com/opensymphony/xwork2/conversion/impl/XWorkBasicConverterTest.java
@@ -20,11 +20,10 @@ package com.opensymphony.xwork2.conversion.impl;
 
 import com.opensymphony.xwork2.ActionContext;
 import com.opensymphony.xwork2.XWorkTestCase;
-import com.opensymphony.xwork2.conversion.TypeConversionException;
+import org.apache.struts2.conversion.TypeConversionException;
 import com.opensymphony.xwork2.inject.Container;
 import com.opensymphony.xwork2.test.annotations.Person;
 import org.apache.struts2.StrutsException;
-import org.mockito.Mock;
 import org.mockito.Mockito;
 
 import java.math.BigDecimal;

--- a/core/src/test/java/com/opensymphony/xwork2/conversion/impl/XWorkBasicConverterTest.java
+++ b/core/src/test/java/com/opensymphony/xwork2/conversion/impl/XWorkBasicConverterTest.java
@@ -310,7 +310,6 @@ public class XWorkBasicConverterTest extends XWorkTestCase {
             assertEquals(TypeConversionException.class, ex.getClass());
             assertTrue(ex.getMessage().startsWith("Cannot create type"));
         }
-        
     }
     
     public void testExceptionInDoConvertToClass() {
@@ -395,6 +394,5 @@ public class XWorkBasicConverterTest extends XWorkTestCase {
         super.tearDown();
         ActionContext.setContext(null);
     }
-
-
+    
 }

--- a/core/src/test/java/com/opensymphony/xwork2/conversion/impl/XWorkBasicConverterTest.java
+++ b/core/src/test/java/com/opensymphony/xwork2/conversion/impl/XWorkBasicConverterTest.java
@@ -20,8 +20,12 @@ package com.opensymphony.xwork2.conversion.impl;
 
 import com.opensymphony.xwork2.ActionContext;
 import com.opensymphony.xwork2.XWorkTestCase;
+import com.opensymphony.xwork2.conversion.TypeConversionException;
+import com.opensymphony.xwork2.inject.Container;
 import com.opensymphony.xwork2.test.annotations.Person;
 import org.apache.struts2.StrutsException;
+import org.mockito.Mock;
+import org.mockito.Mockito;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -37,6 +41,9 @@ import java.util.*;
 public class XWorkBasicConverterTest extends XWorkTestCase {
 
     private XWorkBasicConverter basicConverter;
+    private Container mockedContainer;
+    private final static String MSG_EXCEPTION_EXPECTED = "TypeConversionException expected";
+    private final static String MSG_TYPE_CONVERTER_EXCEPTION = "TypeConverter with name";
 
     // TODO: test for every possible conversion
     // take into account of empty string
@@ -294,11 +301,93 @@ public class XWorkBasicConverterTest extends XWorkTestCase {
         Class toType = String.class;
         basicConverter.convertValue(context, value, null, s, value, toType);
     }
+    
+    public void testExceptionWhenCantCreateTypeFromValue() {
+        try{
+            Object convertedObject = basicConverter.convertValue(new HashMap<String, Object>(), null, null, null, 4, Date.class);
+            fail(MSG_EXCEPTION_EXPECTED);
+        }catch(Exception ex){
+            assertEquals(TypeConversionException.class, ex.getClass());
+            assertTrue(ex.getMessage().startsWith("Cannot create type"));
+        }
+        
+    }
+    
+    public void testExceptionInDoConvertToClass() {
+        try{
+            Object convertedObject = basicConverter.convertValue(new HashMap<String, Object>(), null, null, null, "Foo", Class.class);
+            fail(MSG_EXCEPTION_EXPECTED);
+        }catch(Exception ex){
+            assertEquals(TypeConversionException.class, ex.getClass());
+        }
+    }
+    
+    public void testExceptionInDoConvertToCollection() {
+        try{
+            Mockito.when(mockedContainer.getInstanceNames(CollectionConverter.class)).thenReturn(null);
+            basicConverter.setContainer(mockedContainer);
+            Object convertedObject = basicConverter.convertValue(new HashMap<String, Object>(), null, null, null, "Foo", ArrayList.class);
+            fail(MSG_EXCEPTION_EXPECTED);
+        }catch(Exception ex){
+            assertEquals(TypeConversionException.class, ex.getClass());
+            assertTrue(ex.getMessage().startsWith(MSG_TYPE_CONVERTER_EXCEPTION));
+        }
+    }
+    
+    public void testExceptionInDoConvertToArray() {
+        try{
+            int[] arrayInt = new int[1];
+            Mockito.when(mockedContainer.getInstanceNames(ArrayConverter.class)).thenReturn(null);
+            basicConverter.setContainer(mockedContainer);
+            Object convertedObject = basicConverter.convertValue(new HashMap<String, Object>(), null, null, null, "Foo", arrayInt.getClass());
+            fail(MSG_EXCEPTION_EXPECTED);
+        }catch(Exception ex){
+            assertEquals(TypeConversionException.class, ex.getClass());
+            assertTrue(ex.getMessage().startsWith(MSG_TYPE_CONVERTER_EXCEPTION));
+        }
+    }
+    
+    public void testExceptionInDoConvertToDate() {
+        try{
+            Mockito.when(mockedContainer.getInstanceNames(DateConverter.class)).thenReturn(null);
+            basicConverter.setContainer(mockedContainer);
+            Object convertedObject = basicConverter.convertValue(new HashMap<String, Object>(), null, null, null, "Foo", Date.class);
+            fail(MSG_EXCEPTION_EXPECTED);
+        }catch(Exception ex){
+            assertEquals(TypeConversionException.class, ex.getClass());
+            assertTrue(ex.getMessage().startsWith(MSG_TYPE_CONVERTER_EXCEPTION));
+        }
+    }
+    
+    public void testExceptionInDoConvertToNumber() {
+        try{
+            Mockito.when(mockedContainer.getInstanceNames(NumberConverter.class)).thenReturn(null);
+            basicConverter.setContainer(mockedContainer);
+            Object convertedObject = basicConverter.convertValue(new HashMap<String, Object>(), null, null, null, "Foo", int.class);
+            fail(MSG_EXCEPTION_EXPECTED);
+        }catch(Exception ex){
+            assertEquals(TypeConversionException.class, ex.getClass());
+            assertTrue(ex.getMessage().startsWith(MSG_TYPE_CONVERTER_EXCEPTION));
+        }
+    }
+    
+    public void testExceptionInDoConvertToString() {
+        try{
+            Mockito.when(mockedContainer.getInstanceNames(StringConverter.class)).thenReturn(null);
+            basicConverter.setContainer(mockedContainer);
+            Object convertedObject = basicConverter.convertValue(new HashMap<String, Object>(), null, null, null, 1, String.class);
+            fail(MSG_EXCEPTION_EXPECTED);
+        }catch(Exception ex){
+            assertEquals(TypeConversionException.class, ex.getClass());
+            assertTrue(ex.getMessage().startsWith(MSG_TYPE_CONVERTER_EXCEPTION));
+        }
+    }
 
     @Override
     protected void setUp() throws Exception {
         super.setUp();
         basicConverter = container.getInstance(XWorkBasicConverter.class);
+        mockedContainer = Mockito.mock(Container.class);
     }
 
     @Override


### PR DESCRIPTION
The StrutsException was switched to TypeConversionException in these classes:
 - DateConverter
 - NumberConverter
 - XWorkBasicConverter

Required tests were added in these classes:
 - DateConverterTest (New class)
 - NumberConverterTest
 - XWorkBasicConverterTest
