### PR TITLE
[WW-5113] [WW-5114] Drops deprecated config options

### DIFF
--- a/core/src/main/java/com/opensymphony/xwork2/TextProvider.java
+++ b/core/src/main/java/com/opensymphony/xwork2/TextProvider.java
@@ -42,7 +42,7 @@ import java.util.ResourceBundle;
  * When you want to use your own implementation for Struts 2 project you have to define following
  * bean and constant in struts.xml:
  * &lt;bean class=&quot;org.demo.MyTextProvider&quot; name=&quot;myTextProvider&quot; type=&quot;com.opensymphony.xwork2.TextProvider&quot; /&gt;
- * &lt;constant name=&quot;struts.xworkTextProvider&quot; value=&quot;myTextProvider&quot; /&gt;
+ * &lt;constant name=&quot;struts.textProvider&quot; value=&quot;myTextProvider&quot; /&gt;
  * </p>
  *
  * <p>

--- a/core/src/main/java/org/apache/struts2/StrutsConstants.java
+++ b/core/src/main/java/org/apache/struts2/StrutsConstants.java
@@ -213,13 +213,6 @@ public final class StrutsConstants {
 
     public static final String STRUTS_ALWAYS_SELECT_FULL_NAMESPACE = "struts.mapper.alwaysSelectFullNamespace";
 
-    /**
-     * XWork default text provider
-     * @deprecated use {@link #STRUTS_TEXT_PROVIDER} instead
-     */
-    @Deprecated
-    public static final String STRUTS_XWORKTEXTPROVIDER = "struts.xworkTextProvider";
-
     /** The {@link com.opensymphony.xwork2.LocaleProviderFactory} implementation class */
     public static final String STRUTS_LOCALE_PROVIDER_FACTORY = "struts.localeProviderFactory";
 

--- a/core/src/main/java/org/apache/struts2/StrutsConstants.java
+++ b/core/src/main/java/org/apache/struts2/StrutsConstants.java
@@ -220,13 +220,6 @@ public final class StrutsConstants {
     @Deprecated
     public static final String STRUTS_XWORKTEXTPROVIDER = "struts.xworkTextProvider";
 
-    /**
-     * The {@link com.opensymphony.xwork2.LocaleProvider} implementation class
-     * @deprecated use {@link StrutsConstants#STRUTS_LOCALE_PROVIDER_FACTORY} instead
-     */
-    @Deprecated
-    public static final String STRUTS_LOCALE_PROVIDER = "struts.localeProvider";
-
     /** The {@link com.opensymphony.xwork2.LocaleProviderFactory} implementation class */
     public static final String STRUTS_LOCALE_PROVIDER_FACTORY = "struts.localeProviderFactory";
 

--- a/core/src/main/java/org/apache/struts2/config/StrutsBeanSelectionProvider.java
+++ b/core/src/main/java/org/apache/struts2/config/StrutsBeanSelectionProvider.java
@@ -390,7 +390,6 @@ public class StrutsBeanSelectionProvider extends AbstractBeanSelectionProvider {
         alias(TypeConverterCreator.class, StrutsConstants.STRUTS_CONVERTER_CREATOR, builder, props);
         alias(TypeConverterHolder.class, StrutsConstants.STRUTS_CONVERTER_HOLDER, builder, props);
 
-        alias(TextProvider.class, StrutsConstants.STRUTS_XWORKTEXTPROVIDER, builder, props, Scope.PROTOTYPE);
         alias(TextProvider.class, StrutsConstants.STRUTS_TEXT_PROVIDER, builder, props, Scope.PROTOTYPE);
         alias(TextProviderFactory.class, StrutsConstants.STRUTS_TEXT_PROVIDER_FACTORY, builder, props, Scope.PROTOTYPE);
         alias(LocaleProviderFactory.class, StrutsConstants.STRUTS_LOCALE_PROVIDER_FACTORY, builder, props);

--- a/core/src/main/java/org/apache/struts2/config/StrutsBeanSelectionProvider.java
+++ b/core/src/main/java/org/apache/struts2/config/StrutsBeanSelectionProvider.java
@@ -208,15 +208,15 @@ import org.apache.struts2.views.util.UrlHelper;
  *   </tr>
  *   <tr>
  *     <td>com.opensymphony.xwork2.TextProvider</td>
- *     <td>struts.xworkTextProvider</td>
+ *     <td>struts.textProvider</td>
  *     <td>default</td>
- *     <td>Allows provide custom TextProvider for whole application</td>
+ *     <td>Allows provide custom TextProvider for whole application, it's better to use struts.textProviderFactory</td>
  *   </tr>
  *   <tr>
- *     <td>com.opensymphony.xwork2.LocaleProvider</td>
- *     <td>struts.localeProvider</td>
- *     <td>singleton</td>
- *     <td>DEPRECATED! Allows provide custom TextProvider for whole application - instead this endpoint use <b>struts.localeProviderFactory</b></td>
+ *     <td>com.opensymphony.xwork2.TextProviderFactory</td>
+ *     <td>struts.textProviderFactory</td>
+ *     <td>default</td>
+ *     <td>Allows provide custom TextProviderFactory for whole application</td>
  *   </tr>
  *   <tr>
  *     <td>com.opensymphony.xwork2.LocaleProviderFactory</td>

--- a/core/src/main/java/org/apache/struts2/config/entities/ConstantConfig.java
+++ b/core/src/main/java/org/apache/struts2/config/entities/ConstantConfig.java
@@ -88,7 +88,6 @@ public class ConstantConfig {
     private BeanConfig xworkConverter;
     private Boolean mapperAlwaysSelectFullNamespace;
     private BeanConfig xworkTextProvider;
-    private BeanConfig localeProvider;
     private BeanConfig localeProviderFactory;
     private String mapperIdParameterName;
     private Boolean ognlAllowStaticFieldAccess;
@@ -219,7 +218,6 @@ public class ConstantConfig {
         map.put(StrutsConstants.STRUTS_XWORKCONVERTER, beanConfToString(xworkConverter));
         map.put(StrutsConstants.STRUTS_ALWAYS_SELECT_FULL_NAMESPACE, Objects.toString(mapperAlwaysSelectFullNamespace, null));
         map.put(StrutsConstants.STRUTS_XWORKTEXTPROVIDER, beanConfToString(xworkTextProvider));
-        map.put(StrutsConstants.STRUTS_LOCALE_PROVIDER, beanConfToString(localeProvider));
         map.put(StrutsConstants.STRUTS_LOCALE_PROVIDER_FACTORY, beanConfToString(localeProviderFactory));
         map.put(StrutsConstants.STRUTS_ID_PARAMETER_NAME, mapperIdParameterName);
         map.put(StrutsConstants.STRUTS_ALLOW_STATIC_FIELD_ACCESS, Objects.toString(ognlAllowStaticFieldAccess, null));
@@ -790,18 +788,6 @@ public class ConstantConfig {
 
     public void setXworkTextProvider(Class<?> clazz) {
         this.xworkTextProvider = new BeanConfig(clazz, clazz.getName());
-    }
-
-    public BeanConfig getLocaleProvider() {
-        return localeProvider;
-    }
-
-    public void setLocaleProvider(BeanConfig localeProvider) {
-        this.localeProvider = localeProvider;
-    }
-
-    public void setLocaleProvider(Class<?> clazz) {
-        this.localeProvider = new BeanConfig(clazz, clazz.getName());
     }
 
     public BeanConfig getLocaleProviderFactory() {

--- a/core/src/main/java/org/apache/struts2/config/entities/ConstantConfig.java
+++ b/core/src/main/java/org/apache/struts2/config/entities/ConstantConfig.java
@@ -87,7 +87,6 @@ public class ConstantConfig {
     private Boolean freemarkerWrapperAltMap;
     private BeanConfig xworkConverter;
     private Boolean mapperAlwaysSelectFullNamespace;
-    private BeanConfig xworkTextProvider;
     private BeanConfig localeProviderFactory;
     private String mapperIdParameterName;
     private Boolean ognlAllowStaticFieldAccess;
@@ -217,7 +216,6 @@ public class ConstantConfig {
         map.put(StrutsConstants.STRUTS_FREEMARKER_WRAPPER_ALT_MAP, Objects.toString(freemarkerWrapperAltMap, null));
         map.put(StrutsConstants.STRUTS_XWORKCONVERTER, beanConfToString(xworkConverter));
         map.put(StrutsConstants.STRUTS_ALWAYS_SELECT_FULL_NAMESPACE, Objects.toString(mapperAlwaysSelectFullNamespace, null));
-        map.put(StrutsConstants.STRUTS_XWORKTEXTPROVIDER, beanConfToString(xworkTextProvider));
         map.put(StrutsConstants.STRUTS_LOCALE_PROVIDER_FACTORY, beanConfToString(localeProviderFactory));
         map.put(StrutsConstants.STRUTS_ID_PARAMETER_NAME, mapperIdParameterName);
         map.put(StrutsConstants.STRUTS_ALLOW_STATIC_FIELD_ACCESS, Objects.toString(ognlAllowStaticFieldAccess, null));
@@ -776,18 +774,6 @@ public class ConstantConfig {
 
     public void setMapperAlwaysSelectFullNamespace(Boolean mapperAlwaysSelectFullNamespace) {
         this.mapperAlwaysSelectFullNamespace = mapperAlwaysSelectFullNamespace;
-    }
-
-    public BeanConfig getXworkTextProvider() {
-        return xworkTextProvider;
-    }
-
-    public void setXworkTextProvider(BeanConfig xworkTextProvider) {
-        this.xworkTextProvider = xworkTextProvider;
-    }
-
-    public void setXworkTextProvider(Class<?> clazz) {
-        this.xworkTextProvider = new BeanConfig(clazz, clazz.getName());
     }
 
     public BeanConfig getLocaleProviderFactory() {

--- a/plugins/config-browser/src/main/java/org/apache/struts2/config_browser/ShowBeansAction.java
+++ b/plugins/config-browser/src/main/java/org/apache/struts2/config_browser/ShowBeansAction.java
@@ -20,7 +20,6 @@ package org.apache.struts2.config_browser;
 
 import com.opensymphony.xwork2.ActionProxyFactory;
 import com.opensymphony.xwork2.ObjectFactory;
-import com.opensymphony.xwork2.TextProvider;
 import com.opensymphony.xwork2.conversion.ObjectTypeDeterminer;
 import com.opensymphony.xwork2.conversion.impl.XWorkConverter;
 import com.opensymphony.xwork2.inject.Container;
@@ -49,10 +48,9 @@ public class ShowBeansAction extends ActionNamesAction {
     @Inject
     public void setContainer(Container container) {
         super.setContainer(container);
-        bindings = new TreeMap<String, Set<Binding>>();
+        bindings = new TreeMap<>();
         bindings.put(ObjectFactory.class.getName(), addBindings(container, ObjectFactory.class, StrutsConstants.STRUTS_OBJECTFACTORY));
         bindings.put(XWorkConverter.class.getName(), addBindings(container, XWorkConverter.class, StrutsConstants.STRUTS_XWORKCONVERTER));
-        bindings.put(TextProvider.class.getName(), addBindings(container, TextProvider.class, StrutsConstants.STRUTS_XWORKTEXTPROVIDER));
         bindings.put(ActionProxyFactory.class.getName(), addBindings(container, ActionProxyFactory.class, StrutsConstants.STRUTS_ACTIONPROXYFACTORY));
         bindings.put(ObjectTypeDeterminer.class.getName(), addBindings(container, ObjectTypeDeterminer.class, StrutsConstants.STRUTS_OBJECTTYPEDETERMINER));
         bindings.put(ActionMapper.class.getName(), addBindings(container, ActionMapper.class, StrutsConstants.STRUTS_MAPPER_CLASS));
@@ -66,8 +64,8 @@ public class ShowBeansAction extends ActionNamesAction {
         return bindings;
     }
 
-    protected Set<Binding> addBindings(Container container, Class type, String constName) {
-        Set<Binding> bindings = new TreeSet<Binding>();
+    protected Set<Binding> addBindings(Container container, Class<?> type, String constName) {
+        Set<Binding> bindings = new TreeSet<>();
         String chosenName = container.getInstance(String.class, constName);
         if (chosenName == null) {
             chosenName = "struts";
@@ -84,7 +82,7 @@ public class ShowBeansAction extends ActionNamesAction {
         return bindings;
     }
 
-    String getInstanceClassName(Container container, Class type, String name) {
+    String getInstanceClassName(Container container, Class<?> type, String name) {
         String instName = "Class unable to be loaded";
         try {
             Object inst = container.getInstance(type, name);
@@ -95,11 +93,12 @@ public class ShowBeansAction extends ActionNamesAction {
         return instName;
     }
 
-    public class Binding implements Comparable<Binding> {
-        private String impl;
-        private String alias;
-        private String constant;
-        private boolean isDefault;
+    public static class Binding implements Comparable<Binding> {
+
+        private final String impl;
+        private final String alias;
+        private final String constant;
+        private final boolean isDefault;
 
         public Binding(String impl, String alias, String constant, boolean def) {
             this.impl = impl;
@@ -125,7 +124,7 @@ public class ShowBeansAction extends ActionNamesAction {
         }
 
         public int compareTo(Binding b2) {
-            int ret = 0;
+            int ret;
             if (isDefault) {
                 ret = -1;
             } else if (b2.isDefault()) {


### PR DESCRIPTION
Drops deprecated `struts.xworkTextProvider` and `struts.localeProvider` config options.

Refs [WW-5113](https://issues.apache.org/jira/browse/WW-5113)
Refs [WW-5114](https://issues.apache.org/jira/browse/WW-5114)