### PR TITLE
[WW-5088] Empty file upload, storeLocation null gives wrong error message.

### DIFF
--- a/core/src/main/java/org/apache/struts2/interceptor/FileUploadInterceptor.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/FileUploadInterceptor.java
@@ -345,6 +345,14 @@ public class FileUploadInterceptor extends AbstractInterceptor {
             if (LOG.isWarnEnabled()) {
                 LOG.warn(errMsg);
             }
+        } else if (file.getContent() == null) {
+            String errMsg = getTextMessage(action, "struts.messages.error.uploading", new String[]{filename});
+            if (validation != null) {
+                validation.addFieldError(inputName, errMsg);
+            }
+            if (LOG.isWarnEnabled()) {
+                LOG.warn(errMsg);
+            }
         } else if (maximumSize != null && maximumSize < file.length()) {
             String errMsg = getTextMessage(action, "struts.messages.error.file.too.large", new String[]{inputName, filename, file.getName(), "" + file.length(), getMaximumSizeStr(action)});
             if (validation != null) {


### PR DESCRIPTION
On an empty file upload the storeLocation is null, so adds a file new StrutsUploadedFile(null)

JakartaMultiPartRequest

List fileList = new ArrayList<>(items.size());
for (FileItem fileItem : items) {
File storeLocation = ((DiskFileItem) fileItem).getStoreLocation();
if (fileItem.isInMemory() && storeLocation != null && !storeLocation.exists()) {
try {
storeLocation.createNewFile();
} catch (IOException e) {
LOG.error("Cannot write uploaded empty file to disk: {}", storeLocation.getAbsolutePath(), e);
}
}
fileList.add(new StrutsUploadedFile(storeLocation));
}

The FileUploadInterceptor checks for a null file but not null content from the new StrutsUploadedFile(null).

eg for an empty file main.js

Error message should be:
Error uploading: main.js
but gives:
Error setting expression 'uploadedFiles' with value ['org.apache.struts2.dispatcher.multipart.StrutsUploadedFile@202585bc', ]
Error setting expression 'uploadedFiles' with value ['org.apache.struts2.dispatcher.multipart.StrutsUploadedFile@49553150', ]

