### PR TITLE
[WW-5125] use .get(...) instead of [...] for fieldErrors

### DIFF
--- a/apps/showcase/src/main/resources/template/ajaxErrorContainers/controlfooter.ftl
+++ b/apps/showcase/src/main/resources/template/ajaxErrorContainers/controlfooter.ftl
@@ -22,12 +22,12 @@ ${parameters.after!}<#t/>
     </td><#lt/>
 </tr>
 <#if (parameters.errorposition!"top") == 'bottom'>
-<#assign hasFieldErrors = parameters.name?? && fieldErrors?? && fieldErrors[parameters.name]??/>
+<#assign hasFieldErrors = parameters.name?? && fieldErrors?? && fieldErrors.get(parameters.name)??/>
 <#if hasFieldErrors>
 <tr errorFor="${parameters.id}">
     <td class="tdErrorMessage" colspan="2"><#rt/>
         <#if hasFieldErrors>
-            <#list fieldErrors[parameters.name] as error>
+            <#list fieldErrors.get(parameters.name) as error>
                 <div class="errorMessage">${error?html}</div><#t/>
             </#list>
         </#if>

--- a/apps/showcase/src/main/resources/template/ajaxErrorContainers/controlheader-core.ftl
+++ b/apps/showcase/src/main/resources/template/ajaxErrorContainers/controlheader-core.ftl
@@ -21,12 +21,12 @@
 <#--
 	Always include elements to show errors. They may be filled later via AJAX.
 -->
-<#assign hasFieldErrors = parameters.name?? && fieldErrors?? && fieldErrors[parameters.name]??/>
+<#assign hasFieldErrors = parameters.name?? && fieldErrors?? && fieldErrors.get(parameters.name)??/>
 <#if (parameters.errorposition!"top") == 'top'>
 <tr errorFor="${parameters.id}">
     <td class="tdErrorMessage" colspan="2" data-error-for-fieldname="${parameters.name}"><#rt/>
         <#if hasFieldErrors>
-            <#list fieldErrors[parameters.name] as error>
+            <#list fieldErrors.get(parameters.name) as error>
                 <div class="errorMessage">${error?html}</div><#t/>
             </#list>
         </#if>

--- a/core/src/main/resources/template/css_xhtml/checkbox.ftl
+++ b/core/src/main/resources/template/css_xhtml/checkbox.ftl
@@ -23,12 +23,12 @@ NOTE: The 'header' stuff that follows is in this one file for checkbox due to th
 that for checkboxes we do not want the label field to show up as checkboxes handle their own
 lables
 -->
-<#assign hasFieldErrors = fieldErrors?? && fieldErrors[parameters.name]??/>
+<#assign hasFieldErrors = fieldErrors?? && fieldErrors.get(parameters.name)??/>
 <div <#rt/><#if parameters.id??>id="wwgrp_${parameters.id}"<#rt/></#if> class="wwgrp">
 
 <#if hasFieldErrors>
 <div <#rt/><#if parameters.id??>id="wwerr_${parameters.id}"<#rt/></#if> class="wwerr">
-<#list fieldErrors[parameters.name] as error>
+<#list fieldErrors.get(parameters.name) as error>
     <div<#rt/>
     <#if parameters.id??>
      errorFor="${parameters.id}"<#rt/>

--- a/core/src/main/resources/template/css_xhtml/controlfooter.ftl
+++ b/core/src/main/resources/template/css_xhtml/controlfooter.ftl
@@ -31,10 +31,10 @@ ${parameters.after!}<#t/>
 </span> <#rt/>
 </#if>
 <#if (parameters.errorposition!"top") == 'bottom'>
-<#assign hasFieldErrors = parameters.name?? && fieldErrors?? && fieldErrors[parameters.name]??/>
+<#assign hasFieldErrors = parameters.name?? && fieldErrors?? && fieldErrors.get(parameters.name)??/>
 <#if hasFieldErrors>
 <div <#rt/><#if parameters.id??>id="wwerr_${parameters.id}"<#rt/></#if> class="wwerr">
-<#list fieldErrors[parameters.name] as error>
+<#list fieldErrors.get(parameters.name) as error>
     <div<#rt/>
     <#if parameters.id??>
      errorFor="${parameters.id}"<#rt/>

--- a/core/src/main/resources/template/css_xhtml/controlheader-core.ftl
+++ b/core/src/main/resources/template/css_xhtml/controlheader-core.ftl
@@ -22,13 +22,13 @@
 	Only show message if errors are available.
 	This will be done if ActionSupport is used.
 -->
