### PR TITLE
Proposed WW-5067 change

### DIFF
--- a/apps/showcase/pom.xml
+++ b/apps/showcase/pom.xml
@@ -167,7 +167,7 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-validator</artifactId>
-            <version>5.1.3.Final</version>
+            <version>5.4.3.Final</version>
         </dependency>
 
         <!-- The Servlet API mocks in Spring Framework 4.x only supports Servlet 3.0 and higher.

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -190,7 +190,8 @@
                 <dependency>
                     <groupId>com.sun</groupId>
                     <artifactId>tools</artifactId>
-                    <version>1.5.0</version>
+                    <version>1.7.0</version>
+                    <!-- Match version of minimum compatible version -->
                     <scope>system</scope>
                     <systemPath>${java.home}/../lib/tools.jar</systemPath>
                 </dependency>

--- a/plugins/bean-validation/pom.xml
+++ b/plugins/bean-validation/pom.xml
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-validator</artifactId>
-            <version>5.1.3.Final</version>
+            <version>5.4.3.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/plugins/cdi/pom.xml
+++ b/plugins/cdi/pom.xml
@@ -47,8 +47,8 @@
         </dependency>
 
         <dependency>
-            <groupId>org.jboss.weld</groupId>
-            <artifactId>weld-se</artifactId>
+            <groupId>org.jboss.weld.se</groupId>
+            <artifactId>weld-se-core</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -96,20 +96,20 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <ognl.version>3.1.26</ognl.version>
-        <spring.platformVersion>4.3.25.RELEASE</spring.platformVersion>
-        <asm.version>7.1</asm.version>
+        <ognl.version>3.1.28</ognl.version>
+        <spring.platformVersion>4.3.26.RELEASE</spring.platformVersion>
+        <asm.version>7.3.1</asm.version>
         <tiles.version>3.0.8</tiles.version>
         <tiles-request.version>1.0.7</tiles-request.version>
         <log4j2.version>2.12.1</log4j2.version>
-        <jackson.version>2.10.0</jackson.version>
+        <jackson.version>2.10.3</jackson.version>
 
         <!-- Site generation -->
         <fluido-skin.version>1.8</fluido-skin.version>
 
         <!-- Sonar -->
         <sonar.host.url>https://builds.apache.org/analysis/</sonar.host.url>
-        <maven-surefire-plugin.version>2.22.1</maven-surefire-plugin.version>
+        <maven-surefire-plugin.version>3.0.0-M4</maven-surefire-plugin.version>
     </properties>
 
     <profiles>
@@ -217,7 +217,7 @@
                     <plugin>
                         <groupId>com.updateimpact</groupId>
                         <artifactId>updateimpact-maven-plugin</artifactId>
-                        <version>1.0.10</version>
+                        <version>1.0.12</version>
                     </plugin>
                 </plugins>
             </build>
@@ -230,7 +230,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-project-info-reports-plugin</artifactId>
-                    <version>2.7</version>
+                    <version>3.0.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -262,17 +262,19 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-war-plugin</artifactId>
-                    <version>2.1</version>
+                    <version>3.2.3</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
                     <version>2.1.0</version>
+                    <!-- Warning: Version 2.2.0+ often produces "java.lang.OutOfMemoryError: PermGen space" failure with JDK7 and default
+                         heap settings.  The "Final Memory:" total memory from a build with 2.2.0+ is 3x or more than that of 2.1.0. -->
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>2.10</version>
+                    <version>3.1.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -327,7 +329,7 @@
                 <plugin>
                     <groupId>org.owasp</groupId>
                     <artifactId>dependency-check-maven</artifactId>
-                    <version>3.3.4</version>
+                    <version>5.3.2</version>
                     <configuration>
                         <suppressionFiles>
                             <suppressionFile>src/etc/project-suppression.xml</suppressionFile>
@@ -388,12 +390,12 @@
                     <dependency>
                         <groupId>org.apache.maven.doxia</groupId>
                         <artifactId>doxia-core</artifactId>
-                        <version>1.8</version>
+                        <version>1.9.1</version>
                     </dependency>
                     <dependency>
                         <groupId>org.apache.maven.doxia</groupId>
                         <artifactId>doxia-module-markdown</artifactId>
-                        <version>1.7</version>
+                        <version>1.9.1</version>
                     </dependency>
                 </dependencies>
             </plugin>
@@ -622,13 +624,13 @@
             <dependency>
                 <groupId>org.freemarker</groupId>
                 <artifactId>freemarker</artifactId>
-                <version>2.3.28</version>
+                <version>2.3.30</version>
             </dependency>
 
             <dependency>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>org.apache.felix.main</artifactId>
-                <version>4.6.1</version>
+                <version>6.0.3</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.felix</groupId>
@@ -1000,12 +1002,12 @@
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
-                <version>1.7.28</version>
+                <version>1.7.30</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-simple</artifactId>
-                <version>1.7.28</version>
+                <version>1.7.30</version>
             </dependency>
 
             <dependency>
@@ -1099,19 +1101,19 @@
             <dependency>
                 <groupId>javax.enterprise</groupId>
                 <artifactId>cdi-api</artifactId>
-                <version>1.0-SP4</version>
+                <version>1.2</version>
             </dependency>
 
             <dependency>
                 <groupId>org.jboss.weld</groupId>
                 <artifactId>weld-core</artifactId>
-                <version>1.0.1-SP4</version>
+                <version>2.2.16.SP1</version>
             </dependency>
 
             <dependency>
-                <groupId>org.jboss.weld</groupId>
-                <artifactId>weld-se</artifactId>
-                <version>1.0.1-Final</version>
+                <groupId>org.jboss.weld.se</groupId>
+                <artifactId>weld-se-core</artifactId>
+                <version>2.2.16.SP1</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Proposed WW-5067 change
------
Proposed list of library version updates:
---
- cdi-api 1.0-SP4 -> 1.2
- weld-core 1.0.1-SP4 -> 2.2.16.SP1
- weld-se 1.0.1-Final -> weld-se-core 2.2.16.SP1
- slf4j-api 1.7.28 -> 1.7.30
- slf4j-simple 1.7.28 -> 1.7.30
- jackson 2.10.0 -> 2.10.3
- ognl 3.1.26 -> 3.1.28
- asm 7.1 -> 7.3.1
- spring 4.3.25.RELEASE -> 4.3.26.RELEASE
- freemarker 2.3.28 -> 2.3.30
- org.apache.felix.main 4.6.1 -> 6.0.3
---
Proposed list of Maven plugin version updates:
---
- doxia-core 1.8 -> 1.9.1
- doxia-module-markdown 1.7 -> 1.9.1
- maven-project-info-reports-plugin 2.7 -> 3.0.0
- updateimpact-maven-plugin 1.0.10 -> 1.0.12
- maven-surefire-plugin 2.22.1 -> 3.0.0-M4
- maven-war-plugin 2.1 -> 3.2.3
- maven-dependency-plugin 2.10 -> 3.1.2
- dependency-check-maven 3.3.4 -> 5.3.2
Note: Unable to upgrade maven-bundle-plugin past 2.1.0 as it introduced
      OOM during JDK7 builds with default heap settings.
---