### PR TITLE
WW-5087 handle Parameter.Empty properly

### DIFF
--- a/core/src/main/java/com/opensymphony/xwork2/interceptor/AliasInterceptor.java
+++ b/core/src/main/java/com/opensymphony/xwork2/interceptor/AliasInterceptor.java
@@ -31,6 +31,7 @@ import com.opensymphony.xwork2.util.reflection.ReflectionContextState;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.struts2.dispatcher.HttpParameters;
+import org.apache.struts2.dispatcher.Parameter;
 import org.apache.struts2.StrutsConstants;
 
 import java.util.Map;
@@ -173,7 +174,10 @@ public class AliasInterceptor extends AbstractInterceptor {
                         HttpParameters contextParameters = ActionContext.getContext().getParameters();
 
                         if (null != contextParameters) {
-                            value = new Evaluated(contextParameters.get(name));
+                            Parameter param = contextParameters.get(name);
+                            if (param.isDefined()) {
+                                value = new Evaluated(param.getValue());
+                            }
                         }
                     }
                     if (value.isDefined()) {

--- a/core/src/test/resources/xwork-sample.xml
+++ b/core/src/test/resources/xwork-sample.xml
@@ -97,7 +97,7 @@
         </action>
 
         <action name="aliasTest" class="com.opensymphony.xwork2.SimpleAction">
-           	<param name="aliases">#{ "aliasSource" : "aliasDest", "bar":"baz" }</param>
+           	<param name="aliases">#{ "aliasSource" : "aliasDest", "bar":"baz", "notExisting":"blah" }</param>
 			<interceptor-ref name="params"/>
          	<interceptor-ref name="alias"/>
          	<result name="success" type="mock" />


### PR DESCRIPTION
There was a bug with AliasInterceptor not handling the Parameter.Empty that is returned from HttpParameters.get(). Since HttpParameters.get() always returns a non-null value, the Evaluated object is treated as always being defined, which results in the empty value being set incorrectly on the stack.