### PR TITLE
Update log4j to 2.17.1 to address CVE-2021-44832.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
         <asm.version>9.2</asm.version>
         <jackson.version>2.10.5</jackson.version>
         <jackson-databind.version>2.10.5.1</jackson-databind.version>
-        <log4j2.version>2.17.0</log4j2.version>
+        <log4j2.version>2.17.1</log4j2.version>
         <ognl.version>3.2.20</ognl.version>
         <slf4j.version>1.7.32</slf4j.version>
         <spring.platformVersion>4.3.30.RELEASE</spring.platformVersion>


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2021-44832