### PR TITLE
[WW-5119] Fix: remove contention during localized text lookup (JDK 1.7+)

### DIFF
--- a/core/src/main/java/com/opensymphony/xwork2/util/AbstractLocalizedTextProvider.java
+++ b/core/src/main/java/com/opensymphony/xwork2/util/AbstractLocalizedTextProvider.java
@@ -31,8 +31,6 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.text.MessageFormat;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -61,7 +59,7 @@ abstract class AbstractLocalizedTextProvider implements LocalizedTextProvider {
 
     private final ConcurrentMap<MessageFormatKey, MessageFormat> messageFormats = new ConcurrentHashMap<>();
     private final ConcurrentMap<Integer, List<String>> classLoaderMap = new ConcurrentHashMap<>();
-    private final Set<String> missingBundles = Collections.synchronizedSet(new HashSet<String>());
+    private final ConcurrentMap<String,Boolean> missingBundles = new ConcurrentHashMap<>();
     private final ConcurrentMap<Integer, ClassLoader> delegatedClassLoaderMap = new ConcurrentHashMap<>();
 
     /**
@@ -390,7 +388,7 @@ abstract class AbstractLocalizedTextProvider implements LocalizedTextProvider {
         ClassLoader classLoader = getCurrentThreadContextClassLoader();
         String key = createMissesKey(String.valueOf(classLoader.hashCode()), aBundleName, locale);
 
-        if (missingBundles.contains(key)) {
+        if (missingBundles.containsKey(key)) {
             return null;
         }
 
@@ -413,11 +411,11 @@ abstract class AbstractLocalizedTextProvider implements LocalizedTextProvider {
                     }
                 } catch (MissingResourceException e) {
                     LOG.debug("Missing resource bundle [{}]!", aBundleName, e);
-                    missingBundles.add(key);
+                    missingBundles.put(key, Boolean.TRUE);
                 }
             } else {
                 LOG.debug("Missing resource bundle [{}]!", aBundleName);
-                missingBundles.add(key);
+                missingBundles.put(key, Boolean.TRUE);
             }
         }
         return bundle;

--- a/core/src/main/java/com/opensymphony/xwork2/util/AbstractLocalizedTextProvider.java
+++ b/core/src/main/java/com/opensymphony/xwork2/util/AbstractLocalizedTextProvider.java
@@ -59,7 +59,7 @@ abstract class AbstractLocalizedTextProvider implements LocalizedTextProvider {
 
     private final ConcurrentMap<MessageFormatKey, MessageFormat> messageFormats = new ConcurrentHashMap<>();
     private final ConcurrentMap<Integer, List<String>> classLoaderMap = new ConcurrentHashMap<>();
-    private final ConcurrentMap<String,Boolean> missingBundles = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, Boolean> missingBundles = new ConcurrentHashMap<>();
     private final ConcurrentMap<Integer, ClassLoader> delegatedClassLoaderMap = new ConcurrentHashMap<>();
 
     /**
@@ -411,11 +411,11 @@ abstract class AbstractLocalizedTextProvider implements LocalizedTextProvider {
                     }
                 } catch (MissingResourceException e) {
                     LOG.debug("Missing resource bundle [{}]!", aBundleName, e);
-                    missingBundles.put(key, Boolean.TRUE);
+                    missingBundles.putIfAbsent(key, Boolean.TRUE);
                 }
             } else {
                 LOG.debug("Missing resource bundle [{}]!", aBundleName);
-                missingBundles.put(key, Boolean.TRUE);
+                missingBundles.putIfAbsent(key, Boolean.TRUE);
             }
         }
         return bundle;


### PR DESCRIPTION
Backport of pull request #476 for Struts 2.5.x (JDK 1.7 still supported in this branch).

The `ConcurrentHashMap.newKeySet()` usage (available only in JDK 1.8+) is replaced by a `ConcurrentHashMap<String,Boolean>` to guarantee JDK 1.7 compatibility.

Fixes [WW-5119](https://issues.apache.org/jira/browse/WW-5119)