### PR TITLE
sort results of getAnnotations() for deterministic iteration order

### DIFF
--- a/core/src/main/java/com/opensymphony/xwork2/validator/AnnotationValidationConfigurationBuilder.java
+++ b/core/src/main/java/com/opensymphony/xwork2/validator/AnnotationValidationConfigurationBuilder.java
@@ -56,6 +56,7 @@ public class AnnotationValidationConfigurationBuilder {
         if (o instanceof Class) {
             Class clazz = (Class) o;
             annotations = clazz.getAnnotations();
+            Arrays.sort(annotations, (a, b) -> a.toString().compareTo(b.toString()));
         }
 
         if (o instanceof Method) {
@@ -64,6 +65,7 @@ public class AnnotationValidationConfigurationBuilder {
             methodName = method.getName();
 
             annotations = method.getAnnotations();
+            Arrays.sort(annotations, (a, b) -> a.toString().compareTo(b.toString()));
         }
 
         if (annotations != null) {


### PR DESCRIPTION
The tests `com.opensymphony.xwork2.validator.AnnotationActionValidatorManagerTest.testGetValidatorsForInterface` and `com.opensymphony.xwork2.validator.AnnotationActionValidatorManagerTest.testSkipUserMarkerActionLevelShortCircuit` can fail due to a different iteration order of `Object.getAnnotations()`. The failures are as follows:

```
[ERROR]   AnnotationActionValidatorManagerTest.testGetValidatorsForInterface:157
[ERROR]   FreemarkerResultMockedTest.testDynamicAttributesSupport:130 expected:<... value="" id="test" [foo="bar" placeholder="input]"/><input type="text...> but was:<... value="" id="test" [placeholder="input" foo="bar]"/><input type="text...>  

[ERROR] com.opensymphony.xwork2.validator.AnnotationActionValidatorManagerTest.testSkipUserMarkerActionLevelShortCircuit  Time elapsed: 0.033 s  <<< FAILURE!
junit.framework.AssertionFailedError: expected:<1> but was:<2>
    at com.opensymphony.xwork2.validator.AnnotationActionValidatorManagerTest.testSkipUserMarkerActionLevelShortCircuit(AnnotationActionValidatorManagerTest.java:307)
```

The fix is to sort the result of `getAnnotations()` so that the iteration order remains stable and the failure will not occur any more. In this way, the test will be more stable.