### PR TITLE
Backport a few PR#433 OSGi plugin-related changes from 2.6 to 2.5.

### DIFF
--- a/bundles/admin/src/main/resources/static/js/shell.js
+++ b/bundles/admin/src/main/resources/static/js/shell.js
@@ -29,8 +29,8 @@
       result_div.appendChild(document.createElement('br'));
 
       for (var line_index in result_array) {
-          var result_wrap = document.createElement('pre')
-          line = document.createTextNode(result_array[line_index]);
+          var result_wrap = document.createElement('pre');
+          var line = document.createTextNode(result_array[line_index]);
           result_wrap.appendChild(line);
           result_div.appendChild(result_wrap);
           result_div.appendChild(document.createElement('br'));

--- a/bundles/demo/pom.xml
+++ b/bundles/demo/pom.xml
@@ -67,7 +67,6 @@
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <extensions>true</extensions>
-                <version>2.1.0</version>
                 <configuration>
                     <instructions>
                         <manifestLocation>META-INF</manifestLocation>

--- a/bundles/demo/src/main/java/actions/osgi/HelloWorldAction.java
+++ b/bundles/demo/src/main/java/actions/osgi/HelloWorldAction.java
@@ -22,13 +22,21 @@ package actions.osgi;
 
 import com.opensymphony.xwork2.ActionSupport;
 import org.apache.struts2.convention.annotation.Action;
+import org.apache.struts2.convention.annotation.Actions;
+import org.apache.struts2.convention.annotation.Namespace;
+import org.apache.struts2.convention.annotation.Result;
 import org.apache.struts2.convention.annotation.ResultPath;
 
-@ResultPath("/content")
+@Namespace("/osgi")
+@ResultPath("/content/osgi")
 public class HelloWorldAction extends ActionSupport {
-    private Message message;
+    private Message message = new Message("Default non-null message");
 
-    @Action("hello-convention")
+    @Override
+    @Actions({
+        @Action(value="hello-convention", results={@Result(name="success", type="freemarker", location="/content/osgi/hello-convention.ftl")}),
+        @Action(value="/osgi/hello-convention", results={@Result(name="success", type="freemarker", location="/content/osgi/hello-convention.ftl")})
+    })
     public String execute() {
         return SUCCESS;
     }
@@ -45,6 +53,7 @@ public class HelloWorldAction extends ActionSupport {
         return "Hello!!!";
     }
 
+    @Override
     public String toString() {
         StringBuilder sb = new StringBuilder("{message:");
         sb.append(message != null ? message.getText() : "null");

--- a/bundles/demo/src/main/resources/content/osgi/hello.ftl
+++ b/bundles/demo/src/main/resources/content/osgi/hello.ftl
@@ -20,7 +20,7 @@
 -->
 <html>
     <head>
-        <title>Action mapped by the XML configurationn</title>
+        <title>Action mapped by the XML configuration</title>
     </head>
     <body>
         This is an action mapped by XML configuration, using a <b>FreeMarker</b> result.

--- a/bundles/demo/src/main/resources/content/osgi/hello.vm
+++ b/bundles/demo/src/main/resources/content/osgi/hello.vm
@@ -18,7 +18,7 @@
 *# 
 <html>
     <head>
-        <title>Action mapped by the XML configurationn</title>
+        <title>Action mapped by the XML configuration</title>
     </head>
     <body>
         This is an action mapped by XML configuration, using a <b>Velocity</b> result.

--- a/bundles/demo/src/main/resources/struts.xml
+++ b/bundles/demo/src/main/resources/struts.xml
@@ -20,21 +20,36 @@
  */
 -->
 <!DOCTYPE struts PUBLIC
-    "-//Apache Software Foundation//DTD Struts Configuration 2.0//EN"
-    "http://struts.apache.org/dtds/struts-2.0.dtd">
+    "-//Apache Software Foundation//DTD Struts Configuration 2.5//EN"
+    "http://struts.apache.org/dtds/struts-2.5.dtd">
 
 <struts>
-    <package name="bundle-demo" namespace="/osgi" extends="osgi-default">
+    <!-- Set some Struts 2 constants relevant to the OSGi Plugin. 
+           Note:  The constant definitions specified here (within the demo bundle) may also need to be 
+                  duplicated in the struts.xml configuration of the outer project that packages the demo
+                  bundle JAR file within it.
+    -->
+    <constant name="struts.objectFactory" value="osgi" />
+    <constant name="struts.objectFactory.delegate" value="struts" />
+    <constant name="struts.freemarker.manager.classname" value="org.apache.struts2.osgi.BundleFreemarkerManager" />
+    <constant name="struts.velocity.manager.classname" value="org.apache.struts2.osgi.VelocityBundleResourceLoader" />
+    <constant name="struts.staticContentLoader" value="org.apache.struts2.osgi.loaders.StaticContentBundleResourceLoader" />
+
+    <package name="bundle-demo" namespace="/osgi" extends="osgi-default" strict-method-invocation="true">
+
         <default-action-ref name="home" />
-        <action name="hello-velocity" class="helloWorldAction">
+
+        <action name="hello-velocity" class="actions.osgi.HelloWorldAction">
             <result type="velocity">/content/osgi/hello.vm</result>
         </action>
-        <action name="hello-freemarker" class="helloWorldAction">
+
+        <action name="hello-freemarker" class="actions.osgi.HelloWorldAction">
             <result type="freemarker">/content/osgi/hello.ftl</result>
         </action>
 
-        <action name="home">
+        <action name="home" class="actions.osgi.HelloWorldAction">
             <result type="freemarker">/content/osgi/home.ftl</result>
         </action>
+
     </package>
 </struts>

--- a/plugins/osgi/src/main/java/org/apache/struts2/osgi/BundlePackageLoader.java
+++ b/plugins/osgi/src/main/java/org/apache/struts2/osgi/BundlePackageLoader.java
@@ -24,11 +24,11 @@ import com.opensymphony.xwork2.config.Configuration;
 import com.opensymphony.xwork2.config.ConfigurationException;
 import com.opensymphony.xwork2.config.entities.PackageConfig;
 import com.opensymphony.xwork2.config.impl.DefaultConfiguration;
-import com.opensymphony.xwork2.config.providers.XmlConfigurationProvider;
 import com.opensymphony.xwork2.inject.Container;
 import com.opensymphony.xwork2.util.fs.DefaultFileManagerFactory;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.apache.struts2.config.StrutsXmlConfigurationProvider;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 
@@ -140,18 +140,18 @@ public class BundlePackageLoader implements PackageLoader {
         this.contextContainer = contextContainer;
     }
 
-    static class BundleConfigurationProvider extends XmlConfigurationProvider {
+    static class BundleConfigurationProvider extends StrutsXmlConfigurationProvider {
         private Bundle bundle;
         private BundleContext bundleContext;
 
         public BundleConfigurationProvider(String filename, Bundle bundle, BundleContext bundleContext) {
-            super(filename, false);
+            super(filename, false, null);  // Currently no dependency on ServletContext
             this.bundle = bundle;
             this.bundleContext = bundleContext;
         }
 
         public BundleConfigurationProvider(String filename) {
-            super(filename);
+            super(filename, false, null);  // Currently no dependency on ServletContext
         }
 
         @Override


### PR DESCRIPTION
Backport a few PR#433 OSGi plugin-related changes from 2.6 to 2.5.
- Fix to allow the OSGi plugin to initialize with no internet connection.
- Fix an unintended JS change for the admin bundle.
- Fix the OSGi Demo bundle so it works under 2.5.x as well.