### PR TITLE
Fix flaky test testDynamicAttributesSupport.

### DIFF
--- a/core/src/test/java/org/apache/struts2/views/freemarker/FreemarkerResultMockedTest.java
+++ b/core/src/test/java/org/apache/struts2/views/freemarker/FreemarkerResultMockedTest.java
@@ -113,15 +113,16 @@ public class FreemarkerResultMockedTest extends StrutsInternalTestCase {
         ActionMapping mapping = container.getInstance(ActionMapper.class).getMapping(request, configurationManager);
         dispatcher.serviceAction(request, response, mapping);
 
-        String expected =
-            "<input type=\"text\" name=\"test\" value=\"\" id=\"test\" foo=\"bar\" placeholder=\"input\"/>"
-                + "<input type=\"text\" name=\"test\" value=\"\" id=\"test\" foo=\"bar\" placeholder=\"input\"/>"
-                + "<input type=\"text\" name=\"test\" value=\"\" id=\"test\" break=\"true\"/>"
-                + "<input type=\"text\" name=\"required\" value=\"\" id=\"required\" required=\"true\"/>";
+        String input1 = "<input type=\"text\" name=\"test\" value=\"\" id=\"test\" foo=\"bar\" placeholder=\"input\"/>";
+        String input2 = "<input type=\"text\" name=\"test\" value=\"\" id=\"test\" placeholder=\"input\" foo=\"bar\"/>";
+        String input34 = "<input type=\"text\" name=\"test\" value=\"\" id=\"test\" break=\"true\"/>"
+                       + "<input type=\"text\" name=\"required\" value=\"\" id=\"required\" required=\"true\"/>";
 
         String result = stringWriter.toString();
-
-        assertEquals(expected, result);
+        assertTrue(result.equals(input1 + input1 + input34)
+                || result.equals(input1 + input2 + input34)
+                || result.equals(input2 + input1 + input34)
+                || result.equals(input2 + input2 + input34));
     }
 
     public void testManualListInTemplate() throws Exception {

--- a/core/src/test/java/org/apache/struts2/views/freemarker/FreemarkerResultMockedTest.java
+++ b/core/src/test/java/org/apache/struts2/views/freemarker/FreemarkerResultMockedTest.java
@@ -38,6 +38,11 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 
 import static org.apache.struts2.views.jsp.AbstractUITagTest.normalize;
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.endsWith;
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class FreemarkerResultMockedTest extends StrutsInternalTestCase {
 
@@ -114,10 +119,11 @@ public class FreemarkerResultMockedTest extends StrutsInternalTestCase {
         dispatcher.serviceAction(request, response, mapping);
 
         String result = stringWriter.toString();
-        assertTrue((result.contains("<input type=\"text\" name=\"test\" value=\"\" id=\"test\" foo=\"bar\" placeholder=\"input\"/>")
-                 || result.contains("<input type=\"text\" name=\"test\" value=\"\" id=\"test\" placeholder=\"input\" foo=\"bar\"/>"))
-                 && result.endsWith("<input type=\"text\" name=\"test\" value=\"\" id=\"test\" break=\"true\"/>"
-                 + "<input type=\"text\" name=\"required\" value=\"\" id=\"required\" required=\"true\"/>"));
+        assertThat(result, allOf(startsWith("<input type=\"text\" name=\"test\" value=\"\" id=\"test\""),
+                                 containsString("foo=\"bar\""),
+                                 containsString("placeholder=\"input\""),
+                                 endsWith("<input type=\"text\" name=\"test\" value=\"\" id=\"test\" break=\"true\"/>"
+                                        + "<input type=\"text\" name=\"required\" value=\"\" id=\"required\" required=\"true\"/>")));
     }
 
     public void testManualListInTemplate() throws Exception {

--- a/core/src/test/java/org/apache/struts2/views/freemarker/FreemarkerResultMockedTest.java
+++ b/core/src/test/java/org/apache/struts2/views/freemarker/FreemarkerResultMockedTest.java
@@ -113,16 +113,11 @@ public class FreemarkerResultMockedTest extends StrutsInternalTestCase {
         ActionMapping mapping = container.getInstance(ActionMapper.class).getMapping(request, configurationManager);
         dispatcher.serviceAction(request, response, mapping);
 
-        String input1 = "<input type=\"text\" name=\"test\" value=\"\" id=\"test\" foo=\"bar\" placeholder=\"input\"/>";
-        String input2 = "<input type=\"text\" name=\"test\" value=\"\" id=\"test\" placeholder=\"input\" foo=\"bar\"/>";
-        String input34 = "<input type=\"text\" name=\"test\" value=\"\" id=\"test\" break=\"true\"/>"
-                       + "<input type=\"text\" name=\"required\" value=\"\" id=\"required\" required=\"true\"/>";
-
         String result = stringWriter.toString();
-        assertTrue(result.equals(input1 + input1 + input34)
-                || result.equals(input1 + input2 + input34)
-                || result.equals(input2 + input1 + input34)
-                || result.equals(input2 + input2 + input34));
+        assertTrue((result.contains("<input type=\"text\" name=\"test\" value=\"\" id=\"test\" foo=\"bar\" placeholder=\"input\"/>")
+                 || result.contains("<input type=\"text\" name=\"test\" value=\"\" id=\"test\" placeholder=\"input\" foo=\"bar\"/>"))
+                 && result.endsWith("<input type=\"text\" name=\"test\" value=\"\" id=\"test\" break=\"true\"/>"
+                 + "<input type=\"text\" name=\"required\" value=\"\" id=\"required\" required=\"true\"/>"));
     }
 
     public void testManualListInTemplate() throws Exception {


### PR DESCRIPTION
Fixed the flaky test testDynamicAttributesSupport due to non-deterministic order of two attributes.

This flaky test is found by using [Nondex](https://github.com/TestingResearchIllinois/NonDex), a tool used to find flaky tests in Java projects. In the first two elements of the expected string, the order of the two attributes, ```foo``` and ```placeholder```, is non-deterministic, which means ```foo``` can be either before or after ```placeholder```. To make the test pass every time, all 4 possible orders are covered in the assertion.