### PR TITLE
WW-5083 PR#426 follow-up.

### DIFF
--- a/core/src/main/java/org/apache/struts2/interceptor/FetchMetadataInterceptor.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/FetchMetadataInterceptor.java
@@ -76,7 +76,7 @@ public class FetchMetadataInterceptor extends AbstractInterceptor {
             return invocation.invoke();
         }
 
-        LOG.debug("Fetch metadata rejected cross-origin request to [{}]", contextPath);
+        LOG.info("Fetch metadata rejected cross-origin request to [{}]", contextPath);
         return SC_FORBIDDEN;
     }
 

--- a/core/src/main/java/org/apache/struts2/interceptor/FetchMetadataInterceptor.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/FetchMetadataInterceptor.java
@@ -21,12 +21,13 @@ package org.apache.struts2.interceptor;
 import static org.apache.struts2.interceptor.ResourceIsolationPolicy.SEC_FETCH_DEST_HEADER;
 import static org.apache.struts2.interceptor.ResourceIsolationPolicy.SEC_FETCH_MODE_HEADER;
 import static org.apache.struts2.interceptor.ResourceIsolationPolicy.SEC_FETCH_SITE_HEADER;
+import static org.apache.struts2.interceptor.ResourceIsolationPolicy.SEC_FETCH_USER_HEADER;
 import static org.apache.struts2.interceptor.ResourceIsolationPolicy.VARY_HEADER;
 
 import com.opensymphony.xwork2.ActionContext;
 import com.opensymphony.xwork2.ActionInvocation;
+import com.opensymphony.xwork2.inject.Inject;
 import com.opensymphony.xwork2.interceptor.AbstractInterceptor;
-import com.opensymphony.xwork2.interceptor.PreResultListener;
 import com.opensymphony.xwork2.util.TextParseUtil;
 import java.util.HashSet;
 import java.util.Set;
@@ -41,17 +42,19 @@ import org.apache.logging.log4j.Logger;
  * filter the requests allowed to be processed.
  *
  * @see <a href="https://web.dev/fetch-metadata/">https://web.dev/fetch-metadata/</a>
+ * @see <a href="https://www.w3.org/TR/fetch-metadata/">https://www.w3.org/TR/fetch-metadata/</a>
  **/
 
 public class FetchMetadataInterceptor extends AbstractInterceptor {
-    private static final Logger logger = LogManager.getLogger(FetchMetadataInterceptor.class);
-    private static final String VARY_HEADER_VALUE = String.format("%s,%s,%s", SEC_FETCH_DEST_HEADER, SEC_FETCH_SITE_HEADER, SEC_FETCH_MODE_HEADER);
+    private static final Logger LOG = LogManager.getLogger(FetchMetadataInterceptor.class);
+    private static final String VARY_HEADER_VALUE = String.format("%s,%s,%s,%s", SEC_FETCH_DEST_HEADER, SEC_FETCH_MODE_HEADER, SEC_FETCH_SITE_HEADER, SEC_FETCH_USER_HEADER);
     private static final String SC_FORBIDDEN = String.valueOf(HttpServletResponse.SC_FORBIDDEN);
 
     private final Set<String> exemptedPaths = new HashSet<>();
     private final ResourceIsolationPolicy resourceIsolationPolicy = new StrutsResourceIsolationPolicy();
 
-    public void setExemptedPaths(String paths){
+    @Inject (required=false)
+    public void setExemptedPaths(String paths) {
         this.exemptedPaths.addAll(TextParseUtil.commaDelimitedStringToSet(paths));
     }
 
@@ -73,15 +76,31 @@ public class FetchMetadataInterceptor extends AbstractInterceptor {
             return invocation.invoke();
         }
 
-        logger.atDebug().log(
-            "Fetch metadata rejected cross-origin request to %s",
-            contextPath
-        );
+        LOG.debug("Fetch metadata rejected cross-origin request to [{}]", contextPath);
         return SC_FORBIDDEN;
     }
 
+    /**
+     * Sets {@link SEC_FETCH_DEST_HEADER}, {@link SEC_FETCH_MODE_HEADER}, {@link SEC_FETCH_SITE_HEADER}, and {@link SEC_FETCH_USER_HEADER}
+     * elements in the provided ActionInvocation's HttpServletResponse {@link VARY_HEADER} response header.
+     * 
+     * Note: This method will replace any previous Vary header content already set for the response.
+     * Note: In order to be effective, the Vary header modification must take place at (or very near) the start of this interceptor's processing.
+     * 
+     * @param invocation  Supplies the HttpServletResponse (if present) to which the SEC_FETCH_* header names are be added to its {@link VARY_HEADER} response header.
+     */
     private void addVaryHeaders(ActionInvocation invocation) {
         HttpServletResponse response = invocation.getInvocationContext().getServletResponse();
-        response.setHeader(VARY_HEADER, VARY_HEADER_VALUE);
+        if (response != null) {
+            // TODO: Whenever servlet 3.x becomes the baseline for Struts, consider revising this method to use
+            //       getHeader(VARY_HEADER) and preserve any VARY_HEADER content already set in the response.
+            //       This will probably require some tokenization logic for the header contents.
+            if (LOG.isDebugEnabled() && response.containsHeader(VARY_HEADER)) {
+                LOG.debug("HTTP response already has a [{}] header set, the old value will be overwritten (replaced)", VARY_HEADER);
+            }
+            response.setHeader(VARY_HEADER, VARY_HEADER_VALUE);
+        } else {
+            LOG.debug("HTTP response is null, cannot add a new [{}] header", VARY_HEADER);
+        }
     }
 }

