### PR TITLE
Partial backport of Tiny improvements PR#414 to 2.5.x:

### DIFF
--- a/core/src/main/java/org/apache/struts2/dispatcher/Dispatcher.java
+++ b/core/src/main/java/org/apache/struts2/dispatcher/Dispatcher.java
@@ -696,12 +696,23 @@ public class Dispatcher {
             try {
                 locale = LocaleUtils.toLocale(defaultLocale);
             } catch (IllegalArgumentException e) {
-                LOG.warn(new ParameterizedMessage("Cannot convert 'struts.locale' = [{}] to proper locale, defaulting to request locale [{}]",
-                                defaultLocale, request.getLocale()), e);
-                locale = request.getLocale();
+                try {
+                    locale = request.getLocale();
+                    LOG.warn(new ParameterizedMessage("Cannot convert 'struts.locale' = [{}] to proper locale, defaulting to request locale [{}]",
+                                    defaultLocale, locale), e);
+                } catch (RuntimeException rex) {
+                    LOG.warn(new ParameterizedMessage("Cannot convert 'struts.locale' = [{}] to proper locale, and cannot get locale from HTTP Request, falling back to system default locale",
+                                    defaultLocale), rex);
+                    locale = Locale.getDefault();
+                }
             }
         } else {
-            locale = request.getLocale();
+            try {
+                locale = request.getLocale();
+            } catch (RuntimeException rex) {
+                LOG.warn("Cannot get locale from HTTP Request, falling back to system default locale", rex);
+                locale = Locale.getDefault();
+            }
         }
         return locale;
     }


### PR DESCRIPTION
Partial backport of L. Lenart's PR#414 to 2.5.x:
- Improve `Dispatcher` `getLocale()` handling if running in AppEngine.
- Implemented the same improvement to the `defaultLocale` logic path within `getLocale()`.