### PR TITLE
Basic LocalDateTime support

### DIFF
--- a/core/src/main/java/com/opensymphony/xwork2/conversion/impl/DateConverter.java
+++ b/core/src/main/java/com/opensymphony/xwork2/conversion/impl/DateConverter.java
@@ -152,8 +152,8 @@ public class DateConverter extends DefaultTypeConverter {
         if (tp != null) {
             String globalFormat = tp.getText(dateTagProperty);
             // if tp.getText can not find the property then the returned string
-            // is the same as input = DATETAG_PROPERTY (blank to suppress tp warnings)
-            if (globalFormat != null && !"".equals(globalFormat) && !dateTagProperty.equals(globalFormat)) {
+            // is the same as input = DATETAG_PROPERTY
+            if (globalFormat != null && !dateTagProperty.equals(globalFormat)) {
                 LOG.debug("Found \"{}\" as \"{}\"", dateTagProperty, globalFormat);
                 globalDateString = globalFormat;
             } else {
@@ -210,22 +210,11 @@ public class DateConverter extends DefaultTypeConverter {
      * @return a list of DateTimeFormatter to be used for date conversion
      */
     private DateTimeFormatter[] getLocalDateFormats(ActionContext context, Locale locale) {
-        DateTimeFormatter globalDateFormat = null;
-        String globalFormat = getGlobalDateString(context);
-        if (globalFormat != null) {
-            globalDateFormat = DateTimeFormatter.ofPattern(globalFormat, locale);
-        }
 
         // Basic support LocalDateTime.now()
         DateTimeFormatter df1 = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
 
-        final DateTimeFormatter[] dateFormats;
-
-        if (globalDateFormat == null) {
-            dateFormats = new DateTimeFormatter[] { df1 };
-        } else {
-            dateFormats = new DateTimeFormatter[] { globalDateFormat, df1 };
-        }
+        final DateTimeFormatter[] dateFormats = new DateTimeFormatter[] { df1 };
 
         return dateFormats;
     }

--- a/core/src/main/java/com/opensymphony/xwork2/conversion/impl/DateConverter.java
+++ b/core/src/main/java/com/opensymphony/xwork2/conversion/impl/DateConverter.java
@@ -152,8 +152,8 @@ public class DateConverter extends DefaultTypeConverter {
         if (tp != null) {
             String globalFormat = tp.getText(dateTagProperty);
             // if tp.getText can not find the property then the returned string
-            // is the same as input = DATETAG_PROPERTY
-            if (globalFormat != null && !dateTagProperty.equals(globalFormat)) {
+            // is the same as input = DATETAG_PROPERTY (blank to suppress tp warnings)
+            if (globalFormat != null && !"".equals(globalFormat) && !dateTagProperty.equals(globalFormat)) {
                 LOG.debug("Found \"{}\" as \"{}\"", dateTagProperty, globalFormat);
                 globalDateString = globalFormat;
             } else {
@@ -174,6 +174,7 @@ public class DateConverter extends DefaultTypeConverter {
     private DateFormat[] getDateFormats(ActionContext context, Locale locale) {
         DateFormat globalDateFormat = null;
         String globalFormat = getGlobalDateString(context);
+        //
         if (globalFormat != null) {
             globalDateFormat = new SimpleDateFormat(globalFormat, locale);
         }

--- a/core/src/main/java/com/opensymphony/xwork2/conversion/impl/DateConverter.java
+++ b/core/src/main/java/com/opensymphony/xwork2/conversion/impl/DateConverter.java
@@ -214,7 +214,7 @@ public class DateConverter extends DefaultTypeConverter {
      * 
      * @return a list of DateTimeFormatter to be used for date conversion
      */
-    private DateTimeFormatter[] getDateTimeFormats(ActionContext context, Locale locale) {
+    protected DateTimeFormatter[] getDateTimeFormats(ActionContext context, Locale locale) {
 
         DateTimeFormatter df1 = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
 

--- a/core/src/main/java/com/opensymphony/xwork2/conversion/impl/XWorkBasicConverter.java
+++ b/core/src/main/java/com/opensymphony/xwork2/conversion/impl/XWorkBasicConverter.java
@@ -25,6 +25,7 @@ import com.opensymphony.xwork2.inject.Inject;
 import org.apache.struts2.StrutsConstants;
 
 import java.lang.reflect.Member;
+import java.time.LocalDateTime;
 import java.util.Calendar;
 import java.util.Collection;
 import java.util.Date;
@@ -98,6 +99,8 @@ public class XWorkBasicConverter extends DefaultTypeConverter {
         } else if (toType.isArray()) {
             result = doConvertToArray(context, o, member, propertyName, value, toType);
         } else if (Date.class.isAssignableFrom(toType)) {
+            result = doConvertToDate(context, value, toType);
+        } else if (LocalDateTime.class.isAssignableFrom(toType)) {
             result = doConvertToDate(context, value, toType);
         } else if (Calendar.class.isAssignableFrom(toType)) {
             result = doConvertToCalendar(context, value);

--- a/core/src/main/java/com/opensymphony/xwork2/interceptor/ParametersInterceptor.java
+++ b/core/src/main/java/com/opensymphony/xwork2/interceptor/ParametersInterceptor.java
@@ -201,7 +201,7 @@ public class ParametersInterceptor extends MethodFilterInterceptor {
             ReflectionContextState.setReportingConversionErrors(context, true);
 
             //keep locale from original context
-            newStack.getActionContext().withLocale(stack.getActionContext().getLocale());
+            newStack.getActionContext().withLocale(stack.getActionContext().getLocale()).withValueStack(stack);
         }
 
         boolean memberAccessStack = newStack instanceof MemberAccessValueStack;

--- a/core/src/test/java/com/opensymphony/xwork2/conversion/impl/DateConverterTest.java
+++ b/core/src/test/java/com/opensymphony/xwork2/conversion/impl/DateConverterTest.java
@@ -28,6 +28,7 @@ import org.apache.struts2.conversion.TypeConversionException;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.text.DateFormat;
+import java.time.LocalDateTime;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Locale;
@@ -43,6 +44,9 @@ public class DateConverterTest extends StrutsInternalTestCase {
     private final static String DATE_STR = "2020-03-20";
     private final static String DATE_CONVERTED = "Fri Mar 20 00:00:00";
     private final static String INVALID_DATE = "99/99/2010";
+    private final static String LOCALDATETIME_STR = "2020-03-20T00:00:00.000000";
+    private final static String LOCALDATETIME_CONVERTED = "2020-03-20T00:00";
+    private final static String INVALID_LOCALDATETIME = "2010-99-99T00:00";
     private final static String MESSAGE_PARSE_ERROR = "Could not parse date";
     private final static String MESSAGE_DEFAULT_CONSTRUCTOR_ERROR = "Couldn't create class null using default (long) constructor";
 
@@ -115,6 +119,43 @@ public class DateConverterTest extends StrutsInternalTestCase {
         } catch (Exception ex) {
             assertEquals(TypeConversionException.class, ex.getClass());
             assertEquals(MESSAGE_DEFAULT_CONSTRUCTOR_ERROR, ex.getMessage());
+        }
+    }
+
+    public void testLocalDateTimeType() {
+        DateConverter converter = new DateConverter();
+
+        Map<String, String> map = new HashMap<>();
+        map.put(org.apache.struts2.components.Date.DATETAG_PROPERTY, "yyyy-MM-dd");
+        ValueStack stack = new StubValueStack();
+        stack.push(new StubTextProvider(map));
+
+        ActionContext context = ActionContext.of(new HashMap<>())
+            .withLocale(new Locale("es_MX", "MX"))
+            .withValueStack(stack);
+
+        Object value = converter.convertValue(context.getContextMap(), null, null, null, LOCALDATETIME_STR, LocalDateTime.class);
+        assertTrue(value.toString().startsWith(LOCALDATETIME_CONVERTED));
+    }
+
+    public void testLocalDateTimeTypeConversionExceptionWhenParseError() {
+        DateConverter converter = new DateConverter();
+
+        Map<String, String> map = new HashMap<>();
+        map.put(org.apache.struts2.components.Date.DATETAG_PROPERTY, "yyyy-MM-dd");
+        ValueStack stack = new StubValueStack();
+        stack.push(new StubTextProvider(map));
+
+        ActionContext context = ActionContext.of(new HashMap<>())
+            .withLocale(new Locale("es_MX", "MX"))
+            .withValueStack(stack);
+
+        try {
+            converter.convertValue(context.getContextMap(), null, null, null, INVALID_LOCALDATETIME, LocalDateTime.class);
+            fail("TypeConversionException expected - Conversion error occurred");
+        } catch (Exception ex) {
+            assertEquals(TypeConversionException.class, ex.getClass());
+            assertEquals(MESSAGE_PARSE_ERROR, ex.getMessage());
         }
     }
 


### PR DESCRIPTION
Add support for LocalDateTime for the LocalDateTime.now() variant. DateTimeFormatter.ISO_LOCAL_DATE_TIME.

See [WW-5175](https://issues.apache.org/jira/browse/WW-5175)