### PR TITLE
WW-5116: Fix wrong regex range

### DIFF
--- a/core/src/main/java/org/apache/struts2/result/PostbackResult.java
+++ b/core/src/main/java/org/apache/struts2/result/PostbackResult.java
@@ -152,7 +152,7 @@ public class PostbackResult extends StrutsResultSupport {
         } else {
             String location = getLocation();
             // Do not prepend if the URL is a FQN
-            if (!location.matches("^([a-zA-z]+:)?//.*")) {
+            if (!location.matches("^([a-zA-Z]+:)?//.*")) {
                 // If the URL is relative to the servlet context, prepend the servlet context path
                 if (prependServletContext && (request.getContextPath() != null) && (request.getContextPath().length() > 0)) {
                     location = request.getContextPath() + location;


### PR DESCRIPTION
I assume `A-z` is a typo (and should be `A-Z`) because it matches:
- `A-Z`
- `[`, `\`, `]`, `^`, `_`, <code>`</code>
- `a-z`
