### PR TITLE
Proposed WW-5068 change

### DIFF
--- a/apps/rest-showcase/pom.xml
+++ b/apps/rest-showcase/pom.xml
@@ -80,7 +80,7 @@
         <dependency>
             <groupId>net.sourceforge.htmlunit</groupId>
             <artifactId>htmlunit</artifactId>
-            <version>2.27</version>
+            <version>2.39.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/apps/showcase/pom.xml
+++ b/apps/showcase/pom.xml
@@ -144,7 +144,7 @@
        <dependency>
             <groupId>net.sourceforge.htmlunit</groupId>
             <artifactId>htmlunit</artifactId>
-            <version>2.37.0</version>
+            <version>2.39.0</version>
             <scope>test</scope>
         </dependency>
 
@@ -152,7 +152,7 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-validator</artifactId>
-            <version>5.4.3.Final</version>
+            <version>6.1.2.Final</version>
         </dependency>
 
         <!-- The Servlet API mocks in Spring Framework 4.x only supports Servlet 3.0 and higher.
@@ -171,7 +171,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.22.2</version>
+                <version>3.0.0-M4</version>
                 <configuration>
                     <includes>
                         <include>it.org.apache.struts2.showcase.*Test</include>

--- a/plugins/bean-validation/pom.xml
+++ b/plugins/bean-validation/pom.xml
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>
-            <version>1.1.0.Final</version>
+            <version>2.0.1.Final</version>
         </dependency>
 
         <dependency>
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-validator</artifactId>
-            <version>5.4.3.Final</version>
+            <version>6.1.2.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -82,7 +82,7 @@
         <dependency>
             <groupId>com.sun.xml.bind</groupId>
             <artifactId>jaxb-impl</artifactId>
-            <version>2.3.1</version>
+            <version>2.3.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/plugins/cdi/pom.xml
+++ b/plugins/cdi/pom.xml
@@ -47,7 +47,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.jboss.weld</groupId>
+            <groupId>org.jboss.weld.se</groupId>
             <artifactId>weld-se</artifactId>
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -99,21 +99,21 @@
         <java.version>1.8</java.version>
 
         <!-- dependency versions in alphanumeric order -->
-        <asm.version>7.2</asm.version>
-        <jackson.version>2.10.1</jackson.version>
-        <log4j2.version>2.12.1</log4j2.version>
-        <ognl.version>3.2.12</ognl.version>
-        <slf4j.version>1.7.29</slf4j.version>
-        <spring.platformVersion>4.3.25.RELEASE</spring.platformVersion>
+        <asm.version>7.3.1</asm.version>
+        <jackson.version>2.10.3</jackson.version>
+        <log4j2.version>2.13.1</log4j2.version>
+        <ognl.version>3.2.14</ognl.version>
+        <slf4j.version>1.7.30</slf4j.version>
+        <spring.platformVersion>4.3.26.RELEASE</spring.platformVersion>
         <tiles.version>3.0.8</tiles.version>
         <tiles-request.version>1.0.7</tiles-request.version>
 
         <!-- Site generation -->
-        <fluido-skin.version>1.8</fluido-skin.version>
+        <fluido-skin.version>1.9</fluido-skin.version>
 
         <!-- Sonar -->
         <sonar.host.url>https://builds.apache.org/analysis/</sonar.host.url>
-        <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
+        <maven-surefire-plugin.version>3.0.0-M4</maven-surefire-plugin.version>
     </properties>
 
     <profiles>
@@ -223,7 +223,7 @@
                     <plugin>
                         <groupId>org.jacoco</groupId>
                         <artifactId>jacoco-maven-plugin</artifactId>
-                        <version>0.8.4</version>
+                        <version>0.8.5</version>
                         <executions>
                             <execution>
                                 <id>prepare-agent</id>
@@ -287,17 +287,17 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-war-plugin</artifactId>
-                    <version>3.2.2</version>
+                    <version>3.2.3</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
-                    <version>3.5.0</version>
+                    <version>4.2.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>3.1.1</version>
+                    <version>3.1.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -353,7 +353,7 @@
                 <plugin>
                     <groupId>org.owasp</groupId>
                     <artifactId>dependency-check-maven</artifactId>
