### PR TITLE
[WW-5117] Evaluates dynamic attributes

### DIFF
--- a/core/src/main/java/org/apache/struts2/components/CheckboxList.java
+++ b/core/src/main/java/org/apache/struts2/components/CheckboxList.java
@@ -48,7 +48,7 @@ import com.opensymphony.xwork2.util.ValueStack;
         allowDynamicAttributes = true)
 public class CheckboxList extends ListUIBean {
     final public static String TEMPLATE = "checkboxlist";
-    
+
     public CheckboxList(ValueStack stack, HttpServletRequest request, HttpServletResponse response) {
         super(stack, request, response);
     }
@@ -56,9 +56,19 @@ public class CheckboxList extends ListUIBean {
     protected String getDefaultTemplate() {
         return TEMPLATE;
     }
-    
+
     public void evaluateExtraParams() {
     	super.evaluateExtraParams();
+    }
+
+    /**
+     * Checkboxlist tag requires lazy evaluation as list of tags is dynamically generated using <s:iterator/>
+     *
+     * @return boolean true by default
+     */
+    @Override
+    protected boolean lazyEvaluation() {
+        return true;
     }
 
 }

--- a/core/src/main/java/org/apache/struts2/components/ListUIBean.java
+++ b/core/src/main/java/org/apache/struts2/components/ListUIBean.java
@@ -188,7 +188,6 @@ public abstract class ListUIBean extends UIBean {
         this.listTitle = listTitle;
     }
 
-
     public void setThrowExceptionOnNullValueAttribute(boolean throwExceptionOnNullValueAttribute) {
         this.throwExceptionOnNullValueAttribute = throwExceptionOnNullValueAttribute;
     }

--- a/core/src/main/java/org/apache/struts2/components/Radio.java
+++ b/core/src/main/java/org/apache/struts2/components/Radio.java
@@ -57,7 +57,7 @@ import javax.servlet.http.HttpServletResponse;
         allowDynamicAttributes = true)
 public class Radio extends ListUIBean {
     final public static String TEMPLATE = "radiomap";
-    
+
     public Radio(ValueStack stack, HttpServletRequest request, HttpServletResponse response) {
         super(stack, request, response);
     }
@@ -65,8 +65,19 @@ public class Radio extends ListUIBean {
     protected String getDefaultTemplate() {
         return TEMPLATE;
     }
-    
+
     public void evaluateExtraParams() {
     	super.evaluateExtraParams();
     }
+
+    /**
+     * Radio tag requires lazy evaluation as list of tags is dynamically generated using <s:iterator/>
+     *
+     * @return boolean true by default
+     */
+    @Override
+    protected boolean lazyEvaluation() {
+        return true;
+    }
+
 }

--- a/core/src/main/java/org/apache/struts2/components/UIBean.java
+++ b/core/src/main/java/org/apache/struts2/components/UIBean.java
@@ -20,6 +20,7 @@ package org.apache.struts2.components;
 
 import com.opensymphony.xwork2.config.ConfigurationException;
 import com.opensymphony.xwork2.inject.Inject;
+import com.opensymphony.xwork2.util.TextParseUtil;
 import com.opensymphony.xwork2.util.ValueStack;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -1265,7 +1266,8 @@ public abstract class UIBean extends Component {
 
             if (!isValidTagAttribute(attrName)) {
                 if (ComponentUtils.altSyntax(getStack()) && ComponentUtils.containsExpression(attrValue) && !lazyEvaluation()) {
-                    dynamicAttributes.put(attrName, ObjectUtils.defaultIfNull(findString(attrValue), attrValue));
+                    String translated = TextParseUtil.translateVariables('%', attrValue, stack);
+                    dynamicAttributes.put(attrName, ObjectUtils.defaultIfNull(translated, attrValue));
                 } else {
                     dynamicAttributes.put(attrName, attrValue);
                 }

--- a/core/src/main/java/org/apache/struts2/components/UIBean.java
+++ b/core/src/main/java/org/apache/struts2/components/UIBean.java
@@ -21,6 +21,7 @@ package org.apache.struts2.components;
 import com.opensymphony.xwork2.config.ConfigurationException;
 import com.opensymphony.xwork2.inject.Inject;
 import com.opensymphony.xwork2.util.ValueStack;
+import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -30,6 +31,7 @@ import org.apache.struts2.components.template.Template;
 import org.apache.struts2.components.template.TemplateEngine;
 import org.apache.struts2.components.template.TemplateEngineManager;
 import org.apache.struts2.components.template.TemplateRenderingContext;
+import org.apache.struts2.util.ComponentUtils;
 import org.apache.struts2.util.TextProviderHelper;
 import org.apache.struts2.views.annotations.StrutsTagAttribute;
 import org.apache.struts2.views.util.ContextUtil;
@@ -1258,20 +1260,25 @@ public abstract class UIBean extends Component {
 
     public void setDynamicAttributes(Map<String, String> tagDynamicAttributes) {
         for (Map.Entry<String, String> entry : tagDynamicAttributes.entrySet()) {
-            String key = entry.getKey();
+            String attrName = entry.getKey();
+            String attrValue = entry.getValue();
 
-            if (!isValidTagAttribute(key)) {
-                dynamicAttributes.put(key, entry.getValue());
+            if (!isValidTagAttribute(attrName)) {
+                if (ComponentUtils.altSyntax(getStack()) && ComponentUtils.isExpression(attrValue)) {
+                    dynamicAttributes.put(attrName, String.valueOf(ObjectUtils.defaultIfNull(findString(attrValue), attrValue)));
+                } else {
+                    dynamicAttributes.put(attrName, attrValue);
+                }
             }
         }
     }
 
-    @Override
     /**
      * supports dynamic attributes for freemarker ui tags
-     * @see https://issues.apache.org/jira/browse/WW-3174
-     * @see https://issues.apache.org/jira/browse/WW-4166
+     * @see "https://issues.apache.org/jira/browse/WW-3174"
+     * @see "https://issues.apache.org/jira/browse/WW-4166"
      */
+    @Override
     public void copyParams(Map params) {
         super.copyParams(params);
         for (Object o : params.entrySet()) {

--- a/core/src/main/java/org/apache/struts2/components/UIBean.java
+++ b/core/src/main/java/org/apache/struts2/components/UIBean.java
@@ -1264,8 +1264,8 @@ public abstract class UIBean extends Component {
             String attrValue = entry.getValue();
 
             if (!isValidTagAttribute(attrName)) {
-                if (ComponentUtils.altSyntax(getStack()) && ComponentUtils.isExpression(attrValue)) {
-                    dynamicAttributes.put(attrName, String.valueOf(ObjectUtils.defaultIfNull(findString(attrValue), attrValue)));
+                if (ComponentUtils.altSyntax(getStack()) && ComponentUtils.containsExpression(attrValue) && !lazyEvaluation()) {
+                    dynamicAttributes.put(attrName, ObjectUtils.defaultIfNull(findString(attrValue), attrValue));
                 } else {
                     dynamicAttributes.put(attrName, attrValue);
                 }
@@ -1288,6 +1288,16 @@ public abstract class UIBean extends Component {
                 dynamicAttributes.put(key, entry.getValue());
             }
         }
+    }
+
+    /**
+     * Used to avoid evaluating attributes in {@link #evaluateParams()} or {@link #evaluateExtraParams()}
+     * as evaluation will happen in tag's template
+     *
+     * @return boolean false if evaluation should be performed in ftl
+     */
+    protected boolean lazyEvaluation() {
+        return false;
     }
 
 }

--- a/core/src/main/java/org/apache/struts2/components/template/FreemarkerTemplateEngine.java
+++ b/core/src/main/java/org/apache/struts2/components/template/FreemarkerTemplateEngine.java
@@ -148,16 +148,13 @@ public class FreemarkerTemplateEngine extends BaseTemplateEngine {
             }
         };
 
-        LOG.debug("Puts action on the top of ValueStack, just before the tag");
-        action = stack.pop();
+        LOG.debug("Push tag on top of the stack");
         stack.push(templateContext.getTag());
-        stack.push(action);
         try {
             template.process(model, writer);
         } finally {
-            stack.pop(); // removes action
-            stack.pop(); // removes tag
-            stack.push(action); // puts back action
+            LOG.debug("Removes tag from top of the stack");
+            stack.pop();
         }
     }
 

--- a/core/src/main/resources/template/simple/checkboxlist.ftl
+++ b/core/src/main/resources/template/simple/checkboxlist.ftl
@@ -30,7 +30,7 @@
         <#assign itemKeyStr = stack.findString('top')>
     </#if>
     <#if parameters.listLabelKey??>
-    <#-- checks the valueStack for the 'valueKey.' The valueKey is then looked-up in the locale 
+    <#-- checks the valueStack for the 'valueKey.' The valueKey is then looked-up in the locale
        file for it's localized value.  This is then used as a label -->
         <#assign itemValue = struts.getText(stack.findString(parameters.listLabelKey))/>
     <#elseif parameters.listValue??>
@@ -95,9 +95,10 @@
     <#include "/${parameters.templateDir}/${parameters.expandTheme}/css.ftl" />
     <#include "/${parameters.templateDir}/${parameters.expandTheme}/scripting-events.ftl" />
     <#include "/${parameters.templateDir}/${parameters.expandTheme}/common-attributes.ftl" />
+    <#global evaluate_dynamic_attributes = true/>
     <#include "/${parameters.templateDir}/${parameters.expandTheme}/dynamic-attributes.ftl" />
         />
-<label<#rt/> 
+<label<#rt/>
     <#if parameters.id?has_content>
         for="${parameters.id?html}-${itemCount}"<#rt/>
     <#else>
@@ -106,7 +107,6 @@
         class="checkboxLabel">${itemValue?html}</label>
 </@s.iterator>
     <#else>
-    &nbsp;
 </#if>
 <input type="hidden" id="__multiselect_${parameters.id?html}" name="__multiselect_${parameters.name?html}"
        value=""<#rt/>

--- a/core/src/main/resources/template/simple/dynamic-attributes.ftl
+++ b/core/src/main/resources/template/simple/dynamic-attributes.ftl
@@ -23,9 +23,13 @@
 <#list aKeys as aKey><#rt/>
   <#assign keyValue = parameters.dynamicAttributes.get(aKey)/>
   <#if keyValue?is_string>
-      <#assign value = struts.translateVariables(keyValue)!keyValue/>
+    <#if evaluate_dynamic_attributes!false == true>
+      <#assign value = struts.translateVariables(keyValue)!keyValue/><#rt/>
+    <#else>
+      <#assign value = keyValue/><#rt/>
+    </#if>
   <#else>
-      <#assign value = keyValue?string/>
+    <#assign value = keyValue?string/><#rt/>
   </#if>
  ${aKey}="${value?html}"<#rt/>
 </#list><#rt/>

--- a/core/src/main/resources/template/simple/radiomap.ftl
+++ b/core/src/main/resources/template/simple/radiomap.ftl
@@ -27,7 +27,7 @@
         <#assign itemKeyStr = stack.findString('top')>
     </#if>
     <#if parameters.listValueKey??>
-        <#-- checks the valueStack for the 'valueKey.' The valueKey is then looked-up in the locale 
+        <#-- checks the valueStack for the 'valueKey.' The valueKey is then looked-up in the locale
              file for it's localized value.  This is then used as a label -->
         <#assign valueKey = stack.findString(parameters.listValueKey)!''/>
         <#if valueKey?has_content>
@@ -94,6 +94,7 @@
 <#include "/${parameters.templateDir}/${parameters.expandTheme}/css.ftl" />
 <#include "/${parameters.templateDir}/${parameters.expandTheme}/scripting-events.ftl" />
 <#include "/${parameters.templateDir}/${parameters.expandTheme}/common-attributes.ftl" />
+<#global evaluate_dynamic_attributes = true/>
 <#include "/${parameters.templateDir}/${parameters.expandTheme}/dynamic-attributes.ftl" />
 /><#rt/>
 <label for="${parameters.id?html}${itemKeyStr?html}"<#include "/${parameters.templateDir}/${parameters.expandTheme}/css.ftl"/>><#rt/>

--- a/core/src/test/java/org/apache/struts2/views/jsp/ui/TextfieldTest.java
+++ b/core/src/test/java/org/apache/struts2/views/jsp/ui/TextfieldTest.java
@@ -92,7 +92,7 @@ public class TextfieldTest extends AbstractUITagTest {
 
         verify(TextFieldTag.class.getResource("Textfield-3.txt"));
     }
-    
+
     public void testLabelSeparatorJsp() throws Exception {
         TestAction testAction = (TestAction) action;
         testAction.setFoo("bar");
@@ -172,13 +172,14 @@ public class TextfieldTest extends AbstractUITagTest {
         tag.setName("myname");
         tag.setValue("%{foo}");
         tag.setSize("10");
+        tag.setDynamicAttribute(null, "anotherAttr", "another_%{foo}");
 
         tag.doStartTag();
         tag.doEndTag();
 
         verify(TextFieldTag.class.getResource("Textfield-5.txt"));
     }
-    
+
     public void testSimple_recursionTestNoValue() throws Exception {
         TestAction testAction = (TestAction) action;
         testAction.setFoo("%{1+1}");

--- a/core/src/test/resources/org/apache/struts2/views/jsp/ui/Textfield-5.txt
+++ b/core/src/test/resources/org/apache/struts2/views/jsp/ui/Textfield-5.txt
@@ -1,4 +1,4 @@
 <tr>
     <td class="tdLabel"><label for="myname" class="label">mylabel:</label></td>
-    <td class="tdInput"><input type="text" name="myname" size="10" value="%{1+1}" id="myname"/></td>
+    <td class="tdInput"><input type="text" name="myname" size="10" value="%{1+1}" id="myname" anotherAttr="another_%{1+1}"/></td>
 </tr>


### PR DESCRIPTION
This PR introduces conditional lazy evaluation of some tag's attributes (e.g.: _dynamic attributes_) to avoid double evaluation vulnerability.

Reverts changes in #475 and fixes [WW-5117](https://issues.apache.org/jira/browse/WW-5117)