### PR TITLE
Refactoring Nonce Propagation in Struts Tags for CSP

### DIFF
--- a/apps/rest-showcase/src/main/webapp/WEB-INF/content/orders-deleteConfirm.jsp
+++ b/apps/rest-showcase/src/main/webapp/WEB-INF/content/orders-deleteConfirm.jsp
@@ -27,14 +27,14 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Orders</title>
-    <link href="${pageContext.request.contextPath}/css/bootstrap.min.css" rel="stylesheet">
-    <link href="${pageContext.request.contextPath}/css/app.css" rel="stylesheet">
+    <s:link href="${pageContext.request.contextPath}/css/bootstrap.min.css" rel="stylesheet">
+    <s:link href="${pageContext.request.contextPath}/css/app.css" rel="stylesheet">
 
     <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
     <!--[if lt IE 9]>
-    <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
-    <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
+    <s:script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></s:script>
+    <s:script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></s:script>
     <![endif]-->
 </head>
 <body>

--- a/apps/rest-showcase/src/main/webapp/WEB-INF/content/orders-deleteConfirm.jsp
+++ b/apps/rest-showcase/src/main/webapp/WEB-INF/content/orders-deleteConfirm.jsp
@@ -27,8 +27,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Orders</title>
-    <s:link href="${pageContext.request.contextPath}/css/bootstrap.min.css" rel="stylesheet">
-    <s:link href="${pageContext.request.contextPath}/css/app.css" rel="stylesheet">
+    <s:link href="${pageContext.request.contextPath}/css/bootstrap.min.css" rel="stylesheet"></s:link>
+    <s:link href="${pageContext.request.contextPath}/css/app.css" rel="stylesheet"></s:link>
 
     <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->

--- a/apps/rest-showcase/src/main/webapp/WEB-INF/content/orders-edit.jsp
+++ b/apps/rest-showcase/src/main/webapp/WEB-INF/content/orders-edit.jsp
@@ -27,14 +27,14 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Orders</title>
-    <link href="${pageContext.request.contextPath}/css/bootstrap.min.css" rel="stylesheet">
-    <link href="${pageContext.request.contextPath}/css/app.css" rel="stylesheet">
+    <s:link href="${pageContext.request.contextPath}/css/bootstrap.min.css" rel="stylesheet">
+    <s:link href="${pageContext.request.contextPath}/css/app.css" rel="stylesheet">
 
     <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
     <!--[if lt IE 9]>
-    <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
-    <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
+    <s:script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></s:script>
+    <s:script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></s:script>
     <![endif]-->
 </head>
 <body>

--- a/apps/rest-showcase/src/main/webapp/WEB-INF/content/orders-edit.jsp
+++ b/apps/rest-showcase/src/main/webapp/WEB-INF/content/orders-edit.jsp
@@ -27,8 +27,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Orders</title>
-    <s:link href="${pageContext.request.contextPath}/css/bootstrap.min.css" rel="stylesheet">
-    <s:link href="${pageContext.request.contextPath}/css/app.css" rel="stylesheet">
+    <s:link href="${pageContext.request.contextPath}/css/bootstrap.min.css" rel="stylesheet"></s:link>
+    <s:link href="${pageContext.request.contextPath}/css/app.css" rel="stylesheet"></s:link>
 
     <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->

--- a/apps/rest-showcase/src/main/webapp/WEB-INF/content/orders-editNew.jsp
+++ b/apps/rest-showcase/src/main/webapp/WEB-INF/content/orders-editNew.jsp
@@ -27,8 +27,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Orders</title>
-    <s:link href="${pageContext.request.contextPath}/css/bootstrap.min.css" rel="stylesheet">
-    <s:link href="${pageContext.request.contextPath}/css/app.css" rel="stylesheet">
+    <s:link href="${pageContext.request.contextPath}/css/bootstrap.min.css" rel="stylesheet"></s:link>
+    <s:link href="${pageContext.request.contextPath}/css/app.css" rel="stylesheet"></s:link>
     <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
     <!--[if lt IE 9]>

--- a/apps/rest-showcase/src/main/webapp/WEB-INF/content/orders-editNew.jsp
+++ b/apps/rest-showcase/src/main/webapp/WEB-INF/content/orders-editNew.jsp
@@ -27,13 +27,13 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Orders</title>
-    <link href="${pageContext.request.contextPath}/css/bootstrap.min.css" rel="stylesheet">
-    <link href="${pageContext.request.contextPath}/css/app.css" rel="stylesheet">
+    <s:link href="${pageContext.request.contextPath}/css/bootstrap.min.css" rel="stylesheet">
+    <s:link href="${pageContext.request.contextPath}/css/app.css" rel="stylesheet">
     <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
     <!--[if lt IE 9]>
-    <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
-    <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
+    <s:script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></s:script>
+    <s:script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></s:script>
     <![endif]-->
 </head>
 <body>

--- a/apps/rest-showcase/src/main/webapp/WEB-INF/content/orders-index.jsp
+++ b/apps/rest-showcase/src/main/webapp/WEB-INF/content/orders-index.jsp
@@ -27,14 +27,14 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Orders</title>
-    <link href="${pageContext.request.contextPath}/css/bootstrap.min.css" rel="stylesheet">
-    <link href="${pageContext.request.contextPath}/css/app.css" rel="stylesheet">
+    <s:link href="${pageContext.request.contextPath}/css/bootstrap.min.css" rel="stylesheet">
+    <s:link href="${pageContext.request.contextPath}/css/app.css" rel="stylesheet">
 
     <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
     <!--[if lt IE 9]>
-    <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
-    <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
+    <s:script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></s:script>
+    <s:script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></s:script>
     <![endif]-->
 </head>
 <body>

--- a/apps/rest-showcase/src/main/webapp/WEB-INF/content/orders-index.jsp
+++ b/apps/rest-showcase/src/main/webapp/WEB-INF/content/orders-index.jsp
@@ -27,8 +27,8 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Orders</title>
-    <s:link href="${pageContext.request.contextPath}/css/bootstrap.min.css" rel="stylesheet">
-    <s:link href="${pageContext.request.contextPath}/css/app.css" rel="stylesheet">
+    <s:link href="${pageContext.request.contextPath}/css/bootstrap.min.css" rel="stylesheet"></s:link>
+    <s:link href="${pageContext.request.contextPath}/css/app.css" rel="stylesheet"></s:link>
 
     <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->

--- a/apps/rest-showcase/src/main/webapp/WEB-INF/content/orders-show.jsp
+++ b/apps/rest-showcase/src/main/webapp/WEB-INF/content/orders-show.jsp
@@ -27,14 +27,14 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Orders</title>
-    <link href="${pageContext.request.contextPath}/css/bootstrap.min.css" rel="stylesheet">
-    <link href="${pageContext.request.contextPath}/css/app.css" rel="stylesheet">
+    <s:link href="${pageContext.request.contextPath}/css/bootstrap.min.css" rel="stylesheet">
+    <s:link href="${pageContext.request.contextPath}/css/app.css" rel="stylesheet">
 
     <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
     <!--[if lt IE 9]>
-    <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
-    <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
+    <s:script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></s:script>
+    <s:script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></s:script>
     <![endif]-->
 </head>
 <body>

--- a/apps/rest-showcase/src/main/webapp/WEB-INF/content/orders-show.jsp
+++ b/apps/rest-showcase/src/main/webapp/WEB-INF/content/orders-show.jsp
@@ -27,8 +27,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Orders</title>
-    <s:link href="${pageContext.request.contextPath}/css/bootstrap.min.css" rel="stylesheet">
-    <s:link href="${pageContext.request.contextPath}/css/app.css" rel="stylesheet">
+<s:link href="${pageContext.request.contextPath}/css/bootstrap.min.css" rel="stylesheet"></s:link>
+    <s:link href="${pageContext.request.contextPath}/css/app.css" rel="stylesheet"></s:link>
 
     <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->

--- a/apps/showcase/src/main/webapp/WEB-INF/decorators/main.jsp
+++ b/apps/showcase/src/main/webapp/WEB-INF/decorators/main.jsp
@@ -63,26 +63,26 @@
 
     <title><decorator:title default="Struts2 Showcase"/></title>
 