--- a/core/src/main/java/org/apache/struts2/interceptor/ResourceIsolationPolicy.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/ResourceIsolationPolicy.java
@@ -30,24 +30,49 @@ import javax.servlet.http.HttpServletRequest;
  * See {@link StrutsResourceIsolationPolicy} for the default implementation used.
  *
  * @see <a href="https://web.dev/fetch-metadata/">https://web.dev/fetch-metadata/</a>
+ * @see <a href="https://www.w3.org/TR/fetch-metadata/">https://www.w3.org/TR/fetch-metadata/</a>
  **/
 
 @FunctionalInterface
 public interface ResourceIsolationPolicy {
-    String SEC_FETCH_SITE_HEADER = "sec-fetch-site";
-    String SEC_FETCH_MODE_HEADER = "sec-fetch-mode";
-    String SEC_FETCH_DEST_HEADER = "sec-fetch-dest";
+    String SEC_FETCH_DEST_HEADER = "Sec-Fetch-Dest";
+    String SEC_FETCH_MODE_HEADER = "Sec-Fetch-Mode";
+    String SEC_FETCH_SITE_HEADER = "Sec-Fetch-Site";
+    String SEC_FETCH_USER_HEADER = "Sec-Fetch-User";
     String VARY_HEADER = "Vary";
-    String SAME_ORIGIN = "same-origin";
-    String SAME_SITE = "same-site";
-    String NONE = "none";
-    String MODE_NAVIGATE = "navigate";
-    String DEST_OBJECT = "object";
+    // Valid values for the SEC_FETCH_DEST_HEADER.  Note: The specifications says servers should ignore the header if it contains an invalid value.
+    String DEST_AUDIO = "audio";
+    String DEST_AUDIOWORKLET = "audioworklet";
+    String DEST_DOCUMENT = "document";
     String DEST_EMBED = "embed";
-    String CROSS_SITE = "cross-site";
-    String CORS = "cors";
-    String DEST_SCRIPT = "script";
+    String DEST_EMPTY = "empty";
+    String DEST_FONT = "font";
     String DEST_IMAGE = "image";
+    String DEST_MANIFEST = "manifest";
+    String DEST_NESTED_DOCUMENT = "nested-document";
+    String DEST_OBJECT = "object";
+    String DEST_PAINTWORKLET = "paintworklet";
+    String DEST_REPORT = "report";
+    String DEST_SCRIPT = "script";
+    String DEST_SERVICEWORKER = "serviceworker";
+    String DEST_SHAREDWORKER = "sharedworker";
+    String DEST_STYLE = "style";
+    String DEST_TRACK = "track";
+    String DEST_VIDEO = "video";
+    String DEST_WORKER = "worker";
+    String DEST_XSLT = "xslt";
+    // Valid values for the SEC_FETCH_MODE_HEADER.  Note: The specifications says servers should ignore the header if it contains an invalid value.
+    String MODE_CORS = "cors";
+    String MODE_NAVIGATE = "navigate";
+    String MODE_NESTED_NAVIGATE = "nested-navigate";
+    String MODE_NO_CORS = "no-cors";
+    String MODE_SAME_ORIGIN = "same-origin";
+    String MODE_WEBSOCKET = "websocket";
+     // Valid values for the SEC_FETCH_SITE_HEADER.  Note: The specifications says servers should ignore the header if it contains an invalid value.
+    String SITE_CROSS_SITE = "cross-site";
+    String SITE_SAME_ORIGIN = "same-origin";
+    String SITE_SAME_SITE = "same-site";
+    String SITE_NONE = "none";
 
     boolean isRequestAllowed(HttpServletRequest request);
 }

--- a/core/src/main/java/org/apache/struts2/interceptor/StrutsResourceIsolationPolicy.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/StrutsResourceIsolationPolicy.java
@@ -29,6 +29,7 @@ import javax.servlet.http.HttpServletRequest;
  * <a href="https://web.dev/fetch-metadata/">https://web.dev/fetch-metadata/</a>.
  *
  * @see <a href="https://web.dev/fetch-metadata/">https://web.dev/fetch-metadata/</a>
