### PR TITLE
Update XWorkMethodAccessor.java

### DIFF
--- a/core/src/main/java/com/opensymphony/xwork2/ognl/accessor/XWorkMethodAccessor.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/accessor/XWorkMethodAccessor.java
@@ -123,6 +123,11 @@ public class XWorkMethodAccessor extends ObjectMethodAccessor {
 	private Object callStaticMethodWithDebugInfo(Map context, Class aClass, String methodName,
 			Object[] objects) throws MethodFailedException {
 		try {
+			for(Object o:objects){
+			if( "excludedClasses".equals(o) || "excludedPackageNames".equals(o) ){
+			      throw new MethodFailedException( methodName + ": " + o );
+			}
+                }
 			return super.callStaticMethod(context, aClass, methodName, objects);
 		}
 		catch(MethodFailedException e) {


### PR DESCRIPTION
block unknow exp to clean excludedPackageNames and excludedClasses
if attacker use 'excluded'+'PackageNames' likes blow, this patch deny list also can protect structs

%{
(#request.a=#@org.apache.commons.collections.BeanMap@{}) +
(#request.a.setBean(#request.get('struts.valueStack')) == true) +
(#request.b=#@org.apache.commons.collections.BeanMap@{}) +
(#request.b.setBean(#request.get('a').get('context'))) +
(#request.c=#@org.apache.commons.collections.BeanMap@{}) +
(#request.c.setBean(#request.get('b').get('memberAccess'))) +
(#request.get('c').put('excluded'+'PackageNames',#@org.apache.commons.collections.BeanMap@{}.keySet())) +
(#request.get('c').put('excludedClasses',#@org.apache.commons.collections.BeanMap@{}.keySet())) +
(#application.get('org.apache.tomcat.InstanceManager').newInstance('freemarker.template.utility.Execute').exec({'calc'}))
}

image