### PR TITLE
sort getMethods for deterministic iteration order

### DIFF
--- a/plugins/json/src/main/java/org/apache/struts2/json/JSONUtil.java
+++ b/plugins/json/src/main/java/org/apache/struts2/json/JSONUtil.java
@@ -411,9 +411,9 @@ public class JSONUtil {
     public static Method[] listSMDMethods(Class clazz, boolean ignoreInterfaces) {
         final List<Method> methods = new LinkedList<>();
         if (ignoreInterfaces) {
-            Method[] SMDMethods = clazz.getMethods();
-            Arrays.sort(SMDMethods, (a, b) -> a.toString().compareTo(b.toString()));
-            for (Method method : SMDMethods) {
+            Method[] classMethods = clazz.getMethods();
+            Arrays.sort(classMethods, (a, b) -> a.toString().compareTo(b.toString()));
+            for (Method method : classMethods) {
                 SMDMethod smdMethodAnnotation = method.getAnnotation(SMDMethod.class);
                 if (smdMethodAnnotation != null) {
                     methods.add(method);
@@ -424,9 +424,9 @@ public class JSONUtil {
             // order encountered
             JSONUtil.visitInterfaces(clazz, new JSONUtil.ClassVisitor() {
                 public boolean visit(Class aClass) {
-                    Method[] SMDMethods = aClass.getMethods();
-                    Arrays.sort(SMDMethods, (a, b) -> a.toString().compareTo(b.toString()));
-                    for (Method method : SMDMethods) {
+                    Method[] classMethods = aClass.getMethods();
+                    Arrays.sort(classMethods, (a, b) -> a.toString().compareTo(b.toString()));
+                    for (Method method : classMethods) {
                         SMDMethod smdMethodAnnotation = method.getAnnotation(SMDMethod.class);
                         if ((smdMethodAnnotation != null) && !methods.contains(method)) {
                             methods.add(method);

--- a/plugins/json/src/main/java/org/apache/struts2/json/JSONUtil.java
+++ b/plugins/json/src/main/java/org/apache/struts2/json/JSONUtil.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.zip.GZIPOutputStream;
+import java.util.Arrays;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -410,7 +411,9 @@ public class JSONUtil {
     public static Method[] listSMDMethods(Class clazz, boolean ignoreInterfaces) {
         final List<Method> methods = new LinkedList<>();
         if (ignoreInterfaces) {
-            for (Method method : clazz.getMethods()) {
+            Method[] SMDMethods = clazz.getMethods();
+            Arrays.sort(SMDMethods, (a, b) -> a.toString().compareTo(b.toString()));
+            for (Method method : SMDMethods) {
                 SMDMethod smdMethodAnnotation = method.getAnnotation(SMDMethod.class);
                 if (smdMethodAnnotation != null) {
                     methods.add(method);
@@ -421,7 +424,9 @@ public class JSONUtil {
             // order encountered
             JSONUtil.visitInterfaces(clazz, new JSONUtil.ClassVisitor() {
                 public boolean visit(Class aClass) {
-                    for (Method method : aClass.getMethods()) {
+                    Method[] SMDMethods = aClass.getMethods();
+                    Arrays.sort(SMDMethods, (a, b) -> a.toString().compareTo(b.toString()));
+                    for (Method method : SMDMethods) {
                         SMDMethod smdMethodAnnotation = method.getAnnotation(SMDMethod.class);
                         if ((smdMethodAnnotation != null) && !methods.contains(method)) {
                             methods.add(method);


### PR DESCRIPTION
The tests `org.apache.struts2.json.SMDMethodInterfaceTest#testBaseClassOnly` and `org.apache.struts2.json.SMDMethodInterfaceTest#testInterfaces` can fail due to a different iteration order of `Object.getMethods()`. The failures are as follows:
```
[ERROR] org.apache.struts2.json.SMDMethodInterfaceTest.testBaseClassOnly  Time elapsed: 0.008 s  <<< FAILURE!
junit.framework.ComparisonFailure: expected:<get[Z]> but was:<get[X]>
    at org.apache.struts2.json.SMDMethodInterfaceTest.testBaseClassOnly(SMDMethodInterfaceTest.java:136)

[ERROR] org.apache.struts2.json.SMDMethodInterfaceTest.testInterfaces  Time elapsed: 0 s  <<< FAILURE!
junit.framework.ComparisonFailure: expected:<get[Z]> but was:<get[X]>
    at org.apache.struts2.json.SMDMethodInterfaceTest.testInterfaces(SMDMethodInterfaceTest.java:155)
```

The fix is to sort the result of `getMethods()` so that the iteration order remains stable and the failure will not occur any more. In this way, the test will be more stable.