### PR TITLE
Initial fix for WW-5069 (improve build behaviour JDK9+)

### DIFF
--- a/core/src/test/java/com/opensymphony/xwork2/validator/DateRangeValidatorTest.java
+++ b/core/src/test/java/com/opensymphony/xwork2/validator/DateRangeValidatorTest.java
@@ -48,6 +48,7 @@ public class DateRangeValidatorTest extends XWorkTestCase {
         HashMap<String, Object> params = new HashMap<>();
         params.put("date", date.getTime());
         context.put(ActionContext.PARAMETERS, HttpParameters.create(params).build());
+        context.put(ActionContext.LOCALE, Locale.US);  // Force US Locale for date conversion tests on JDK9+
 
         ActionProxy proxy = actionProxyFactory.createActionProxy("", MockConfigurationProvider.VALIDATION_ACTION_NAME, null, context);
         proxy.execute();

--- a/core/src/test/java/com/opensymphony/xwork2/validator/VisitorFieldValidatorTest.java
+++ b/core/src/test/java/com/opensymphony/xwork2/validator/VisitorFieldValidatorTest.java
@@ -38,6 +38,7 @@ public class VisitorFieldValidatorTest extends XWorkTestCase {
     public void setUp() throws Exception {
         super.setUp();
 
+        ActionContext.getContext().put(ActionContext.LOCALE, Locale.US);  // Force US Locale for date conversion tests on JDK9+
         action = container.inject(VisitorValidatorTestAction.class);
 
         TestBean bean = action.getBean();


### PR DESCRIPTION
Initial fix for WW-5069:

- Force US Locale for two tests that use date strings of the form MM/DD/CCYY.
- When the tests/build are run in an environment with a non-US Locale and newer JDKs the tests may fail due to inability to parse the US date format.

Note: Was noticed on Windows 10 with JDK11, but could affect other environments when run in a non-US Locale.