### PR TITLE
[WW-5065] Removing unnecessary part of AbstractMatcher#replaceParameters

### DIFF
--- a/core/src/main/java/com/opensymphony/xwork2/config/impl/AbstractMatcher.java
+++ b/core/src/main/java/com/opensymphony/xwork2/config/impl/AbstractMatcher.java
@@ -158,14 +158,6 @@ public abstract class AbstractMatcher<E> implements Serializable {
             map.put(entry.getKey(), convertParam(entry.getValue(), vars));
         }
         
-        //the values map will contain entries like name->"Lex Luthor" and 1->"Lex Luthor"
-        //now add the non-numeric values
-        for (Map.Entry<String,String> entry: vars.entrySet()) {
-            if (!NumberUtils.isCreatable(entry.getKey())) {
-                map.put(entry.getKey(), entry.getValue());
-            }
-        }
-        
         return map;
     }
 


### PR DESCRIPTION
For [WW-5065] fixing the bug in the AbstractMatcher#replaceParameters method and adding a test case for it.