### PR TITLE
Proposed WW-5074 Fix

### DIFF
--- a/plugins/portlet/pom.xml
+++ b/plugins/portlet/pom.xml
@@ -102,6 +102,15 @@
         </dependency>
 
         <dependency>
+            <!-- Requires ASM 3.3.1 for testing, as jmock-cglib apparently overrides a method made final in later ASM versions
+                 (and apparently jmock-cglib still requires ASM, despite no visible tree dependency). -->
+            <groupId>asm</groupId>
+            <artifactId>asm</artifactId>
+            <version>3.3.1</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>mockobjects</groupId>
             <artifactId>mockobjects-core</artifactId>
             <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -751,6 +751,21 @@
                 <artifactId>asm-commons</artifactId>
                 <version>${asm.version}</version>
             </dependency>
+
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-digester3</artifactId>
+                <optional>true</optional>
+                <!-- Prevent inclusion of ASM 3.3.1 via transitive dependency from velocity-tools-view/commons-digester3/cglib 2.2.2
+                     (its presence creates classpath conflicts / duplicate ASM jars due to ASM groupId changing after 3.x).  -->
+                <exclusions>
+                    <exclusion>
+                        <groupId>asm</groupId>
+                        <artifactId>asm</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
             <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>


### PR DESCRIPTION
Proposed WW-5074 Fix:
- Exclude ASM 3.3.1 from inclusion as a dependency for commons-digester3 (also mark commons-digester3 as optional dependency since it is only listed to allow the exclusion).
- Provide explicit test dependency of ASM 3.3.1 for portlet-plugin (otherwise its jmock tests are unable to execute).