### PR TITLE
WW-5067-Fix1 (correct accidental artifactId change)

### DIFF
--- a/plugins/cdi/pom.xml
+++ b/plugins/cdi/pom.xml
@@ -48,7 +48,7 @@
 
         <dependency>
             <groupId>org.jboss.weld.se</groupId>
-            <artifactId>weld-se-core</artifactId>
+            <artifactId>weld-se</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1112,7 +1112,7 @@
 
             <dependency>
                 <groupId>org.jboss.weld.se</groupId>
-                <artifactId>weld-se-core</artifactId>
+                <artifactId>weld-se</artifactId>
                 <version>2.2.16.SP1</version>
             </dependency>
 


### PR DESCRIPTION
WW-5067-Fix1
- Accidental change of artifactId when groupId was changed for weld-se in original PR.  This commit restores the originally intended artifactId.