-    <link href="<s:url value='/styles/bootstrap.css' encode='false' includeParams='none'/>" rel="stylesheet" type="text/css" media="all">
-    <link href="<s:url value='/styles/main.css' encode='false' includeParams='none'/>" rel="stylesheet" type="text/css" media="all"/>
+    <s:link href="<s:url value='/styles/bootstrap.css' encode='false' includeParams='none'/>" rel="stylesheet" type="text/css" media="all">
+    <s:link href="<s:url value='/styles/main.css' encode='false' includeParams='none'/>" rel="stylesheet" type="text/css" media="all"/>
 
-    <script src="<s:url value='/js/jquery-2.1.4.min.js' encode='false' includeParams='none'/>"></script>
-    <script src="<s:url value='/js/bootstrap.min.js' encode='false' includeParams='none'/>"></script>
-    <script type="text/javascript">
+    <s:script src="<s:url value='/js/jquery-2.1.4.min.js' encode='false' includeParams='none'/>"></s:script>
+    <s:script src="<s:url value='/js/bootstrap.min.js' encode='false' includeParams='none'/>"></s:script>
+    <s:script type="text/javascript">
         $(function () {
             var alerts = $('ul.alert').wrap('<div />');
             alerts.prepend('<a class="close" data-dismiss="alert" href="#">&times;</a>');
             alerts.alert();
         });
-    </script>
+    </s:script>
 
     <!-- Prettify -->
-    <link href="<s:url value='/styles/prettify.css' encode='false' includeParams='none'/>" rel="stylesheet">
-    <script src="<s:url value='/js/prettify.js' encode='false' includeParams='none'/>"></script>
+    <s:link href="<s:url value='/styles/prettify.css' encode='false' includeParams='none'/>" rel="stylesheet">
+    <s:script src="<s:url value='/js/prettify.js' encode='false' includeParams='none'/>"></s:script>
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+    <s:script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></s:script>
     <![endif]-->
 
     <decorator:head/>

--- a/apps/showcase/src/main/webapp/WEB-INF/decorators/main.jsp
+++ b/apps/showcase/src/main/webapp/WEB-INF/decorators/main.jsp
@@ -63,11 +63,15 @@
 
     <title><decorator:title default="Struts2 Showcase"/></title>
 
-    <s:link href="<s:url value='/styles/bootstrap.css' encode='false' includeParams='none'/>" rel="stylesheet" type="text/css" media="all">
-    <s:link href="<s:url value='/styles/main.css' encode='false' includeParams='none'/>" rel="stylesheet" type="text/css" media="all"/>
+    <s:url var="bootstrapCss" value='/styles/bootstrap.css' encode='false' includeParams='none'/>
+    <s:link href="%{bootstrapCss}" rel="stylesheet" type="text/css" media="all"></s:link>
+    <s:url var="mainCss" value='/styles/main.css' encode='false' includeParams='none'/>
+    <s:link href="%{mainCss}" rel="stylesheet" type="text/css" media="all"></s:link>
 
