### PR TITLE
Fix json validation interceptor test

### DIFF
--- a/plugins/json/src/test/java/org/apache/struts2/json/JSONValidationInterceptorTest.java
+++ b/plugins/json/src/test/java/org/apache/struts2/json/JSONValidationInterceptorTest.java
@@ -41,8 +41,6 @@ import java.io.StringWriter;
 import java.util.HashMap;
 import java.util.Map;
 
-
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class JSONValidationInterceptorTest extends StrutsTestCase {

--- a/plugins/json/src/test/java/org/apache/struts2/json/JSONValidationInterceptorTest.java
+++ b/plugins/json/src/test/java/org/apache/struts2/json/JSONValidationInterceptorTest.java
@@ -67,6 +67,7 @@ public class JSONValidationInterceptorTest extends StrutsTestCase {
         String json = stringWriter.toString();
 
         String normalizedActual = TestUtils.normalize(json, true);
+        
         //json
         // fix the order of "Tooshort", and "Thisisnoemail"
         assertThat(normalizedActual).contains("Tooshort");

--- a/plugins/json/src/test/java/org/apache/struts2/json/JSONValidationInterceptorTest.java
+++ b/plugins/json/src/test/java/org/apache/struts2/json/JSONValidationInterceptorTest.java
@@ -67,7 +67,6 @@ public class JSONValidationInterceptorTest extends StrutsTestCase {
         String json = stringWriter.toString();
 
         String normalizedActual = TestUtils.normalize(json, true);
-        
         //json
         // fix the order of "Tooshort", and "Thisisnoemail"
         assertThat(normalizedActual).contains("Tooshort");

--- a/plugins/json/src/test/java/org/apache/struts2/json/JSONValidationInterceptorTest.java
+++ b/plugins/json/src/test/java/org/apache/struts2/json/JSONValidationInterceptorTest.java
@@ -33,12 +33,15 @@ import org.apache.struts2.StrutsTestCase;
 import org.apache.struts2.interceptor.validation.AnnotationValidationInterceptor;
 import org.apache.struts2.interceptor.validation.SkipValidation;
 import org.apache.struts2.util.TestUtils;
+import org.assertj.core.internal.bytebuddy.asm.Advice;
 
 import javax.servlet.http.HttpServletResponse;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.HashMap;
 import java.util.Map;
+
+
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -66,8 +69,23 @@ public class JSONValidationInterceptorTest extends StrutsTestCase {
         String json = stringWriter.toString();
 
         String normalizedActual = TestUtils.normalize(json, true);
-
         //json
+        // fix the order of "Tooshort", and "Thisisnoemail"
+        assertThat(normalizedActual).contains("Tooshort");
+        assertThat(normalizedActual).contains("Thisisnoemail");
+        int tooshortIndex = normalizedActual.indexOf("Tooshort");
+        int ThisisnoemailIndex = normalizedActual.indexOf("Thisisnoemail");
+        if (tooshortIndex > ThisisnoemailIndex){
+            // swap the items
+            String temp = normalizedActual.substring(0,ThisisnoemailIndex);
+            temp += "Tooshort";
+            int lengthOfNoEmail = 13;
+            int lengthOfTooShort = 8;
+            temp += normalizedActual.substring(ThisisnoemailIndex + lengthOfNoEmail, tooshortIndex);
+            temp += "Thisisnoemail";
+            temp += normalizedActual.substring(tooshortIndex + lengthOfTooShort);
+            normalizedActual = temp;
+        }
         assertThat(normalizedActual)
                 .contains("\"errors\":[\"Generalerror\"]")
                 .contains("\"fieldErrors\":{")


### PR DESCRIPTION
The test method testValidationFails in test class JSONValidationInterceptorTest is flaky.

The "TestUtils.normalize" function will break the order of the original list, and there are two potential orders.
["Tooshort","Thisisnoemail"], and ["Thisisnoemail", "Tooshort"]
The assertion test only test against one order: ["Tooshort","Thisisnoemail"], and thus the test will fail if the second order is returned by the normalize function.

To fix this flaky test, I add two assertion tests to verify that two strings "Tooshort" and "Thisisnoemail" do exist in the normalized string, and then check the indexes of those two strings. If the string "Thisisnoemail" has a smaller index, swap those two strings, and the order of the list is preserved.