### PR TITLE
[WW-5151] Bump to 2.15.0 to fix log4j vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
         <asm.version>9.2</asm.version>
         <jackson.version>2.10.5</jackson.version>
         <jackson-databind.version>2.10.5.1</jackson-databind.version>
-        <log4j2.version>2.13.3</log4j2.version>
+        <log4j2.version>2.15.0</log4j2.version>
         <ognl.version>3.2.20</ognl.version>
         <slf4j.version>1.7.30</slf4j.version>
         <spring.platformVersion>4.3.29.RELEASE</spring.platformVersion>


### PR DESCRIPTION
Hello,

It seems Apache struts is affected by the [log4j vulnerability](https://www.lunasec.io/docs/blog/log4j-zero-day/). I've shared my findings with the security team privately where you could review the vulnerable code paths. 

Fixes [WW-5151](https://issues.apache.org/jira/browse/WW-5151)