### PR TITLE
make expressionMaxLength enabled by default

### DIFF
--- a/core/src/main/resources/org/apache/struts2/default.properties
+++ b/core/src/main/resources/org/apache/struts2/default.properties
@@ -235,13 +235,13 @@ struts.handle.exception=true
 
 ### Applies maximum length allowed on OGNL expressions for security enhancement (optional)
 ###
-### **WARNING**: If developers enable this option (by configuration) they should make sure that they understand the implications of setting
+### **WARNING**: If developers disabled this option (by configuration) they should make sure that they understand the implications of setting
 ###   struts.ognl.expressionMaxLength.  They must choose a value large enough to permit ALL valid OGNL expressions used within the application.
 ###   Values larger than the 200-400 range have diminishing security value (at which point it is really only a "style guard" for long OGNL
 ###   expressions in an application.  Setting a value of null or "" will also disable the feature.
 ###
-### NOTE: The sample line below is *INTENTIONALLY* commented out, as this feature is disabled by default.
-# struts.ognl.expressionMaxLength=256
+### NOTE: The sample line below is *INTENTIONALLY* commented out, as this feature is enabled by default.
+struts.ognl.expressionMaxLength=256
 
 ### Defines which named instance of DateFormatter to use, there are two instances:
 ### - simpleDateFormatter (based on SimpleDateFormat)


### PR DESCRIPTION
struts.ognl.expressionMaxLength enabled by default to block unknow 0day