-<#assign hasFieldErrors = parameters.name?? && fieldErrors?? && fieldErrors[parameters.name]??/>
+<#assign hasFieldErrors = parameters.name?? && fieldErrors?? && fieldErrors.get(parameters.name)??/>
 <div <#rt/><#if parameters.id??>id="wwgrp_${parameters.id}"<#rt/></#if> class="wwgrp">
 	
 <#if (parameters.errorposition!"top") == 'top'>
 <#if hasFieldErrors>
 <div <#rt/><#if parameters.id??>id="wwerr_${parameters.id}"<#rt/></#if> class="wwerr">
-<#list fieldErrors[parameters.name] as error>
+<#list fieldErrors.get(parameters.name) as error>
     <div<#rt/>
     <#if parameters.id??>
      errorFor="${parameters.id}"<#rt/>

--- a/core/src/main/resources/template/simple/css.ftl
+++ b/core/src/main/resources/template/simple/css.ftl
@@ -18,7 +18,7 @@
  * under the License.
  */
 -->
-<#assign hasFieldErrors = parameters.name?? && fieldErrors?? && fieldErrors[parameters.name]??/>
+<#assign hasFieldErrors = parameters.name?? && fieldErrors?? && fieldErrors.get(parameters.name)??/>
 <#if parameters.cssClass?has_content && !(hasFieldErrors && parameters.cssErrorClass??)>
  class="${parameters.cssClass?html}"<#rt/>
 <#elseif parameters.cssClass?has_content && (hasFieldErrors && parameters.cssErrorClass??)>

--- a/core/src/main/resources/template/simple/fielderror.ftl
+++ b/core/src/main/resources/template/simple/fielderror.ftl
@@ -29,7 +29,7 @@
             <#list eKeys as eKey><#t/>
                 <#if (eKey = fieldErrorFieldName)><#t/>
                     <#assign haveMatchedErrorField=true><#t/>
-                    <#assign eValue = fieldErrors[fieldErrorFieldName]><#t/>
+                    <#assign eValue = fieldErrors.get(fieldErrorFieldName)><#t/>
                     <#if (haveMatchedErrorField && (!doneStartUlTag))><#t/>
                     <ul<#rt/>
                         <#if parameters.id?has_content>
@@ -69,7 +69,7 @@
             </#if>
                 >
             <#list eKeys as eKey><#t/>
-                <#assign eValue = fieldErrors[eKey]><#t/>
+                <#assign eValue = fieldErrors.get(eKey)><#t/>
                 <#list eValue as eEachValue><#t/>
                     <li><span><#if parameters.escape>${eEachValue!?html}<#else>${eEachValue!}</#if></span></li>
                 </#list><#t/>

--- a/core/src/main/resources/template/xhtml/checkbox.ftl
+++ b/core/src/main/resources/template/xhtml/checkbox.ftl
@@ -18,9 +18,9 @@
  * under the License.
  */
 -->
-<#assign hasFieldErrors = fieldErrors?? && fieldErrors[parameters.name]??/>
+<#assign hasFieldErrors = fieldErrors?? && fieldErrors.get(parameters.name)??/>
 <#if hasFieldErrors>
-<#list fieldErrors[parameters.name] as error>
+<#list fieldErrors.get(parameters.name) as error>
 <tr<#rt/>
 <#if parameters.id??>
  errorFor="${parameters.id}"<#rt/>

--- a/core/src/main/resources/template/xhtml/controlfooter.ftl
+++ b/core/src/main/resources/template/xhtml/controlfooter.ftl
@@ -22,9 +22,9 @@ ${parameters.after!}<#t/>
     </td><#lt/>
 </tr>
 <#if (parameters.errorposition!"top") == 'bottom'>
-<#assign hasFieldErrors = parameters.name?? && fieldErrors?? && fieldErrors[parameters.name]??/>
+<#assign hasFieldErrors = parameters.name?? && fieldErrors?? && fieldErrors.get(parameters.name)??/>
 <#if hasFieldErrors>
-<#list fieldErrors[parameters.name] as error>
+<#list fieldErrors.get(parameters.name) as error>
 <tr errorFor="${parameters.id}">
     <td class="tdErrorMessage" colspan="2"><#rt/>
         <span class="errorMessage">${error?html}</span><#t/>

--- a/core/src/main/resources/template/xhtml/controlheader-core.ftl
+++ b/core/src/main/resources/template/xhtml/controlheader-core.ftl
@@ -22,10 +22,10 @@
 	Only show message if errors are available.
 	This will be done if ActionSupport is used.
 -->
-<#assign hasFieldErrors = parameters.name?? && fieldErrors?? && fieldErrors[parameters.name]??/>
+<#assign hasFieldErrors = parameters.name?? && fieldErrors?? && fieldErrors.get(parameters.name)??/>
 <#if (parameters.errorposition!"top") == 'top'>
 <#if hasFieldErrors>
