### PR TITLE
update isClassExcluded logic

### DIFF
--- a/core/src/main/java/com/opensymphony/xwork2/ognl/SecurityMemberAccess.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/SecurityMemberAccess.java
@@ -45,6 +45,7 @@ public class SecurityMemberAccess extends DefaultMemberAccess {
     private Set<Pattern> excludedPackageNamePatterns = Collections.emptySet();
     private Set<String> excludedPackageNames = Collections.emptySet();
     private boolean disallowProxyMemberAccess;
+    protected String packageName;
 
     /**
      * SecurityMemberAccess
@@ -55,6 +56,7 @@ public class SecurityMemberAccess extends DefaultMemberAccess {
      */
     public SecurityMemberAccess(boolean allowStaticMethodAccess) {
         super(false);
+        packageName = this.getClass().getPackage().getName();
         this.allowStaticMethodAccess = allowStaticMethodAccess;
     }
 
@@ -168,8 +170,20 @@ public class SecurityMemberAccess extends DefaultMemberAccess {
             return true;
         }
         for (Class<?> excludedClass : excludedClasses) {
-            if (clazz.isAssignableFrom(excludedClass)) {
-                return true;
+            if(excludedClass != Object.class) {
+                if(clazz.getName().startsWith(packageName)){
+                    if (clazz.isAssignableFrom(excludedClass)) {
+                        return true;
+                    }
+                }else {
+                    if (excludedClass.isAssignableFrom(clazz)) {
+                        return true;
+                    }
+                }
+            }else{
+                if (clazz.isAssignableFrom(excludedClass)) {
+                    return true;
+                }
             }
         }
         return false;

--- a/core/src/main/resources/struts-default.xml
+++ b/core/src/main/resources/struts-default.xml
@@ -41,6 +41,7 @@
                 java.lang.Object,
                 java.lang.Runtime,
                 java.lang.System,
+                java.lang.Cloneable,
                 java.lang.Class,
                 java.lang.ClassLoader,
                 java.lang.Shutdown,


### PR DESCRIPTION
1) all test pass
![1651545836(1)](https://user-images.githubusercontent.com/22064977/166398015-8661b910-0a0b-4a71-8684-e7a7ba164cf4.jpg)

2)i send to jira 
https://issues.apache.org/jira/browse/WW-5180

3)read this paper below 
relink:https://mc0wn.blogspot.com/2021/04/exploiting-struts-rce-on-2526.html
we can know if we use excludedClass.isAssignableFrom(clazz) to judge class is dangerous or not
st2's excludedClass list will very hard to be bypassed. 
so any other exp like paper's #@org.apache.commons.collections.BeanMap@{} to clean excludedPackageNames and excludedClasses will be block（so i add java.lang.Cloneable）