-                    <version>5.2.4</version>
+                    <version>5.3.2</version>
                     <configuration>
                         <suppressionFiles>
                             <suppressionFile>src/etc/project-suppression.xml</suppressionFile>
@@ -366,7 +366,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>3.0.0-M2</version>
+                    <version>3.0.0-M3</version>
                     <executions>
                         <execution>
                             <id>enforce</id>
@@ -425,7 +425,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>
-                <version>3.8.2</version>
+                <version>3.9.0</version>
                 <configuration>
                     <relativizeDecorationLinks>false</relativizeDecorationLinks>
                 </configuration>
@@ -433,12 +433,12 @@
                     <dependency>
                         <groupId>org.apache.maven.doxia</groupId>
                         <artifactId>doxia-core</artifactId>
-                        <version>1.9</version>
+                        <version>1.9.1</version>
                     </dependency>
                     <dependency>
                         <groupId>org.apache.maven.doxia</groupId>
                         <artifactId>doxia-module-markdown</artifactId>
-                        <version>1.9</version>
+                        <version>1.9.1</version>
                     </dependency>
                 </dependencies>
             </plugin>
@@ -678,13 +678,13 @@
             <dependency>
                 <groupId>org.freemarker</groupId>
                 <artifactId>freemarker</artifactId>
-                <version>2.3.28</version>
+                <version>2.3.30</version>
             </dependency>
 
             <dependency>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>org.apache.felix.main</artifactId>
-                <version>4.6.1</version>
+                <version>6.0.3</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.felix</groupId>
@@ -713,7 +713,7 @@
             <dependency>
                 <groupId>org.apache.velocity</groupId>
                 <artifactId>velocity-engine-core</artifactId>
-                <version>2.1</version>
+                <version>2.2</version>
             </dependency>
 
             <dependency>
@@ -746,13 +746,13 @@
             <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
-                <version>4.12</version>
+                <version>4.13</version>
             </dependency>
 
             <dependency>
                 <groupId>org.easymock</groupId>
                 <artifactId>easymock</artifactId>
-                <version>3.5.1</version>
+                <version>4.2</version>
                 <scope>test</scope>
             </dependency>
 
@@ -766,7 +766,7 @@
             <dependency>
                 <groupId>org.glassfish</groupId>
                 <artifactId>javax.el</artifactId>
-                <version>3.0.1-b10</version>
+                <version>3.0.1-b11</version>
             </dependency>
 
             <dependency>
@@ -779,21 +779,21 @@
             <dependency>
                 <groupId>javax.servlet</groupId>
                 <artifactId>jstl</artifactId>
-                <version>1.1.2</version>
+                <version>1.2</version>
                 <scope>test</scope>
             </dependency>
 
             <dependency>
                 <groupId>org.apache.tomcat</groupId>
                 <artifactId>tomcat-jasper</artifactId>
-                <version>8.5.37</version>
+                <version>8.5.53</version>
                 <scope>provided</scope>
             </dependency>
 
             <dependency>
                 <groupId>org.apache.tomcat</groupId>
                 <artifactId>tomcat-api</artifactId>
-                <version>8.5.37</version>
+                <version>8.5.53</version>
                 <scope>provided</scope>
             </dependency>
 
@@ -870,7 +870,7 @@
             <dependency>
                 <groupId>org.apache.tomcat</groupId>
                 <artifactId>tomcat-juli</artifactId>
-                <version>8.5.37</version>
+                <version>8.5.53</version>
             </dependency>
 
             <!-- Commons -->
@@ -903,7 +903,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.9</version>
+                <version>3.10</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
@@ -1025,14 +1025,22 @@
             <dependency>
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-core</artifactId>
-                <version>2.9.1</version>
+                <version>3.15.0</version>
                 <scope>test</scope>
             </dependency>
 
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
-                <version>2.23.0</version>
+                <version>3.3.3</version>
+                <exclusions>
+                    <!-- The mockito-core artifact and easymock artifact use different versions of objenesis (2.6 vs 3.1).
+                         Excluding the older version here to pass enforcer.  When next upgrading mockito-core, confirm whether this exclusion is still required. -->
+                    <exclusion>
+                        <groupId>org.objenesis</groupId>
+                        <artifactId>objenesis</artifactId>
+                    </exclusion>
+                </exclusions>
                 <scope>test</scope>
             </dependency>
 