+ * @see <a href="https://www.w3.org/TR/fetch-metadata/">https://www.w3.org/TR/fetch-metadata/</a>
  **/
 
 public final class StrutsResourceIsolationPolicy implements ResourceIsolationPolicy {
@@ -38,12 +39,12 @@ public final class StrutsResourceIsolationPolicy implements ResourceIsolationPol
         String site = request.getHeader(SEC_FETCH_SITE_HEADER);
 
         // Allow requests from browsers which don't send Fetch Metadata
-        if (Strings.isEmpty(site)){
+        if (Strings.isEmpty(site)) {
             return true;
         }
 
         // Allow same-site and browser-initiated requests
-        if (SAME_ORIGIN.equals(site) || SAME_SITE.equals(site) || NONE.equals(site)) {
+        if (SITE_SAME_ORIGIN.equalsIgnoreCase(site) || SITE_SAME_SITE.equalsIgnoreCase(site) || SITE_NONE.equalsIgnoreCase(site)) {
             return true;
         }
 
@@ -55,8 +56,8 @@ public final class StrutsResourceIsolationPolicy implements ResourceIsolationPol
         String mode = request.getHeader(SEC_FETCH_MODE_HEADER);
         String dest = request.getHeader(SEC_FETCH_DEST_HEADER);
 
-        boolean isSimpleTopLevelNavigation = MODE_NAVIGATE.equals(mode) || "GET".equals(request.getMethod());
-        boolean isNotObjectOrEmbedRequest = !DEST_EMBED.equals(dest) && !DEST_OBJECT.equals(dest);
+        boolean isSimpleTopLevelNavigation = MODE_NAVIGATE.equalsIgnoreCase(mode) || "GET".equalsIgnoreCase(request.getMethod());
+        boolean isNotObjectOrEmbedRequest = !DEST_EMBED.equalsIgnoreCase(dest) && !DEST_OBJECT.equalsIgnoreCase(dest);
 
         return isSimpleTopLevelNavigation && isNotObjectOrEmbedRequest;
     }

--- a/core/src/test/resources/struts-testing.xml
+++ b/core/src/test/resources/struts-testing.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+-->
+<!DOCTYPE struts PUBLIC
+          "-//Apache Software Foundation//DTD Struts Configuration 2.5//EN"
+          "http://struts.apache.org/dtds/struts-2.5.dtd">
+<struts>
+    <include file="struts-default.xml"/>
+    <package name="default" extends="struts-default" namespace="/">
+        <interceptors>
+            <interceptor-stack name="defaultInterceptorStack">
+                <interceptor-ref name="defaultStack">
+                    <param name="fetchMetadata.setExemptedPaths">/fetchMetadataExemptedGlobal,/someOtherPath</param>
+                </interceptor-ref>
+            </interceptor-stack>
+        </interceptors>
+
+        <action name="fetchMetadataExempted" class="com.opensymphony.xwork2.SimpleAction">
+            <interceptor-ref name="defaultInterceptorStack">
+               <param name="fetchMetadata.setExemptedPaths">/fetchMetadataExempted</param>
+            </interceptor-ref>
+            <result name="success">hello.jsp</result>
+        </action>
+
+        <action name="fetchMetadataNotExempted" class="com.opensymphony.xwork2.SimpleAction">
+            <interceptor-ref name="defaultInterceptorStack">
+                <param name="fetchMetadata.setExemptedPaths">/nonMatchingActionPath</param>
+            </interceptor-ref>
+            <result name="success">hello.jsp</result>
+        </action>
+
+        <action name="fetchMetadataExemptedGlobal" class="com.opensymphony.xwork2.SimpleAction">
+            <interceptor-ref name="defaultInterceptorStack" />
+            <result name="success">hello.jsp</result>
+        </action>
+    </package>
+</struts>


### PR DESCRIPTION
WW-5083 PR#426 follow-up.
- Updated ResourceIsolationPolicy Sec-Fetch* header cases to match spec.
- Added the Sec-Fetch-User header, plus additional dest/site/mode values  from the spec.
- Renamed ResourceIsolationPolicy interface constants to follow the naming convention that was already present.
- Made StrutsResourceIsolationPolicy checks case-insensitive (even if specification says things should be case-sensitive) to better handle client bugs that will likely occur in the future.
- Updated FetchMetaDataInterceport to use more standard LOG reference name, parameterization and call forms seen in other Struts 2 Interceptors.
- Including the Sec-Fetch-User in the Vary resonse header.
- Make setExemptedPaths an injectable method (but not required).
- Updated unit test to use more of the constants, added test confirming the Vary header replacement.
- A few whitespace changes and JavaDoc additions, including reference to the W3C specification site.