-    <s:script src="<s:url value='/js/jquery-2.1.4.min.js' encode='false' includeParams='none'/>"></s:script>
-    <s:script src="<s:url value='/js/bootstrap.min.js' encode='false' includeParams='none'/>"></s:script>
+    <s:url var="jqueryJs" value='/js/jquery-2.1.4.min.js' encode='false' includeParams='none'/>
+    <s:script src="%{jqueryJs}"></s:script>
+    <s:url var="bootstrapJs" value='/js/bootstrap.min.js' encode='false' includeParams='none'/>
+    <s:script src="%{bootstrapJs}"></s:script>
     <s:script type="text/javascript">
         $(function () {
             var alerts = $('ul.alert').wrap('<div />');
@@ -77,8 +81,10 @@
     </s:script>
 
     <!-- Prettify -->
-    <s:link href="<s:url value='/styles/prettify.css' encode='false' includeParams='none'/>" rel="stylesheet">
-    <s:script src="<s:url value='/js/prettify.js' encode='false' includeParams='none'/>"></s:script>
+    <s:url var="prettifyCss" value='/styles/prettify.css' encode='false' includeParams='none'/>
+    <s:link href="%{prettifyCss}" rel="stylesheet"></s:link>
+    <s:url var="prettifyJs" value='/js/prettify.js' encode='false' includeParams='none'/>
+    <s:script src="%{prettifyJs}"></s:script>
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>

--- a/apps/showcase/src/main/webapp/WEB-INF/validation/ajaxFormSubmit.jsp
+++ b/apps/showcase/src/main/webapp/WEB-INF/validation/ajaxFormSubmit.jsp
@@ -72,7 +72,7 @@
     </div>
 </div>
 
-<script type="text/javascript">
+<s:script type="text/javascript">
 /********************************************************************
  * JS just used on this page.
  * Usually this would be placed in a JS file
@@ -196,6 +196,6 @@ function _handleValidationResult(form, errors) {
 $(window).bind('load', function() {
     $('form').bind('submit', ajaxFormValidation);
 });
-</script>
+</s:script>
 </body>
 </html>

--- a/apps/showcase/src/main/webapp/WEB-INF/validation/quiz-dwr.jsp
+++ b/apps/showcase/src/main/webapp/WEB-INF/validation/quiz-dwr.jsp
@@ -26,10 +26,10 @@
 <head>
 	<title>Struts2 Showcase - Validation - DWR</title>
 	<s:head/>
-	<script type='text/javascript' src='../dwr/engine.js'></script>
-    <script type='text/javascript' src='../dwr/util.js'></script>
-	<script type='text/javascript' src='../dwr/interface/validator.js'></script>
-	<script type='text/javascript'>
+	<s:script type='text/javascript' src='../dwr/engine.js'></s:script>
+    <s:script type='text/javascript' src='../dwr/util.js'></s:script>
+	<s:script type='text/javascript' src='../dwr/interface/validator.js'></s:script>
+	<s:script type='text/javascript'>
         var dwrValidateReply = function(data) {
             var validationResult = '';
             for (index = 0; index < data.actionErrors.length; ++index) {
@@ -62,7 +62,7 @@
             validator.doPost('/validation', 'quizDwr', postData, dwrValidateReply);
             return false;
         }
-	</script>
+	</s:script>
 </head>
 
 <body>

--- a/apps/showcase/src/main/webapp/WEB-INF/viewSource.jsp
+++ b/apps/showcase/src/main/webapp/WEB-INF/viewSource.jsp
@@ -64,11 +64,11 @@
 </div>
 
 
-<script>
+<s:script>
 	$('#codeTab a').click(function (e) {
 		e.preventDefault();
 		$(this).tab('show');
 	})
-</script>
+</s:script>
 </body>
 </html>

--- a/core/src/main/java/org/apache/struts2/components/Link.java
+++ b/core/src/main/java/org/apache/struts2/components/Link.java
@@ -166,10 +166,5 @@ public class Link extends UIBean{
         if (title != null) {
             addParameter("title", findString(title));
         }
-
-        if (stack.getActionContext().getSession().containsKey("nonce")) {
-            String nonceValue = stack.getActionContext().getSession().get("nonce").toString();
-            addParameter("nonce", nonceValue);
-        }
     }
 }

--- a/core/src/main/java/org/apache/struts2/components/Script.java
+++ b/core/src/main/java/org/apache/struts2/components/Script.java
@@ -168,11 +168,6 @@ public class Script extends ClosingUIBean {
         if (crossorigin != null) {
             addParameter("crossorigin", findString(crossorigin));
         }
-
-        if (stack.getActionContext().getSession().containsKey("nonce")) {
-            String nonceValue = stack.getActionContext().getSession().get("nonce").toString();
-            addParameter("nonce", nonceValue);
-        }
     }
 
 }

--- a/core/src/main/java/org/apache/struts2/components/UIBean.java
+++ b/core/src/main/java/org/apache/struts2/components/UIBean.java
@@ -881,6 +881,15 @@ public abstract class UIBean extends Component {
             }
         }
 
+        // to be used with the CSP interceptor - adds the nonce value as a parameter to be accessed from ftl files
+        Map<String, Object> session = stack.getActionContext().getSession();
+        if (session != null) {
+            if (session.containsKey("nonce")) {
+                String nonceValue = session.get("nonce").toString();
+                addParameter("nonce", nonceValue);
+            }
+        }
+
         evaluateExtraParams();
     }
 

--- a/core/src/main/java/org/apache/struts2/views/freemarker/tags/LinkModel.java
+++ b/core/src/main/java/org/apache/struts2/views/freemarker/tags/LinkModel.java
@@ -1,4 +1,3 @@
-<#--
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -17,7 +16,25 @@
  * specific language governing permissions and limitations
  * under the License.
  */
--->
-<script src="${base}/struts/utils.js" type="text/javascript" <#rt/>
-<#include "/${parameters.templateDir}/simple/nonce.ftl" />
-></script>
+package org.apache.struts2.views.freemarker.tags;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.struts2.components.Component;
+import org.apache.struts2.components.Link;
+
+import com.opensymphony.xwork2.util.ValueStack;
+
+/**
+ * @see Link
+ */
+public class LinkModel extends TagModel {
+    public LinkModel(ValueStack stack, HttpServletRequest req, HttpServletResponse res) {
+        super(stack, req, res);
+    }
+
+    protected Component getBean() {
+        return new Link(stack, req, res);
+    }
+}

--- a/core/src/main/java/org/apache/struts2/views/freemarker/tags/ScriptModel.java
+++ b/core/src/main/java/org/apache/struts2/views/freemarker/tags/ScriptModel.java
@@ -1,4 +1,3 @@
-<#--
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -17,7 +16,25 @@
  * specific language governing permissions and limitations
  * under the License.
  */
--->
-<script src="${base}/struts/utils.js" type="text/javascript" <#rt/>
-<#include "/${parameters.templateDir}/simple/nonce.ftl" />
-></script>
+package org.apache.struts2.views.freemarker.tags;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.struts2.components.Component;
+import org.apache.struts2.components.Script;
+
+import com.opensymphony.xwork2.util.ValueStack;
+
+/**
+ * @see Script
+ */
+public class ScriptModel extends TagModel {
+    public ScriptModel(ValueStack stack, HttpServletRequest req, HttpServletResponse res) {
+        super(stack, req, res);
+    }
+
+    protected Component getBean() {
+        return new Script(stack, req, res);
+    }
+}

--- a/core/src/main/java/org/apache/struts2/views/freemarker/tags/StrutsModels.java
+++ b/core/src/main/java/org/apache/struts2/views/freemarker/tags/StrutsModels.java
@@ -22,6 +22,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import com.opensymphony.xwork2.util.ValueStack;
+import org.apache.struts2.components.Script;
 
 /**
  * Provides @s.tag access for various tags.
@@ -73,6 +74,8 @@ public class StrutsModels {
     protected ElseModel elseModel;
     protected ElseIfModel elseIfModel;
     protected InputTransferSelectModel inputtransferselect;
+    protected ScriptModel script;
+    protected LinkModel link;
 
 
     public StrutsModels(ValueStack stack, HttpServletRequest req, HttpServletResponse res) {
@@ -160,6 +163,14 @@ public class StrutsModels {
         return label;
     }
 
+    public LinkModel getLink() {
+        if (link == null) {
+            link = new LinkModel(stack, req, res);
+        }
+
+        return link;
+    }
+
     public PasswordModel getPassword() {
         if (password == null) {
             password = new PasswordModel(stack, req, res);
@@ -174,6 +185,14 @@ public class StrutsModels {
         }
 
         return radio;
+    }
+
+    public ScriptModel getScript() {
+        if (script == null) {
+            script = new ScriptModel(stack, req, res);
+        }
+
+        return script;
     }
 
     public SelectModel getSelect() {

--- a/core/src/main/resources/org/apache/struts2/interceptor/debugging/console.ftl
+++ b/core/src/main/resources/org/apache/struts2/interceptor/debugging/console.ftl
@@ -21,7 +21,9 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <script type="text/javascript">
+    <script type="text/javascript" <#rt/>
+    <#include "/${parameters.templateDir}/simple/nonce.ftl" />
+    >
     var baseUrl = "<@s.url value="/struts" includeParams="none"/>";
     window.open(baseUrl+"/webconsole.html", 'OGNL Console','width=500,height=450,status=no,toolbar=no,menubar=no');
     </script>    

--- a/core/src/main/resources/org/apache/struts2/interceptor/debugging/console.ftl
+++ b/core/src/main/resources/org/apache/struts2/interceptor/debugging/console.ftl
@@ -21,9 +21,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <script type="text/javascript" <#rt/>
-    <#include "/${parameters.templateDir}/simple/nonce.ftl" />
-    >
+    <script type="text/javascript" <#include "/${parameters.templateDir}/simple/nonce.ftl" /> >
     var baseUrl = "<@s.url value="/struts" includeParams="none"/>";
     window.open(baseUrl+"/webconsole.html", 'OGNL Console','width=500,height=450,status=no,toolbar=no,menubar=no');
     </script>    

--- a/core/src/main/resources/template/css_xhtml/head.ftl
+++ b/core/src/main/resources/template/css_xhtml/head.ftl
@@ -18,7 +18,5 @@
  * under the License.
  */
 -->
-<link
-        <#include "/${parameters.templateDir}/simple/nonce.ftl" />
-        rel="stylesheet" href="<@s.url value='/struts/css_xhtml/styles.css' includeParams='none' encode='false' />" type="text/css" />
+<link <#include "/${parameters.templateDir}/simple/nonce.ftl" /> rel="stylesheet" href="<@s.url value='/struts/css_xhtml/styles.css' includeParams='none' encode='false' />" type="text/css" />
 <#include "/${parameters.templateDir}/simple/head.ftl" />

--- a/core/src/main/resources/template/css_xhtml/head.ftl
+++ b/core/src/main/resources/template/css_xhtml/head.ftl
@@ -18,5 +18,7 @@
  * under the License.
  */
 -->
-<link rel="stylesheet" href="<@s.url value='/struts/css_xhtml/styles.css' includeParams='none' encode='false' />" type="text/css" />
+<link
+        <#include "/${parameters.templateDir}/simple/nonce.ftl" />
+        rel="stylesheet" href="<@s.url value='/struts/css_xhtml/styles.css' includeParams='none' encode='false' />" type="text/css" />
 <#include "/${parameters.templateDir}/simple/head.ftl" />

--- a/core/src/main/resources/template/simple/combobox.ftl
+++ b/core/src/main/resources/template/simple/combobox.ftl
@@ -18,9 +18,7 @@
  * under the License.
  */
 -->
-<script type="text/javascript" <#rt/>
-<#include "/${parameters.templateDir}/simple/nonce.ftl" />
->
+<script type="text/javascript" <#include "/${parameters.templateDir}/simple/nonce.ftl" /> >
 	function autoPopulate_${parameters.escapedId}(targetElement) {
 		<#if parameters.headerKey?? && parameters.headerValue??>
 		if (targetElement.options[targetElement.selectedIndex].value == '${parameters.headerKey}') {

--- a/core/src/main/resources/template/simple/combobox.ftl
+++ b/core/src/main/resources/template/simple/combobox.ftl
@@ -18,7 +18,9 @@
  * under the License.
  */
 -->
-<script type="text/javascript">
+<script type="text/javascript" <#rt/>
+<#include "/${parameters.templateDir}/simple/nonce.ftl" />
+>
 	function autoPopulate_${parameters.escapedId}(targetElement) {
 		<#if parameters.headerKey?? && parameters.headerValue??>
 		if (targetElement.options[targetElement.selectedIndex].value == '${parameters.headerKey}') {

--- a/core/src/main/resources/template/simple/debug.ftl
+++ b/core/src/main/resources/template/simple/debug.ftl
@@ -18,9 +18,7 @@
  * under the License.
  */
 -->
-<script type="text/javascript" <#rt/>
-<#include "/${parameters.templateDir}/simple/nonce.ftl" />
->
+<script type="text/javascript" <#include "/${parameters.templateDir}/simple/nonce.ftl" /> >
 <!--
     function toggleDebug(debugId) {
         var debugDiv = document.getElementById(debugId);

--- a/core/src/main/resources/template/simple/debug.ftl
+++ b/core/src/main/resources/template/simple/debug.ftl
@@ -18,7 +18,9 @@
  * under the License.
  */
 -->
-<script type="text/javascript">
+<script type="text/javascript" <#rt/>
+<#include "/${parameters.templateDir}/simple/nonce.ftl" />
+>
 <!--
     function toggleDebug(debugId) {
         var debugDiv = document.getElementById(debugId);

--- a/core/src/main/resources/template/simple/doubleselect.ftl
+++ b/core/src/main/resources/template/simple/doubleselect.ftl
@@ -70,7 +70,9 @@
     </#if>
         />
 </#if>
-<script type="text/javascript">
+<script type="text/javascript" <#rt/>
+    <#include "/${parameters.templateDir}/simple/nonce.ftl" />
+>
     <#assign itemCount = startCount/>
     var ${parameters.id}Group = new Array(${parameters.listSize} + ${startCount});
     for (var i = 0; i < (${parameters.listSize} + ${startCount}); i++) {

--- a/core/src/main/resources/template/simple/doubleselect.ftl
+++ b/core/src/main/resources/template/simple/doubleselect.ftl
@@ -70,9 +70,7 @@
     </#if>
         />
 </#if>
-<script type="text/javascript" <#rt/>
-    <#include "/${parameters.templateDir}/simple/nonce.ftl" />
->
+<script type="text/javascript" <#include "/${parameters.templateDir}/simple/nonce.ftl" /> >
     <#assign itemCount = startCount/>
     var ${parameters.id}Group = new Array(${parameters.listSize} + ${startCount});
     for (var i = 0; i < (${parameters.listSize} + ${startCount}); i++) {

--- a/core/src/main/resources/template/simple/form-close-tooltips.ftl
+++ b/core/src/main/resources/template/simple/form-close-tooltips.ftl
@@ -24,7 +24,11 @@
 --><#t/>
 <#if (parameters.hasTooltip!false)><#t/>
 	<#lt/><!-- javascript that is needed for tooltips -->
-	<#lt/><script type="text/javascript" src='<@s.url value="/struts/domTT.js" includeParams="none" encode="false" />'></script>
-	<#lt/><link rel="stylesheet" type="text/css" href="<@s.url value="/struts/domTT.css" includeParams="none" encode="false" />"/>
+	<#lt/><script type="text/javascript" src='<@s.url value="/struts/domTT.js" includeParams="none" encode="false" />'<#rt/>
+	<#include "/${parameters.templateDir}/simple/nonce.ftl" />
+	></script>
+	<#lt/><link rel="stylesheet" type="text/css" href="<@s.url value="/struts/domTT.css" includeParams="none" encode="false" />" <#rt/>
+	<#include "/${parameters.templateDir}/simple/nonce.ftl" />
+	/>
 	
 </#if><#t/>

--- a/core/src/main/resources/template/simple/form-close-tooltips.ftl
+++ b/core/src/main/resources/template/simple/form-close-tooltips.ftl
@@ -24,11 +24,7 @@
 --><#t/>
 <#if (parameters.hasTooltip!false)><#t/>
 	<#lt/><!-- javascript that is needed for tooltips -->
-	<#lt/><script type="text/javascript" src='<@s.url value="/struts/domTT.js" includeParams="none" encode="false" />'<#rt/>
-	<#include "/${parameters.templateDir}/simple/nonce.ftl" />
-	></script>
-	<#lt/><link rel="stylesheet" type="text/css" href="<@s.url value="/struts/domTT.css" includeParams="none" encode="false" />" <#rt/>
-	<#include "/${parameters.templateDir}/simple/nonce.ftl" />
-	/>
+	<#lt/><script type="text/javascript" src='<@s.url value="/struts/domTT.js" includeParams="none" encode="false" />' <#include "/${parameters.templateDir}/simple/nonce.ftl" /> > </script>
+	<#lt/><link rel="stylesheet" type="text/css" href="<@s.url value="/struts/domTT.css" includeParams="none" encode="false" />" <#include "/${parameters.templateDir}/simple/nonce.ftl" /> />
 	
 </#if><#t/>

--- a/core/src/main/resources/template/simple/form-close.ftl
+++ b/core/src/main/resources/template/simple/form-close.ftl
@@ -21,16 +21,18 @@
 </form>
 
 <#if (parameters.customOnsubmitEnabled??)>
-<script type="text/javascript">
-<#-- 
-  Enable auto-select of optiontransferselect tag's entries upon containing form's 
+<script type="text/javascript" <#rt/>
+   <#include "/${parameters.templateDir}/simple/nonce.ftl" />
+>
+<#--
+  Enable auto-select of optiontransferselect tag's entries upon containing form's
   submission.
 -->
 <#if (parameters.optiontransferselectIds!?size > 0)>
 	var containingForm = document.getElementById("${parameters.id}");
 	<#assign selectObjIds = parameters.optiontransferselectIds.keySet() />
 	<#list selectObjIds as selectObjectId>
-		StrutsUtils.addEventListener(containingForm, "submit", 
+		StrutsUtils.addEventListener(containingForm, "submit",
 			function(evt) {
 				var selectObj = document.getElementById("${selectObjectId}");
 				<#if parameters.optiontransferselectIds.get(selectObjectId)??>
@@ -62,7 +64,7 @@
 	var containingForm = document.getElementById("${parameters.id}");
 	<#assign selectDoubleObjIds = parameters.optiontransferselectDoubleIds.keySet() />
 	<#list selectDoubleObjIds as selectObjId>
-		StrutsUtils.addEventListener(containingForm, "submit", 
+		StrutsUtils.addEventListener(containingForm, "submit",
 			function(evt) {
 				var selectObj = document.getElementById("${selectObjId}");
 				<#if parameters.optiontransferselectDoubleIds.get(selectObjId)??>
@@ -84,7 +86,7 @@
 	var containingForm = document.getElementById("${parameters.id}");
 	<#assign tmpIds = parameters.updownselectIds.keySet() />
 	<#list tmpIds as tmpId>
-		StrutsUtils.addEventListener(containingForm, "submit", 
+		StrutsUtils.addEventListener(containingForm, "submit",
 			function(evt) {
 				var updownselectObj = document.getElementById("${tmpId}");
 				<#if parameters.updownselectIds.get(tmpId)??>

--- a/core/src/main/resources/template/simple/form-close.ftl
+++ b/core/src/main/resources/template/simple/form-close.ftl
@@ -21,9 +21,7 @@
 </form>
 
 <#if (parameters.customOnsubmitEnabled??)>
-<script type="text/javascript" <#rt/>
-   <#include "/${parameters.templateDir}/simple/nonce.ftl" />
->
+<script type="text/javascript" <#include "/${parameters.templateDir}/simple/nonce.ftl" /> >
 <#--
   Enable auto-select of optiontransferselect tag's entries upon containing form's
   submission.

--- a/core/src/main/resources/template/simple/head.ftl
+++ b/core/src/main/resources/template/simple/head.ftl
@@ -18,6 +18,4 @@
  * under the License.
  */
 -->
-<script src="${base}/struts/utils.js" type="text/javascript" <#rt/>
-<#include "/${parameters.templateDir}/simple/nonce.ftl" />
-></script>
+<script src="${base}/struts/utils.js" type="text/javascript" <#include "/${parameters.templateDir}/simple/nonce.ftl" /> ></script>

--- a/core/src/main/resources/template/simple/inputtransferselect.ftl
+++ b/core/src/main/resources/template/simple/inputtransferselect.ftl
@@ -19,7 +19,9 @@
  */
 -->
 <#if !stack.findValue("#inputtransferselect_js_included")??><#t/>
-	<script type="text/javascript" src="<@s.url value="/struts/inputtransferselect.js" encode='false' includeParams='none'/>"></script>
+	<script type="text/javascript" src="<@s.url value="/struts/inputtransferselect.js" encode='false' includeParams='none'/>" <#rt/>
+	<#include "/${parameters.templateDir}/simple/nonce.ftl" />
+	></script>
 	<#assign temporaryVariable = stack.setValue("#inputtransferselect_js_included", "true") /><#t/>
 </#if><#t/>
 <table>

--- a/core/src/main/resources/template/simple/inputtransferselect.ftl
+++ b/core/src/main/resources/template/simple/inputtransferselect.ftl
@@ -19,9 +19,7 @@
  */
 -->
 <#if !stack.findValue("#inputtransferselect_js_included")??><#t/>
-	<script type="text/javascript" src="<@s.url value="/struts/inputtransferselect.js" encode='false' includeParams='none'/>" <#rt/>
-	<#include "/${parameters.templateDir}/simple/nonce.ftl" />
-	></script>
+	<script type="text/javascript" src="<@s.url value="/struts/inputtransferselect.js" encode='false' includeParams='none'/>" <#include "/${parameters.templateDir}/simple/nonce.ftl" /> ></script>
 	<#assign temporaryVariable = stack.setValue("#inputtransferselect_js_included", "true") /><#t/>
 </#if><#t/>
 <table>

--- a/core/src/main/resources/template/simple/link.ftl
+++ b/core/src/main/resources/template/simple/link.ftl
@@ -20,7 +20,8 @@
 -->
 <#include "/${parameters.templateDir}/${parameters.expandTheme}/common-attributes.ftl" />
 <#include "/${parameters.templateDir}/${parameters.expandTheme}/dynamic-attributes.ftl" />
-<link nonce="${parameters.nonce}"<#rt/>
+<link <#rt/>
+<#include "/${parameters.templateDir}/simple/nonce.ftl" />
 <#if parameters.href?has_content>
     href="${parameters.href}"<#rt/>
 </#if>

--- a/core/src/main/resources/template/simple/link.ftl
+++ b/core/src/main/resources/template/simple/link.ftl
@@ -20,8 +20,7 @@
 -->
 <#include "/${parameters.templateDir}/${parameters.expandTheme}/common-attributes.ftl" />
 <#include "/${parameters.templateDir}/${parameters.expandTheme}/dynamic-attributes.ftl" />
-<link <#rt/>
-<#include "/${parameters.templateDir}/simple/nonce.ftl" />
+<link <#include "/${parameters.templateDir}/simple/nonce.ftl" />
 <#if parameters.href?has_content>
     href="${parameters.href}"<#rt/>
 </#if>

--- a/core/src/main/resources/template/simple/nonce.ftl
+++ b/core/src/main/resources/template/simple/nonce.ftl
@@ -18,6 +18,6 @@
  * under the License.
  */
 -->
-<script src="${base}/struts/utils.js" type="text/javascript" <#rt/>
-<#include "/${parameters.templateDir}/simple/nonce.ftl" />
-></script>
+<#if parameters.nonce?has_content>
+    nonce="${parameters.nonce}"<#rt/>
+</#if>

--- a/core/src/main/resources/template/simple/optiontransferselect.ftl
+++ b/core/src/main/resources/template/simple/optiontransferselect.ftl
@@ -19,7 +19,9 @@
  */
 -->
 <#if !stack.findValue("#optiontransferselect_js_included")??><#t/>
-	<script type="text/javascript" src="<@s.url value="/struts/optiontransferselect.js" encode='false' includeParams='none'/>"></script>
+	<script type="text/javascript" src="<@s.url value="/struts/optiontransferselect.js" encode='false' includeParams='none'/>"<#rt/>
+	<#include "/${parameters.templateDir}/simple/nonce.ftl" />
+	></script>
 	<#assign temporaryVariable = stack.setValue("#optiontransferselect_js_included", "true") /><#t/>
 </#if><#t/>
 <table>

--- a/core/src/main/resources/template/simple/optiontransferselect.ftl
+++ b/core/src/main/resources/template/simple/optiontransferselect.ftl
@@ -19,9 +19,7 @@
  */
 -->
 <#if !stack.findValue("#optiontransferselect_js_included")??><#t/>
-	<script type="text/javascript" src="<@s.url value="/struts/optiontransferselect.js" encode='false' includeParams='none'/>"<#rt/>
-	<#include "/${parameters.templateDir}/simple/nonce.ftl" />
-	></script>
+	<script type="text/javascript" src="<@s.url value="/struts/optiontransferselect.js" encode='false' includeParams='none'/>" <#include "/${parameters.templateDir}/simple/nonce.ftl" /> ></script>
 	<#assign temporaryVariable = stack.setValue("#optiontransferselect_js_included", "true") /><#t/>
 </#if><#t/>
 <table>

--- a/core/src/main/resources/template/simple/script.ftl
+++ b/core/src/main/resources/template/simple/script.ftl
@@ -18,12 +18,10 @@
  * under the License.
  */
 -->
+<script <#rt/>
 <#include "/${parameters.templateDir}/${parameters.expandTheme}/common-attributes.ftl" />
 <#include "/${parameters.templateDir}/${parameters.expandTheme}/dynamic-attributes.ftl" />
-<script <#rt/>
-<#if parameters.nonce?has_content>
- nonce="${parameters.nonce}"<#rt/>
-</#if>
+<#include "/${parameters.templateDir}/simple/nonce.ftl" />
 <#if parameters.async?has_content>
  <#if parameters.async=="true">
   async<#rt/>
@@ -42,9 +40,6 @@
 </#if>
 <#if parameters.type?has_content>
  type="${parameters.type}"<#rt/>
-</#if>
-<#if parameters.name?has_content>
- name="${parameters.name}"<#rt/>
 </#if>
 <#if parameters.referrerpolicy?has_content>
  referrerpolicy="${parameters.referrerpolicy}"<#rt/>

--- a/core/src/main/resources/template/simple/updownselect.ftl
+++ b/core/src/main/resources/template/simple/updownselect.ftl
@@ -19,7 +19,9 @@
  */
 -->
 <#if !stack.findValue("#optiontransferselect_js_included")??><#t/>
-	<script type="text/javascript" src="<@s.url value="/struts/optiontransferselect.js" encode='false' includeParams='none'/>"></script>
+	<script type="text/javascript" src="<@s.url value="/struts/optiontransferselect.js" encode='false' includeParams='none'/>" <#rt/>
+	<#include "/${parameters.templateDir}/simple/nonce.ftl" />
+	></script>
 	<#assign temporaryVariable = stack.setValue("#optiontransferselect_js_included", "true") /><#t/>
 </#if><#t/>
 <table>

--- a/core/src/main/resources/template/simple/updownselect.ftl
+++ b/core/src/main/resources/template/simple/updownselect.ftl
@@ -19,9 +19,7 @@
  */
 -->
 <#if !stack.findValue("#optiontransferselect_js_included")??><#t/>
-	<script type="text/javascript" src="<@s.url value="/struts/optiontransferselect.js" encode='false' includeParams='none'/>" <#rt/>
-	<#include "/${parameters.templateDir}/simple/nonce.ftl" />
-	></script>
+	<script type="text/javascript" src="<@s.url value="/struts/optiontransferselect.js" encode='false' includeParams='none'/>" <#include "/${parameters.templateDir}/simple/nonce.ftl" /> ></script>
 	<#assign temporaryVariable = stack.setValue("#optiontransferselect_js_included", "true") /><#t/>
 </#if><#t/>
 <table>

--- a/core/src/main/resources/template/xhtml/form-close-validate.ftl
+++ b/core/src/main/resources/template/xhtml/form-close-validate.ftl
@@ -32,9 +32,7 @@ Only the following validators are supported:
 END SNIPPET: supported-validators
 -->
 <#if ((parameters.validate!false == true) && (parameters.performValidation!false == true))>
-<script type="text/javascript"<#rt/>
-<#include "/${parameters.templateDir}/simple/nonce.ftl" />
->
+<script type="text/javascript" <#include "/${parameters.templateDir}/simple/nonce.ftl" /> >
     function validateForm_${parameters.id?replace('[^a-zA-Z0-9_]', '_', 'r')}() {
         <#--
             In case of multiselect fields return only the first value.

--- a/core/src/main/resources/template/xhtml/form-close-validate.ftl
+++ b/core/src/main/resources/template/xhtml/form-close-validate.ftl
@@ -32,7 +32,9 @@ Only the following validators are supported:
 END SNIPPET: supported-validators
 -->
 <#if ((parameters.validate!false == true) && (parameters.performValidation!false == true))>
-<script type="text/javascript">
+<script type="text/javascript"<#rt/>
+<#include "/${parameters.templateDir}/simple/nonce.ftl" />
+>
     function validateForm_${parameters.id?replace('[^a-zA-Z0-9_]', '_', 'r')}() {
         <#--
             In case of multiselect fields return only the first value.

--- a/core/src/main/resources/template/xhtml/form-close.ftl
+++ b/core/src/main/resources/template/xhtml/form-close.ftl
@@ -22,7 +22,9 @@
 <#include "/${parameters.templateDir}/simple/form-close.ftl" />
 <#include "/${parameters.templateDir}/${parameters.expandTheme}/form-close-validate.ftl" />
 <#if parameters.focusElement??>
-<script type="text/javascript">
+<script type="text/javascript" <#rt/>
+<#include "/${parameters.templateDir}/simple/nonce.ftl" />
+>
     StrutsUtils.addOnLoad(function() {
         var element = document.getElementById("${parameters.focusElement}");
         if(element) {

--- a/core/src/main/resources/template/xhtml/form-close.ftl
+++ b/core/src/main/resources/template/xhtml/form-close.ftl
@@ -22,9 +22,7 @@
 <#include "/${parameters.templateDir}/simple/form-close.ftl" />
 <#include "/${parameters.templateDir}/${parameters.expandTheme}/form-close-validate.ftl" />
 <#if parameters.focusElement??>
-<script type="text/javascript" <#rt/>
-<#include "/${parameters.templateDir}/simple/nonce.ftl" />
->
+<script type="text/javascript" <#include "/${parameters.templateDir}/simple/nonce.ftl" /> >
     StrutsUtils.addOnLoad(function() {
         var element = document.getElementById("${parameters.focusElement}");
         if(element) {

--- a/core/src/main/resources/template/xhtml/form-validate.ftl
+++ b/core/src/main/resources/template/xhtml/form-validate.ftl
@@ -19,7 +19,9 @@
  */
 -->
 <#if parameters.validate!false == true>
-	<script type="text/javascript" src="${base}/struts/xhtml/validation.js"></script>
+	<script type="text/javascript" src="${base}/struts/xhtml/validation.js" <#rt/>
+    <#include "/${parameters.templateDir}/simple/nonce.ftl" />
+	></script>
 	<#if parameters.onsubmit??>
 		${tag.addParameter('onsubmit', "${parameters.onsubmit}; return validateForm_${parameters.id?replace('[^a-zA-Z0-9_]', '_', 'r')}();")}
 	<#else>

--- a/core/src/main/resources/template/xhtml/form-validate.ftl
+++ b/core/src/main/resources/template/xhtml/form-validate.ftl
@@ -19,9 +19,7 @@
  */
 -->
 <#if parameters.validate!false == true>
-	<script type="text/javascript" src="${base}/struts/xhtml/validation.js" <#rt/>
-    <#include "/${parameters.templateDir}/simple/nonce.ftl" />
-	></script>
+	<script type="text/javascript" src="${base}/struts/xhtml/validation.js" <#include "/${parameters.templateDir}/simple/nonce.ftl" /> ></script>
 	<#if parameters.onsubmit??>
 		${tag.addParameter('onsubmit', "${parameters.onsubmit}; return validateForm_${parameters.id?replace('[^a-zA-Z0-9_]', '_', 'r')}();")}
 	<#else>

--- a/core/src/main/resources/template/xhtml/head.ftl
+++ b/core/src/main/resources/template/xhtml/head.ftl
@@ -18,5 +18,7 @@
  * under the License.
  */
 -->
-<link rel="stylesheet" href="<@s.url value='/struts/xhtml/styles.css' includeParams='none' encode='false' />" type="text/css"/>
+<link rel="stylesheet" href="<@s.url value='/struts/xhtml/styles.css' includeParams='none' encode='false'/>" type="text/css"
+<#include "/${parameters.templateDir}/simple/nonce.ftl" />
+/>
 <#include "/${parameters.templateDir}/simple/head.ftl" />

--- a/core/src/main/resources/template/xhtml/head.ftl
+++ b/core/src/main/resources/template/xhtml/head.ftl
@@ -18,7 +18,5 @@
  * under the License.
  */
 -->
-<link rel="stylesheet" href="<@s.url value='/struts/xhtml/styles.css' includeParams='none' encode='false'/>" type="text/css"
-<#include "/${parameters.templateDir}/simple/nonce.ftl" />
-/>
+<link rel="stylesheet" href="<@s.url value='/struts/xhtml/styles.css' includeParams='none' encode='false'/>" type="text/css" <#include "/${parameters.templateDir}/simple/nonce.ftl" /> />
 <#include "/${parameters.templateDir}/simple/head.ftl" />

--- a/core/src/test/java/org/apache/struts2/components/UIBeanTest.java
+++ b/core/src/test/java/org/apache/struts2/components/UIBeanTest.java
@@ -30,6 +30,7 @@ import org.springframework.mock.web.MockHttpServletResponse;
 
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 public class UIBeanTest extends StrutsInternalTestCase {
@@ -304,5 +305,21 @@ public class UIBeanTest extends StrutsInternalTestCase {
         txtFld.evaluateParams();
 
         assertEquals(cssStyle, txtFld.getParameters().get("cssStyle"));
+    }
+
+    public void testNonce() {
+        String nonceVal = "r4nd0m";
+        ValueStack stack = ActionContext.getContext().getValueStack();
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        ActionContext actionContext = stack.getActionContext();
+        Map<String, Object> session = new HashMap<>();
+        session.put("nonce", nonceVal);
+        actionContext.withSession(session);
+
+        DoubleSelect dblSelect = new DoubleSelect(stack, req, res);
+        dblSelect.evaluateParams();
+
+        assertEquals(nonceVal, dblSelect.getParameters().get("nonce"));
     }
 }

--- a/core/src/test/java/org/apache/struts2/views/freemarker/FreemarkerResultMockedTest.java
+++ b/core/src/test/java/org/apache/struts2/views/freemarker/FreemarkerResultMockedTest.java
@@ -238,6 +238,41 @@ public class FreemarkerResultMockedTest extends StrutsInternalTestCase {
         assertTrue(result.contains("<option value=\"2\">2</option>"));
     }
 
+    public void testNonce() throws Exception {
+        File file = new File(ClassLoaderUtil.getResource("template/simple/common-attributes.ftl", getClass()).toURI());
+        EasyMock.expect(servletContext.getRealPath("/template/xhtml/common-attributes.ftl")).andReturn(file.getAbsolutePath());
+        EasyMock.expect(servletContext.getRealPath("/template/~~~xhtml/common-attributes.ftl")).andReturn(file.getAbsolutePath());
+
+        file = new File(ClassLoaderUtil.getResource("template/simple/dynamic-attributes.ftl", getClass()).toURI());
+        EasyMock.expect(servletContext.getRealPath("/template/xhtml/dynamic-attributes.ftl")).andReturn(file.getAbsolutePath());
+        EasyMock.expect(servletContext.getRealPath("/template/~~~xhtml/dynamic-attributes.ftl")).andReturn(file.getAbsolutePath());
+
+        file = new File(ClassLoaderUtil.getResource("template/simple/nonce.ftl", getClass()).toURI());
+        EasyMock.expect(servletContext.getRealPath("/template/simple/nonce.ftl")).andReturn(file.getAbsolutePath());
+
+        file = new File(ClassLoaderUtil.getResource("template/simple/script.ftl", getClass()).toURI());
+        EasyMock.expect(servletContext.getRealPath("/template/simple/script.ftl")).andReturn(file.getAbsolutePath());
+
+        file = new File(ClassLoaderUtil.getResource("template/simple/script-close.ftl", getClass()).toURI());
+        EasyMock.expect(servletContext.getRealPath("/template/simple/script-close.ftl")).andReturn(file.getAbsolutePath());
+
+        file = new File(ClassLoaderUtil.getResource("template/simple/link.ftl", getClass()).toURI());
+        EasyMock.expect(servletContext.getRealPath("/template/simple/link.ftl")).andReturn(file.getAbsolutePath());
+
+        file = new File(FreeMarkerResultTest.class.getResource("nonceTest.ftl").toURI());
+        EasyMock.expect(servletContext.getRealPath("/tutorial/org/apache/struts2/views/freemarker/nonceTest.ftl")).andReturn(file.getAbsolutePath());
+        EasyMock.replay(servletContext);
+
+        init();
+
+        request.setRequestURI("/tutorial/test10.action");
+        ActionMapping mapping = container.getInstance(ActionMapper.class).getMapping(request, configurationManager);
+        dispatcher.serviceAction(request, response, mapping);
+
+        assertTrue(stringWriter.toString().contains("<link nonce=\""));
+        assertTrue(stringWriter.toString().contains("<script nonce=\""));
+    }
+
     private void init() {
         stringWriter = new StringWriter();
         writer = new PrintWriter(stringWriter);

--- a/core/src/test/java/org/apache/struts2/views/jsp/ui/ComboBoxTest.java
+++ b/core/src/test/java/org/apache/struts2/views/jsp/ui/ComboBoxTest.java
@@ -73,6 +73,8 @@ public class ComboBoxTest extends AbstractUITagTest {
         tag.setId("cb");
         tag.setList("collection");
 
+        stack.getActionContext().getSession().put("nonce", "r4nd0m");
+
         tag.doStartTag();
         tag.doEndTag();
 

--- a/core/src/test/java/org/apache/struts2/views/jsp/ui/DebugTagTest.java
+++ b/core/src/test/java/org/apache/struts2/views/jsp/ui/DebugTagTest.java
@@ -48,10 +48,13 @@ public class DebugTagTest extends AbstractUITagTest {
 
     public void testDevModeEnabled() throws Exception {
         setDevMode(true);
+        stack.getActionContext().getSession().put("nonce", "r4nd0m");
 
         tag.doStartTag();
         tag.doEndTag();
         String result = writer.toString();
+
+        assertTrue("Nonce value not included", result.contains("nonce=\"r4nd0m\""));
         assertTrue(StringUtils.isNotEmpty(result));
         assertTrue("Property 'checkStackProperty' should be in Debug Tag output", StringUtils.contains(result, "<td>checkStackProperty</td>"));
     }

--- a/core/src/test/java/org/apache/struts2/views/jsp/ui/DoubleSelectTest.java
+++ b/core/src/test/java/org/apache/struts2/views/jsp/ui/DoubleSelectTest.java
@@ -87,13 +87,15 @@ public class DoubleSelectTest extends AbstractUITagTest {
         tag.setCssStyle("s1");
         tag.setDoubleCssClass("c2");
         tag.setDoubleCssStyle("s2");
-        
+
+        stack.getActionContext().getSession().put("nonce", "r4nd0m");
+
         tag.doStartTag();
         tag.doEndTag();
 
         verify(SelectTag.class.getResource("DoubleSelect-1.txt"));
     }
-    
+
     public void testOnchange() throws Exception {
         TestAction testAction = (TestAction) action;
 
@@ -151,7 +153,7 @@ public class DoubleSelectTest extends AbstractUITagTest {
         tag.setCssStyle("s1");
         tag.setDoubleCssClass("c2");
         tag.setDoubleCssStyle("s2");
-        
+
         tag.doStartTag();
         tag.doEndTag();
 
@@ -221,7 +223,7 @@ public class DoubleSelectTest extends AbstractUITagTest {
 
 
     }
-    
+
     public void testDoubleWithDotName() throws Exception {
         TestAction testAction = (TestAction) action;
 

--- a/core/src/test/java/org/apache/struts2/views/jsp/ui/FormTagTest.java
+++ b/core/src/test/java/org/apache/struts2/views/jsp/ui/FormTagTest.java
@@ -61,6 +61,9 @@ public class FormTagTest extends AbstractUITagTest {
         tag.setEnctype("myEncType");
         tag.setTitle("mytitle");
         tag.setOnsubmit("submitMe()");
+
+        stack.getActionContext().getSession().put("nonce", "r4nd0m");
+
         tag.doStartTag();
         tag.doEndTag();
         

--- a/core/src/test/java/org/apache/struts2/views/jsp/ui/HeadTagTest.java
+++ b/core/src/test/java/org/apache/struts2/views/jsp/ui/HeadTagTest.java
@@ -32,7 +32,9 @@ public class HeadTagTest extends AbstractUITagTest {
     public void testHead1() throws Exception {
         HeadTag tag = new HeadTag();
         tag.setPageContext(pageContext);
-        
+
+        stack.getActionContext().getSession().put("nonce", "r4nd0m");
+
         tag.doStartTag();
         tag.doEndTag();
 

--- a/core/src/test/java/org/apache/struts2/views/jsp/ui/InputTransferSelectTagTest.java
+++ b/core/src/test/java/org/apache/struts2/views/jsp/ui/InputTransferSelectTagTest.java
@@ -42,6 +42,7 @@ public class InputTransferSelectTagTest extends AbstractUITagTest {
 
         tag.setName("collection");
         tag.setList("collection");
+        stack.getActionContext().getSession().put("nonce", "r4nd0m");
 
         tag.doStartTag();
         tag.doEndTag();

--- a/core/src/test/java/org/apache/struts2/views/jsp/ui/OptionTransferSelectTagTest.java
+++ b/core/src/test/java/org/apache/struts2/views/jsp/ui/OptionTransferSelectTagTest.java
@@ -85,6 +85,8 @@ public class OptionTransferSelectTagTest extends AbstractUITagTest {
         tag.setDoubleHeaderKey("Double Header Key");
         tag.setDoubleHeaderValue("Double Header Value");
 
+        stack.getActionContext().getSession().put("nonce", "r4nd0m");
+
         tag.doStartTag();
         tag.doEndTag();
 

--- a/core/src/test/java/org/apache/struts2/views/jsp/ui/UpDownSelectTagTest.java
+++ b/core/src/test/java/org/apache/struts2/views/jsp/ui/UpDownSelectTagTest.java
@@ -60,6 +60,8 @@ public class UpDownSelectTagTest extends AbstractUITagTest {
         tag.setValue("mySelectedMapIds");
         tag.setEmptyOption("false");
 
+        stack.getActionContext().getSession().put("nonce", "r4nd0m");
+
         tag.doStartTag();
         tag.doEndTag();
 

--- a/core/src/test/resources/org/apache/struts2/views/freemarker/nonceTest.ftl
+++ b/core/src/test/resources/org/apache/struts2/views/freemarker/nonceTest.ftl
@@ -1,5 +1,7 @@
 <#--
 /*
+ * $Id: someFreeMarkerFile.ftl 590812 2007-10-31 20:32:54Z apetrelli $
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -18,4 +20,6 @@
  * under the License.
  */
 -->
-<#if parameters.nonce?has_content>nonce="${parameters.nonce}"<#rt/></#if>
+
+<@s.link/>
+<@s.script/>

--- a/core/src/test/resources/org/apache/struts2/views/jsp/ui/ComboBox-1.txt
+++ b/core/src/test/resources/org/apache/struts2/views/jsp/ui/ComboBox-1.txt
@@ -1,7 +1,7 @@
 <tr>
     <td class="tdLabel"><label for="cb" class="label">mylabel:</label></td>
     <td class="tdInput">
-<script type="text/javascript">
+<script type="text/javascript" nonce="r4nd0m">
 	function autoPopulate_cb(targetElement) {
 		targetElement.form.elements['foo'].value=targetElement.options[targetElement.selectedIndex].value;
 	}

--- a/core/src/test/resources/org/apache/struts2/views/jsp/ui/DoubleSelect-1.txt
+++ b/core/src/test/resources/org/apache/struts2/views/jsp/ui/DoubleSelect-1.txt
@@ -8,7 +8,7 @@
 <br/>
 <select name="region" id="region" class="c2" style="s2">
 </select>
-<script type="text/javascript">
+<script type="text/javascript" nonce="r4nd0m">
     var fooGroup = new Array(2 + 0);
     for (var i = 0; i < (2 + 0); i++) {
     fooGroup[i] = [];

--- a/core/src/test/resources/org/apache/struts2/views/jsp/ui/HeadTagTest-1.txt
+++ b/core/src/test/resources/org/apache/struts2/views/jsp/ui/HeadTagTest-1.txt
@@ -1,2 +1,2 @@
-<link rel="stylesheet" href="/struts/xhtml/styles.css" type="text/css"/>
-<script src="/struts/utils.js" type="text/javascript"></script>
+<link rel="stylesheet" href="/struts/xhtml/styles.css" type="text/css" nonce="r4nd0m"/>
+<script src="/struts/utils.js" type="text/javascript" nonce="r4nd0m"></script>

--- a/core/src/test/resources/org/apache/struts2/views/jsp/ui/inputtransferselect-1.txt
+++ b/core/src/test/resources/org/apache/struts2/views/jsp/ui/inputtransferselect-1.txt
@@ -1,7 +1,7 @@
 <tr>
   <td class="tdLabel"></td>
   <td class="tdInput">
-  <script type="text/javascript" src="/struts/inputtransferselect.js"></script>
+  <script type="text/javascript" src="/struts/inputtransferselect.js" nonce="r4nd0m"></script>
   <table>
   <tr><td><input type="text" name="collection_input" id="collection_input"/></td>
       <td class="tdTransferSelect"><inputtype="button"value="-&gt;"onclick="addOption(document.getElementById('collection_input'),document.getElementById('collection'))"/>

--- a/core/src/test/resources/org/apache/struts2/views/jsp/ui/optiontransferselect-1.txt
+++ b/core/src/test/resources/org/apache/struts2/views/jsp/ui/optiontransferselect-1.txt
@@ -1,7 +1,7 @@
 <tr> 
 <td class="tdLabel"></td> 
 <td class="tdInput">
-<script type="text/javascript" src="/struts/optiontransferselect.js"></script>
+<script type="text/javascript" src="/struts/optiontransferselect.js" nonce="r4nd0m"></script>
 <table>
 <tr>
 <td>

--- a/core/src/test/resources/org/apache/struts2/views/jsp/ui/updownselecttag-2.txt
+++ b/core/src/test/resources/org/apache/struts2/views/jsp/ui/updownselecttag-2.txt
@@ -1,5 +1,5 @@
 <tr> <td class="tdLabel"></td> <td class="tdInput">
-<script type="text/javascript" src="/struts/optiontransferselect.js"></script>
+<script type="text/javascript" src="/struts/optiontransferselect.js" nonce="r4nd0m"></script>
 <table>
 <tr><td>
 <select name="myName" size="5" id="myId" multiple="multiple">

--- a/core/src/test/resources/struts.xml
+++ b/core/src/test/resources/struts.xml
@@ -86,6 +86,12 @@
             </result>
         </action>
 
+        <action name="test10" class="com.opensymphony.xwork2.ActionSupport">
+            <result type="freemarker">
+                <param name="location">org/apache/struts2/views/freemarker/nonceTest.ftl</param>
+            </result>
+        </action>
+
     </package>
 
     <package name="sitegraph" namespace="/tutorial/sitegraph" extends="struts-default">

--- a/plugins/javatemplates/src/main/java/org/apache/struts2/views/java/simple/LinkHandler.java
+++ b/plugins/javatemplates/src/main/java/org/apache/struts2/views/java/simple/LinkHandler.java
@@ -31,8 +31,7 @@ public class LinkHandler extends AbstractTagHandler implements TagGenerator {
         Map<String, Object> params = context.getParameters();
         Attributes attrs = new Attributes();
 
-        attrs.add("nonce", (String) params.get("nonce"))
-                .addIfExists("href", params.get(("href")))
+        attrs.addIfExists("href", params.get(("href")))
                 .addIfExists("hreflang", params.get("hreflang"))
                 .addIfExists("rel", params.get("rel"))
                 .addIfExists("media", params.get("media"))

--- a/plugins/javatemplates/src/main/java/org/apache/struts2/views/java/simple/NonceHandler.java
+++ b/plugins/javatemplates/src/main/java/org/apache/struts2/views/java/simple/NonceHandler.java
@@ -1,4 +1,3 @@
-<#--
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -17,7 +16,16 @@
  * specific language governing permissions and limitations
  * under the License.
  */
--->
-<script src="${base}/struts/utils.js" type="text/javascript" <#rt/>
-<#include "/${parameters.templateDir}/simple/nonce.ftl" />
-></script>
+package org.apache.struts2.views.java.simple;
+
+import org.apache.struts2.views.java.Attributes;
+import java.io.IOException;
+
+public class NonceHandler extends AbstractTagHandler {
+
+    @Override
+    public void start(String name, Attributes a) throws IOException {
+        a.addIfExists("nonce", context.getParameters().get("nonce"));
+        super.start(name, a);
+    }
+}

--- a/plugins/javatemplates/src/main/java/org/apache/struts2/views/java/simple/ScriptHandler.java
+++ b/plugins/javatemplates/src/main/java/org/apache/struts2/views/java/simple/ScriptHandler.java
@@ -33,13 +33,11 @@ public class ScriptHandler extends AbstractTagHandler implements TagGenerator {
         Map<String, Object> params = context.getParameters();
         Attributes attrs = new Attributes();
 
-        attrs.add("nonce", (String) params.get("nonce"))
-            .addIfExists("async", params.get("async"))
+        attrs.addIfExists("async", params.get("async"))
             .addIfExists("charset", params.get("charset"))
             .addIfExists("defer", params.get("defer"))
             .addIfExists("src", params.get("src"))
             .addIfExists("type", params.get("type"))
-            .addIfExists("name", params.get("name"))
             .addIfExists("referrerpolicy", params.get("referrerpolicy"))
             .addIfExists("nomodule", params.get("nomodule"))
             .addIfExists("integrity", params.get("integrity"))

--- a/plugins/javatemplates/src/main/java/org/apache/struts2/views/java/simple/SimpleTheme.java
+++ b/plugins/javatemplates/src/main/java/org/apache/struts2/views/java/simple/SimpleTheme.java
@@ -37,7 +37,7 @@ public class SimpleTheme extends DefaultTheme {
                 put("datetextfield", new FactoryList(DateTextFieldHandler.class, ScriptingEventsHandler.class, CommonAttributesHandler.class));
                 put("select", new FactoryList(SelectHandler.class, ScriptingEventsHandler.class, CommonAttributesHandler.class, DynamicAttributesHandler.class));
                 put("form", new FactoryList(FormHandler.class, ScriptingEventsHandler.class, CommonAttributesHandler.class, DynamicAttributesHandler.class));
-                put("form-close", new FactoryList(FormHandler.CloseHandler.class));
+                put("form-close", new FactoryList(FormHandler.CloseHandler.class, ScriptHandler.class, NonceHandler.class));
                 put("a", new FactoryList(AnchorHandler.class));
                 put("a-close", new FactoryList(AnchorHandler.CloseHandler.class, ScriptingEventsHandler.class, CommonAttributesHandler.class, DynamicAttributesHandler.class));
                 put("checkbox", new FactoryList(CheckboxHandler.class, ScriptingEventsHandler.class, CommonAttributesHandler.class, DynamicAttributesHandler.class));
@@ -50,13 +50,13 @@ public class SimpleTheme extends DefaultTheme {
                 put("textarea", new FactoryList(TextAreaHandler.class, ScriptingEventsHandler.class, CommonAttributesHandler.class, DynamicAttributesHandler.class));
                 put("radiomap", new FactoryList(RadioHandler.class, ScriptingEventsHandler.class, CommonAttributesHandler.class, DynamicAttributesHandler.class));
                 put("checkboxlist", new FactoryList(CheckboxListHandler.class, ScriptingEventsHandler.class, CommonAttributesHandler.class, DynamicAttributesHandler.class));
-                put("script", new FactoryList(ScriptHandler.class, CommonAttributesHandler.class, DynamicAttributesHandler.class));
+                put("script", new FactoryList(ScriptHandler.class, CommonAttributesHandler.class, DynamicAttributesHandler.class, NonceHandler.class));
                 put("script-close", new FactoryList(ScriptHandler.CloseHandler.class));
-                put("link", new FactoryList(LinkHandler.class, CommonAttributesHandler.class, DynamicAttributesHandler.class));
+                put("link", new FactoryList(LinkHandler.class, CommonAttributesHandler.class, DynamicAttributesHandler.class, NonceHandler.class));
                 put("actionerror", new FactoryList(ActionErrorHandler.class));
                 put("token", new FactoryList(TokenHandler.class));
                 put("actionmessage", new FactoryList(ActionMessageHandler.class));
-                put("head", new FactoryList(HeadHandler.class));
+                put("head", new FactoryList(HeadHandler.class, NonceHandler.class));
                 put("hidden", new FactoryList(HiddenHandler.class));
                 put("fielderror", new FactoryList(FieldErrorHandler.class));
                 put("empty", new FactoryList(EmptyHandler.class));


### PR DESCRIPTION
Hello Struts devs!

This PR is a follow up to [WW-5084: Add Content Security Policy support to Struts](https://github.com/apache/struts/pull/430) to make all Struts tags CSP ready. After our inital CSP implementation we realized that other Struts tags like `<s:doubleselect>`, `<s:head>` also include `<script>` or `<link/>` blocks, and we wanted to make sure enabling CSP will not compromise any of the functionality for the existing tags! Here's a summary of the changes we made:

* Modify the `UIBean` class to add the nonce value as a parameter so tags that need the nonce value can access it
* Add `nonce.ftl` and `<include />` it for tags that need the nonce attribute 
*  Modify the showcase JSP files to use `<s:script>` and `<s:link/>` instead of `<script>` and `<link/>`
* Add support for FreeMarker tags `<@s.script>` and `<@s.link>`

Co-authored-by: Ecenaz Jen Ozmen - @eozmen410 
Co-authored-by: Giannis Chatziveroglou - @gchatz22 
Co-authored-by: Santiago Diaz - @salcho 