@@ -1063,7 +1071,7 @@
             <dependency>
                 <groupId>org.testng</groupId>
                 <artifactId>testng</artifactId>
-                <version>5.14.10</version>
+                <version>7.1.0</version>
                 <scope>compile</scope>
                 <optional>true</optional>
             </dependency>
@@ -1131,26 +1139,26 @@
             <dependency>
                 <groupId>org.apache.juneau</groupId>
                 <artifactId>juneau-marshall</artifactId>
-                <version>7.2.2</version>
+                <version>8.1.3</version>
             </dependency>
 
             <!-- CDI & Weld -->
             <dependency>
                 <groupId>javax.enterprise</groupId>
                 <artifactId>cdi-api</artifactId>
-                <version>1.0-SP4</version>
+                <version>1.2</version>
             </dependency>
 
             <dependency>
                 <groupId>org.jboss.weld</groupId>
                 <artifactId>weld-core</artifactId>
-                <version>1.0.1-SP4</version>
+                <version>2.2.16.SP1</version>
             </dependency>
 
             <dependency>
-                <groupId>org.jboss.weld</groupId>
+                <groupId>org.jboss.weld.se</groupId>
                 <artifactId>weld-se</artifactId>
-                <version>1.0.1-Final</version>
+                <version>2.2.16.SP1</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Proposed WW-5068 change.
------
Proposed list of library version updates:
---
    cdi-api 1.0-SP4 -> 1.2
    weld-core 1.0.1-SP4 -> 2.2.16.SP1
    weld-se 1.0.1-Final -> weld-se-core 2.2.16.SP1
    htmlunit 2.27.0 and 2.37.0 -> 2.39.0
    slf4j-api 1.7.29 -> 1.7.30
    slf4j-simple 1.7.29 -> 1.7.30
    log4j2 2.12.1 - > 2.13.1
    jackson 2.10.1 -> 2.10.3
    ognl 3.2.12 -> 3.2.14
    asm 7.2 -> 7.3.1
    spring 4.3.25.RELEASE -> 4.3.26.RELEASE
    fluido-skin 1.8 -> 1.9
    freemarker 2.3.28 -> 2.3.30
    org.apache.felix.main 4.6.1 -> 6.0.3
    velocity 2.1 -> 2.2
    junit 4.12 -> 4.13
    easymock 3.5.1 -> 4.2
    javax.el 3.0.1-b10 -> 3.0.1-b11
    jstl 1.1.2 -> 1.2
    tomcat-jasper 8.5.37 -> 8.5.53
    tomcat-api 8.5.37 -> 8.5.53
    tomcat-juli 8.5.37 -> 8.5.53
    commons-lang3 3.9 -> 3.10
    assertj-core 2.9.1 -> 3.15.0
    mockito-core 2.23.0 -> 3.3.3   (required exclusion for objenesis)
    testng 5.14.10 -> 7.1.0
    juneau-marshall 7.2.2 -> 8.1.3
    validation-api 1.1.0.Final -> 2.0.1.Final
    hibernate-validator 5.4.3.Final -> 6.1.2.Final
    jaxb-impl 2.3.1 -> 2.3.2
---
Proposed list of Maven plugin version updates:
---
    maven-project-info-reports-plugin 2.7 -> 3.0.0
    updateimpact-maven-plugin 1.0.10 -> 1.0.12
    maven-surefire-plugin 2.22.2 -> 3.0.0-M4
    jacoco-maven-plugin 0.8.4 - > 0.8.5
    maven-war-plugin 3.2.2 -> 3.2.3
    maven-bundle-plugin 3.5.0 -> 4.2.1
    maven-dependency-plugin 3.1.1 -> 3.1.2
    dependency-check-maven 5.2.4 -> 5.3.2
    maven-enforcer-plugin 3.0.0-M2 -> 3.0.0-M3
    maven-failsafe-plugin 2.22.2 -> 3.0.0-M4
    maven-site-plugin 3.8.2 -> 3.9.0
    doxia-core 1.9 -> 1.9.1
    doxia-module-markdown 1.9 -> 1.9.1
---