### PR TITLE
Fix meaningless close

### DIFF
--- a/plugins/embeddedjsp/src/main/java/org/apache/struts2/jasper/compiler/JspReader.java
+++ b/plugins/embeddedjsp/src/main/java/org/apache/struts2/jasper/compiler/JspReader.java
@@ -209,7 +209,6 @@ class JspReader {
         CharArrayWriter caw = new CharArrayWriter();
         while (!stop.equals(mark()))
             caw.write(nextChar());
-        caw.close();
         reset(oldstart);
         return caw.toString();
     }
@@ -595,7 +594,6 @@ class JspReader {
             char buf[] = new char[1024];
             for (int i = 0 ; (i = reader.read(buf)) != -1 ;)
                 caw.write(buf, 0, i);
-            caw.close();
             if (current == null) {
                 current = new Mark(this, caw.toCharArray(), fileid, 
                                    getFile(fileid), master, encoding);

--- a/plugins/embeddedjsp/src/main/java/org/apache/struts2/jasper/compiler/Parser.java
+++ b/plugins/embeddedjsp/src/main/java/org/apache/struts2/jasper/compiler/Parser.java
@@ -324,7 +324,6 @@ class Parser implements TagConstants {
                 ++i;
             }
         }
-        cw.close();
         return cw.toString();
     }
 


### PR DESCRIPTION
Meaningless Close: In several classes, close(), specified in Closeable interface, has no effect and other methods in those classes can be called after close() without IOException.

