### PR TITLE
Fix NPE in XmlConfigurationProvider.java

### DIFF
--- a/core/src/main/java/com/opensymphony/xwork2/config/providers/XmlConfigurationProvider.java
+++ b/core/src/main/java/com/opensymphony/xwork2/config/providers/XmlConfigurationProvider.java
@@ -1076,8 +1076,12 @@ public abstract class XmlConfigurationProvider implements ConfigurationProvider 
                     InputSource in = new InputSource(is);
 
                     in.setSystemId(url.toString());
-
-                    docs.add(DomHelper.parse(in, dtdMappings));
+                    
+                    Document helperDoc = DomHelper.parse(in, dtdMappings);
+                    if (helperDoc != null) {
+                        docs.add(helperDoc);
+                    }
+                    
                     loadedFileUrls.add(url.toString());
                 } catch (StrutsException e) {
                     if (includeElement != null) {


### PR DESCRIPTION
Hello,
Our static analyzer found a following potential NPE. We have checked the feasibility of this execution trace. It is necessary to defend this vulnerability to improve the code quality.

Here is the bug trace.

1. Return **null** to caller
https://github.com/apache/struts/blob/cb318cdc749f40a06eaaeed789a047f385a55480/core/src/main/java/com/opensymphony/xwork2/util/DomHelper.java#L226

2. Function **getDocument** executes and the return value can be **null**
https://github.com/apache/struts/blob/cb318cdc749f40a06eaaeed789a047f385a55480/core/src/main/java/com/opensymphony/xwork2/util/DomHelper.java#L123

3. Function **parse** executes and pass the return value as the parameter of **add**, which can be **null**
https://github.com/apache/struts/blob/cb318cdc749f40a06eaaeed789a047f385a55480/core/src/main/java/com/opensymphony/xwork2/config/providers/XmlConfigurationProvider.java#L1080

4. Function **add** executes. One of the elements in **docs** can be **null**
https://github.com/apache/struts/blob/cb318cdc749f40a06eaaeed789a047f385a55480/core/src/main/java/com/opensymphony/xwork2/config/providers/XmlConfigurationProvider.java#L1080

5. Function **next** executes and stores the return value to **doc** (doc can be null)
https://github.com/apache/struts/blob/cb318cdc749f40a06eaaeed789a047f385a55480/core/src/main/java/com/opensymphony/xwork2/config/providers/XmlConfigurationProvider.java#L1108

6. **doc** is passed as the **this** pointer to function **getDocumentElement** (**doc** can be **null**), which will lead to null pointer dereference
https://github.com/apache/struts/blob/cb318cdc749f40a06eaaeed789a047f385a55480/core/src/main/java/com/opensymphony/xwork2/config/providers/XmlConfigurationProvider.java#L1109

Commit: cb318cdc749f40a06eaaeed789a047f385a55480

We have fixed this NPE in this PR. Please confirm and merge it to make the code more reliable. Thanks.