-<#list fieldErrors[parameters.name] as error>
+<#list fieldErrors.get(parameters.name) as error>
 <tr errorFor="${parameters.id}">
     <td class="tdErrorMessage" colspan="2"><#rt/>
         <span class="errorMessage">${error?html}</span><#t/>

--- a/core/src/test/java/org/apache/struts2/views/jsp/ui/TextfieldTest.java
+++ b/core/src/test/java/org/apache/struts2/views/jsp/ui/TextfieldTest.java
@@ -145,7 +145,23 @@ public class TextfieldTest extends AbstractUITagTest {
 
         verify(TextFieldTag.class.getResource("Textfield-1.txt"));
     }
-    
+
+    public void testWW5125() throws Exception {
+        TestAction testAction = (TestAction) action;
+
+        for(String fieldName : new String[] {"clone", "size", "clear", "values", "hashCode", "isEmpty", "keySet", "entrySet"}) {
+            testAction.addFieldError(fieldName, fieldName + " error");
+
+            TextFieldTag tag = new TextFieldTag();
+            tag.setPageContext(pageContext);
+            tag.setName(fieldName);
+            tag.doStartTag();
+            tag.doEndTag();
+        }
+
+        verify(TextFieldTag.class.getResource("Textfield-WW-5125.txt"));
+    }
+
     public void testSimple_recursionTest() throws Exception {
         TestAction testAction = (TestAction) action;
         testAction.setFoo("%{1+1}");

--- a/core/src/test/resources/org/apache/struts2/views/jsp/ui/Textfield-WW-5125.txt
+++ b/core/src/test/resources/org/apache/struts2/views/jsp/ui/Textfield-WW-5125.txt
@@ -1,0 +1,80 @@
+<tr errorFor="clone">
+    <td class="tdErrorMessage" colspan="2"><span class="errorMessage">clone error</span></td>
+</tr>
+<tr>
+    <td class="tdLabel"></td>
+    <td
+            class="tdInput"
+><input type="text" name="clone" value="" id="clone"/></td>
+</tr>
+
+<tr errorFor="size">
+    <td class="tdErrorMessage" colspan="2"><span class="errorMessage">size error</span></td>
+</tr>
+<tr>
+    <td class="tdLabel"></td>
+    <td
+            class="tdInput"
+><input type="text" name="size" value="" id="size"/></td>
+</tr>
+
+<tr errorFor="clear">
+    <td class="tdErrorMessage" colspan="2"><span class="errorMessage">clear error</span></td>
+</tr>
+<tr>
+    <td class="tdLabel"></td>
+    <td
+            class="tdInput"
+><input type="text" name="clear" value="" id="clear"/></td>
+</tr>
+
+<tr errorFor="values">
+    <td class="tdErrorMessage" colspan="2"><span class="errorMessage">values error</span></td>
+</tr>
+<tr>
+    <td class="tdLabel"></td>
+    <td
+            class="tdInput"
+><input type="text" name="values" value="" id="values"/></td>
+</tr>
+
+<tr errorFor="hashCode">
+    <td class="tdErrorMessage" colspan="2"><span class="errorMessage">hashCode error</span></td>
+</tr>
+<tr>
+    <td class="tdLabel"></td>
+    <td
+            class="tdInput"
+><input type="text" name="hashCode" value="" id="hashCode"/></td>
+</tr>
+
+<tr errorFor="isEmpty">
+    <td class="tdErrorMessage" colspan="2"><span class="errorMessage">isEmpty error</span></td>
+</tr>
+<tr>
+    <td class="tdLabel"></td>
+    <td
+            class="tdInput"
+><input type="text" name="isEmpty" value="" id="isEmpty"/></td>
+</tr>
+
+<tr errorFor="keySet">
+    <td class="tdErrorMessage" colspan="2"><span class="errorMessage">keySet error</span></td>
+</tr>
+<tr>
+    <td class="tdLabel"></td>
+    <td
+            class="tdInput"
+><input type="text" name="keySet" value="" id="keySet"/></td>
+</tr>
+
+<tr errorFor="entrySet">
+    <td class="tdErrorMessage" colspan="2"><span class="errorMessage">entrySet error</span></td>
+</tr>
+<tr>
+    <td class="tdLabel"></td>
+    <td
+            class="tdInput"
+><input type="text" name="entrySet" value="" id="entrySet"/></td>
+</tr>
+


### PR DESCRIPTION
All [ occurrences in all ftl files reviewed. Only fieldErrors had used [...] which replaced by .get(...) to fix WW-5125 as well as aligning with other ftl files conduct.