### PR TITLE
Proposed TextProvider feature addition (and cleanup)

### DIFF
--- a/core/src/main/java/com/opensymphony/xwork2/util/GlobalLocalizedTextProvider.java
+++ b/core/src/main/java/com/opensymphony/xwork2/util/GlobalLocalizedTextProvider.java
@@ -19,7 +19,6 @@
 package com.opensymphony.xwork2.util;
 
 import com.opensymphony.xwork2.ActionContext;
-import com.opensymphony.xwork2.ModelDriven;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -27,8 +26,10 @@ import java.util.Locale;
 import java.util.ResourceBundle;
 
 /**
- * Provides support for localization in the framework, it can be used to read only default bundles,
- * or it can search the class hierarchy to find proper bundles.
+ * Provides support for localization in the framework, it can be used to read only default bundles.
+ * 
+ * Note that unlike {@link StrutsLocalizedTextProvider}, this class {@link GlobalLocalizedTextProvider} will
+ * <em>only</em> search the default bundles for localized text.
  */
 public class GlobalLocalizedTextProvider extends AbstractLocalizedTextProvider {
 
@@ -62,22 +63,8 @@ public class GlobalLocalizedTextProvider extends AbstractLocalizedTextProvider {
      * </p>
      *
      * <ol>
-     * <li>Look for message in aClass' class hierarchy.
-     * <ol>
-     * <li>Look for the message in a resource bundle for aClass</li>
-     * <li>If not found, look for the message in a resource bundle for any implemented interface</li>
-     * <li>If not found, traverse up the Class' hierarchy and repeat from the first sub-step</li>
-     * </ol></li>
-     * <li>If not found and aClass is a {@link ModelDriven} Action, then look for message in
-     * the model's class hierarchy (repeat sub-steps listed above).</li>
-     * <li>If not found, look for message in child property.  This is determined by evaluating
-     * the message key as an OGNL expression.  For example, if the key is
-     * <i>user.address.state</i>, then it will attempt to see if "user" can be resolved into an
-     * object.  If so, repeat the entire process fromthe beginning with the object's class as
-     * aClass and "address.state" as the message key.</li>
-     * <li>If not found, look for the message in aClass' package hierarchy.</li>
-     * <li>If still not found, look for the message in the default resource bundles.</li>
-     * <li>Return defaultMessage</li>
+     * <li>Look for the message in the default resource bundles.</li>
+     * <li>If not found, return defaultMessage</li>
      * </ol>
      *
      * <p>
@@ -115,22 +102,8 @@ public class GlobalLocalizedTextProvider extends AbstractLocalizedTextProvider {
      * </p>
      *
      * <ol>
-     * <li>Look for message in aClass' class hierarchy.
-     * <ol>
-     * <li>Look for the message in a resource bundle for aClass</li>
-     * <li>If not found, look for the message in a resource bundle for any implemented interface</li>
-     * <li>If not found, traverse up the Class' hierarchy and repeat from the first sub-step</li>
-     * </ol></li>
-     * <li>If not found and aClass is a {@link ModelDriven} Action, then look for message in
-     * the model's class hierarchy (repeat sub-steps listed above).</li>
-     * <li>If not found, look for message in child property.  This is determined by evaluating
-     * the message key as an OGNL expression.  For example, if the key is
-     * <i>user.address.state</i>, then it will attempt to see if "user" can be resolved into an
-     * object.  If so, repeat the entire process fromthe beginning with the object's class as
-     * aClass and "address.state" as the message key.</li>
-     * <li>If not found, look for the message in aClass' package hierarchy.</li>
-     * <li>If still not found, look for the message in the default resource bundles.</li>
-     * <li>Return defaultMessage</li>
+     * <li>Look for the message in the default resource bundles.</li>
+     * <li>If not found, return defaultMessage</li>
      * </ol>
      *
      * <p>
@@ -145,7 +118,7 @@ public class GlobalLocalizedTextProvider extends AbstractLocalizedTextProvider {
      * </p>
      *
      * <p>
-     * If a message is <b>not</b> found a WARN log will be logged.
+     * If a message is <b>not</b> found a DEBUG level log warning will be logged.
      * </p>
      *
      * @param aClass         the class whose name to use as the start point for the search
@@ -180,16 +153,7 @@ public class GlobalLocalizedTextProvider extends AbstractLocalizedTextProvider {
         }
 
         // get default
-        GetDefaultMessageReturnArg result;
-        if (indexedTextName == null) {
-            result = getDefaultMessage(aTextName, locale, valueStack, args, defaultMessage);
-        } else {
-            result = getDefaultMessage(aTextName, locale, valueStack, args, null);
-            if (result != null && result.message != null) {
-                return result.message;
-            }
-            result = getDefaultMessage(indexedTextName, locale, valueStack, args, defaultMessage);
-        }
+        GetDefaultMessageReturnArg result = getDefaultMessageWithAlternateKey(aTextName, indexedTextName, locale, valueStack, args, defaultMessage);
 
         // could we find the text, if not log a warn
         if (unableToFindTextForKey(result) && LOG.isDebugEnabled()) {

--- a/core/src/main/java/org/apache/struts2/StrutsConstants.java
+++ b/core/src/main/java/org/apache/struts2/StrutsConstants.java
@@ -35,6 +35,17 @@ public final class StrutsConstants {
     /** The encoding to use for localization messages */
     public static final String STRUTS_I18N_ENCODING = "struts.i18n.encoding";
 
+    /** 
+     * Whether the default bundles should be searched for messages first.  Can be used to modify the
+     * standard processing order for message lookup in TextProvider implementations.
+     * <p>
+     * Note: This control flag may not be meaningful to all provider implementations, and should be false by default.
+     * </p>
+     * 
+     * @since 2.6
+     */
+    public static final String STRUTS_I18N_SEARCH_DEFAULTBUNDLES_FIRST = "struts.i18n.search.defaultbundles.first";
+
     /** Whether to reload the XML configuration or not */
     public static final String STRUTS_CONFIGURATION_XML_RELOAD = "struts.configuration.xml.reload";
 

--- a/core/src/main/resources/org/apache/struts2/default.properties
+++ b/core/src/main/resources/org/apache/struts2/default.properties
@@ -19,7 +19,7 @@
 ### START SNIPPET: complete_file
 
 ### Struts default properties
-###(can be overridden by a struts.properties file in the root of the classpath)
+### (can be overridden by a struts.properties file in the root of the classpath)
 ###
 
 ### This can be used to set your default locale and encoding scheme
@@ -57,15 +57,15 @@ struts.objectFactory.spring.enableAopSupport = false
 ###       using generics. com.opensymphony.xwork2.util.GenericsObjectTypeDeterminer was deprecated since XWork 2, it's
 ###       functions are integrated in DefaultObjectTypeDeterminer now.
 ###       To disable tiger support use the "notiger" property value here.
-#struts.objectTypeDeterminer = tiger
-#struts.objectTypeDeterminer = notiger
+# struts.objectTypeDeterminer = tiger
+# struts.objectTypeDeterminer = notiger
 
 ### Parser to handle HTTP POST requests, encoded using the MIME-type multipart/form-data
 # struts.multipart.parser=cos
 # struts.multipart.parser=pell
 # struts.multipart.parser=jakarta-stream
 struts.multipart.parser=jakarta
-# uses javax.servlet.context.tempdir by default
+### Uses javax.servlet.context.tempdir by default
 struts.multipart.saveDir=
 struts.multipart.maxSize=2097152
 
@@ -74,7 +74,7 @@ struts.multipart.maxSize=2097152
 
 ### How request URLs are mapped to and from actions
 ### Vy default 'struts' name is used which maps to DefaultActionMapper
-#struts.mapper.class=restful
+# struts.mapper.class=restful
 
 ### Used by the DefaultActionMapper
 ### You may provide a comma separated list, e.g. struts.action.extension=action,jnlp,do
@@ -136,7 +136,7 @@ struts.devMode = false
 
 ### when set to true, resource bundles will be reloaded on _every_ request.
 ### this is good during development, but should never be used in production
-### struts.i18n.reload=false
+# struts.i18n.reload=false
 
 ### Standard UI theme
 ### Change this to reflect which path should be used for JSP control tag templates by default
@@ -144,12 +144,12 @@ struts.ui.theme=xhtml
 struts.ui.templateDir=template
 ### Change this to use a different token to indicate template theme expansion
 struts.ui.theme.expansion.token=~~~
-#sets the default template type. Either ftl, vm, or jsp
+### Sets the default template type. Either ftl, vm, or jsp
 struts.ui.templateSuffix=ftl
 
 ### Configuration reloading
 ### This will cause the configuration to reload struts.xml when it is changed
-### struts.configuration.xml.reload=false
+# struts.configuration.xml.reload=false
 
 ### Location of velocity.properties file.  defaults to velocity.properties
 struts.velocity.configfile = velocity.properties
@@ -169,6 +169,10 @@ struts.url.includeParams = none
 ### Load custom default resource bundles
 # struts.custom.i18n.resources=testmessages,testmessages2
 
+### Control whether to search the default resource bundes for messages first (if true) or not (if false).
+### Default is false (when not set).
+# struts.i18n.search.defaultbundles.first=false
+
 ### workaround for some app servers that don't handle HttpServletRequest.getParameterMap()
 ### often used for WebLogic, Orion, and OC4J
 struts.dispatcher.parametersWorkaround = false
@@ -176,11 +180,11 @@ struts.dispatcher.parametersWorkaround = false
 ### configure the Freemarker Manager class to be used
 ### Allows user to plug-in customised Freemarker Manager if necessary
 ### MUST extends off org.apache.struts2.views.freemarker.FreemarkerManager
-#struts.freemarker.manager.classname=org.apache.struts2.views.freemarker.FreemarkerManager
+# struts.freemarker.manager.classname=org.apache.struts2.views.freemarker.FreemarkerManager
 
 ### Enables caching of FreeMarker templates
 ### Has the same effect as copying the templates under WEB_APP/templates
-### struts.freemarker.templatesCache=false
+# struts.freemarker.templatesCache=false
 
 ### Enables caching of models on the BeanWrapper
 struts.freemarker.beanwrapperCache=false

--- a/core/src/test/resources/com/opensymphony/xwork2/util/Bar.properties
+++ b/core/src/test/resources/com/opensymphony/xwork2/util/Bar.properties
@@ -18,3 +18,5 @@
 #
 title=Title:
 invalid.fieldvalue.title=Title is invalid!
+title.indexed[*]=Indexed title text for test!
+compare.sameproperty.differentbundles=This is the value in the Bar properties!

--- a/core/src/test/resources/com/opensymphony/xwork2/util/LocalizedTextUtilTest.properties
+++ b/core/src/test/resources/com/opensymphony/xwork2/util/LocalizedTextUtilTest.properties
@@ -19,3 +19,4 @@
 test.format.date={0,date,short}
 xw377=xw377
 username=Santa
+compare.sameproperty.differentbundles=This is the value in the LocalizedTextUtilTest properties!


### PR DESCRIPTION
TextProvider feature addition and cleanup:
- Introduce (optional) control flag STRUTS_I18N_SEARCH_DEFAULTBUNDLES_FIRST to request TextProviders read from default resource bundles first, instead of their standard lookup ordering.  Defaults to false.
- Minor refactor of AbstractLocalizedTextProvider hierarchy to introduce getDefaultMessageWithAlternateKey() method that repackages existing logic used by the SrutsLocalizedTextProvider and GlobalLocalizedTextProvider.
- Update GlobalLocalizedTextProvider method comments to properly reflect the actual logic of some of its methods.
- New unit tests to confirm standard and default bundle first lookup ordering.
- Cleanup of some unused imports, a few typos, and code formatting items.
- Cleanup of default.properties comments to make them more consistent.