### PR TITLE
[WW-5119] Fix: remove contention during localized text lookup (JDK 1.8+)

### DIFF
--- a/core/src/main/java/com/opensymphony/xwork2/util/AbstractLocalizedTextProvider.java
+++ b/core/src/main/java/com/opensymphony/xwork2/util/AbstractLocalizedTextProvider.java
@@ -31,8 +31,6 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.text.MessageFormat;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -65,7 +63,7 @@ abstract class AbstractLocalizedTextProvider implements LocalizedTextProvider {
 
     private final ConcurrentMap<MessageFormatKey, MessageFormat> messageFormats = new ConcurrentHashMap<>();
     private final ConcurrentMap<Integer, List<String>> classLoaderMap = new ConcurrentHashMap<>();
-    private final Set<String> missingBundles = Collections.synchronizedSet(new HashSet<String>());
+    private final Set<String> missingBundles = ConcurrentHashMap.newKeySet();
     private final ConcurrentMap<Integer, ClassLoader> delegatedClassLoaderMap = new ConcurrentHashMap<>();
 
     /**


### PR DESCRIPTION
The localized resources lookup shows high contention during significant stress in an enterprise application delivering the UI using Struts 2.5.20.

Profiling the app while under load stress using the excellent https://github.com/jvm-profiling-tools/async-profiler (using the `lock` mode and `--reverse` option to aggregate on the various contention code locations) shows the following picture:

![image](https://user-images.githubusercontent.com/2195557/111143750-7a5d9f80-8586-11eb-9890-a295d6e592ca.png)

No other high contention code paths was detected (profiler obviously shows high lock wait times on EPoll and other `java.util.concurrent`-related waits, which are irrelevant here): this code path is the main contention culprit.

Switching to the concurrent version of `Set` fixes entirely the issue: no more contention detected in this area after applying the fix.

Fixes [WW-5119](https://issues.apache.org/jira/browse/WW-5119)