### PR TITLE
[WW-5121] Fix: remove contention during Scope.SINGLETON injection

### DIFF
--- a/core/src/main/java/com/opensymphony/xwork2/inject/Scope.java
+++ b/core/src/main/java/com/opensymphony/xwork2/inject/Scope.java
@@ -44,15 +44,17 @@ public enum Scope {
         @Override
         <T> InternalFactory<? extends T> scopeFactory(Class<T> type, String name, final InternalFactory<? extends T> factory) {
             return new InternalFactory<T>() {
-                T instance;
+                volatile T instance;
 
                 public T create(InternalContext context) {
-                    synchronized (context.getContainer()) {
-                        if (instance == null) {
-                            instance = InitializableFactory.wrapIfNeeded(factory).create(context);
+                    if (instance == null) {
+                        synchronized (context.getContainer()) {
+                            if (instance == null) {
+                                instance = InitializableFactory.wrapIfNeeded(factory).create(context);
+                            }
                         }
-                        return instance;
                     }
+                    return instance;
                 }
 
                 @Override


### PR DESCRIPTION
Fixes the contention issue described in WW-5121 by applying a double-null-check-with-volatile pattern to avoid the synchronized cost on each and every injection of the singleton.

Same patch as #478 but against the Struts 2.5.x branch.