### PR TITLE
WW-5088: Integration test for empty file upload.

### DIFF
--- a/apps/showcase/src/test/java/it/org/apache/struts2/showcase/FileUploadTest.java
+++ b/apps/showcase/src/test/java/it/org/apache/struts2/showcase/FileUploadTest.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package it.org.apache.struts2.showcase;
 
 import com.gargoylesoftware.htmlunit.WebClient;

--- a/apps/showcase/src/test/java/it/org/apache/struts2/showcase/FileUploadTest.java
+++ b/apps/showcase/src/test/java/it/org/apache/struts2/showcase/FileUploadTest.java
@@ -1,0 +1,36 @@
+package it.org.apache.struts2.showcase;
+
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.html.DomElement;
+import com.gargoylesoftware.htmlunit.html.HtmlFileInput;
+import com.gargoylesoftware.htmlunit.html.HtmlForm;
+import com.gargoylesoftware.htmlunit.html.HtmlInput;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import com.gargoylesoftware.htmlunit.html.HtmlSubmitInput;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+
+public class FileUploadTest {
+
+    @Test
+    public void testEmptyFile() throws Exception {
+        try (final WebClient webClient = new WebClient()) {
+            final HtmlPage page = webClient.getPage(ParameterUtils.getBaseUrl() + "/fileupload/doUpload.action");
+            final HtmlForm form = page.getFormByName("doUpload");
+            HtmlInput captionInput = form.getInputByName("caption");
+            HtmlFileInput uploadInput = form.getInputByName("upload");
+            captionInput.type("some caption");
+            File tempFile = File.createTempFile("testEmptyFile", ".tmp");
+            tempFile.deleteOnExit();
+            uploadInput.setValueAttribute(tempFile.getAbsolutePath());
+            final HtmlSubmitInput button = form.getInputByValue("Submit");
+            final HtmlPage resultPage = button.click();
+            DomElement errorMessage = resultPage.getFirstByXPath("//span[@class='errorMessage']");
+            Assert.assertNotNull(errorMessage);
+            Assert.assertEquals("File cannot be empty", errorMessage.getVisibleText());
+        }
+    }
+
+}

--- a/core/src/main/java/org/apache/struts2/dispatcher/multipart/JakartaMultiPartRequest.java
+++ b/core/src/main/java/org/apache/struts2/dispatcher/multipart/JakartaMultiPartRequest.java
@@ -157,7 +157,7 @@ public class JakartaMultiPartRequest extends AbstractMultiPartRequest {
     protected DiskFileItemFactory createDiskFileItemFactory(String saveDir) {
         DiskFileItemFactory fac = new DiskFileItemFactory();
         // Make sure that the data is written to file, even if the file is empty.
-        fac.setSizeThreshold(0);
+        fac.setSizeThreshold(-1);
         if (saveDir != null) {
             fac.setRepository(new File(saveDir));
         }


### PR DESCRIPTION
Add integration test to detect regressions if commons-fileupload behavior changes in the future.

DiskFileItemFactory#setSizeThreshold should be set to -1 because org.apache.commons.io.output.ThresholdingOutputStream#checkThreshold checks if the current file size is strictly greater than the threshold.