### PR TITLE
REST Showcase fix for broken JSPs using S2 link tags

### DIFF
--- a/apps/rest-showcase/src/main/webapp/WEB-INF/content/orders-deleteConfirm.jsp
+++ b/apps/rest-showcase/src/main/webapp/WEB-INF/content/orders-deleteConfirm.jsp
@@ -27,8 +27,10 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Orders</title>
-    <s:link href="${pageContext.request.contextPath}/css/bootstrap.min.css" rel="stylesheet"></s:link>
-    <s:link href="${pageContext.request.contextPath}/css/app.css" rel="stylesheet"></s:link>
+    <!-- Using a standard HTML link tag with JSP EL to get the contextPath may be simpler, but this is an equivalent for s:link -->
+    <s:set var="pageContextPath"><%=((HttpServletRequest)request).getContextPath()%></s:set>
+    <s:link href="%{#pageContextPath}/css/bootstrap.min.css" rel="stylesheet"></s:link>
+    <s:link href="%{#pageContextPath}/css/app.css" rel="stylesheet"></s:link>
 
     <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->

--- a/apps/rest-showcase/src/main/webapp/WEB-INF/content/orders-edit.jsp
+++ b/apps/rest-showcase/src/main/webapp/WEB-INF/content/orders-edit.jsp
@@ -27,8 +27,10 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Orders</title>
-    <s:link href="${pageContext.request.contextPath}/css/bootstrap.min.css" rel="stylesheet"></s:link>
-    <s:link href="${pageContext.request.contextPath}/css/app.css" rel="stylesheet"></s:link>
+    <!-- Using a standard HTML link tag with JSP EL to get the contextPath may be simpler, but this is an equivalent for s:link -->
+    <s:set var="pageContextPath"><%=((HttpServletRequest)request).getContextPath()%></s:set>
+    <s:link href="%{#pageContextPath}/css/bootstrap.min.css" rel="stylesheet"></s:link>
+    <s:link href="%{#pageContextPath}/css/app.css" rel="stylesheet"></s:link>
 
     <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->

--- a/apps/rest-showcase/src/main/webapp/WEB-INF/content/orders-editNew.jsp
+++ b/apps/rest-showcase/src/main/webapp/WEB-INF/content/orders-editNew.jsp
@@ -27,8 +27,11 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Orders</title>
-    <s:link href="${pageContext.request.contextPath}/css/bootstrap.min.css" rel="stylesheet"></s:link>
-    <s:link href="${pageContext.request.contextPath}/css/app.css" rel="stylesheet"></s:link>
+    <!-- Using a standard HTML link tag with JSP EL to get the contextPath may be simpler, but this is an equivalent for s:link -->
+    <s:set var="pageContextPath"><%=((HttpServletRequest)request).getContextPath()%></s:set>
+    <s:link href="%{#pageContextPath}/css/bootstrap.min.css" rel="stylesheet"></s:link>
+    <s:link href="%{#pageContextPath}/css/app.css" rel="stylesheet"></s:link>
+
     <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
     <!--[if lt IE 9]>

--- a/apps/rest-showcase/src/main/webapp/WEB-INF/content/orders-index.jsp
+++ b/apps/rest-showcase/src/main/webapp/WEB-INF/content/orders-index.jsp
@@ -27,8 +27,10 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Orders</title>
-    <s:link href="${pageContext.request.contextPath}/css/bootstrap.min.css" rel="stylesheet"></s:link>
-    <s:link href="${pageContext.request.contextPath}/css/app.css" rel="stylesheet"></s:link>
+    <!-- Using a standard HTML link tag with JSP EL to get the contextPath may be simpler, but this is an equivalent for s:link -->
+    <s:set var="pageContextPath"><%=((HttpServletRequest)request).getContextPath()%></s:set>
+    <s:link href="%{#pageContextPath}/css/bootstrap.min.css" rel="stylesheet"></s:link>
+    <s:link href="%{#pageContextPath}/css/app.css" rel="stylesheet"></s:link>
 
     <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->

--- a/apps/rest-showcase/src/main/webapp/WEB-INF/content/orders-show.jsp
+++ b/apps/rest-showcase/src/main/webapp/WEB-INF/content/orders-show.jsp
@@ -27,8 +27,10 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Orders</title>
-<s:link href="${pageContext.request.contextPath}/css/bootstrap.min.css" rel="stylesheet"></s:link>
-    <s:link href="${pageContext.request.contextPath}/css/app.css" rel="stylesheet"></s:link>
+    <!-- Using a standard HTML link tag with JSP EL to get the contextPath may be simpler, but this is an equivalent for s:link -->
+    <s:set var="pageContextPath"><%=((HttpServletRequest)request).getContextPath()%></s:set>
+    <s:link href="%{#pageContextPath}/css/bootstrap.min.css" rel="stylesheet"></s:link>
+    <s:link href="%{#pageContextPath}/css/app.css" rel="stylesheet"></s:link>
 
     <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->


### PR DESCRIPTION
Update:
- Fix REST Showcase JSP issue for s:link tags that replaced HTML link tags.
- s:link tags cannot use JSP EL in them.  Modified JSPs to use scriptlet, JSP expression, and OGNL expression to work with s:link tag.