### PR TITLE
fixed flakiness in JacksonXmlHandlerTest.java

### DIFF
--- a/plugins/rest/src/test/java/org/apache/struts2/rest/handler/JacksonXmlHandlerTest.java
+++ b/plugins/rest/src/test/java/org/apache/struts2/rest/handler/JacksonXmlHandlerTest.java
@@ -62,10 +62,10 @@ public class JacksonXmlHandlerTest extends XWorkTestCase {
         // when
         Writer stream = new StringWriter();
         handler.fromObject(ai, obj, null, stream);
-        String actual = stream.toString();
 
         // then
         stream.flush();
+        String actual = stream.toString();
         assertTrue(actual.length() == xml.length() &&
             actual.startsWith(prefix) &&
             actual.contains(name) &&


### PR DESCRIPTION
Hi,

By running the following command:
`mvn -pl plugins/rest/ edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=org.apache.struts2.rest.handler.JacksonXmlHandlerTest `,

`testObjectToXml` method will fail sometimes. This is because `fromObject()` method of `JacksonXmlHandler` uses `com.fasterxml.jackson.dataformat.xml.XmlMapper`, whose marshal strategy that serializes the object is non-deterministic. Thus, the output of `toString()` method of the serialized xml object is non-deterministic. I fixed the bug by checking the output contains all components of the xml object and the expected length.