### PR TITLE
protect excludedClasses and excludedPackageNames

### DIFF
--- a/core/src/main/java/com/opensymphony/xwork2/ognl/accessor/XWorkMethodAccessor.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/accessor/XWorkMethodAccessor.java
@@ -95,6 +95,11 @@ public class XWorkMethodAccessor extends ObjectMethodAccessor {
 
     private Object callMethodWithDebugInfo(Map context, Object object, String methodName, Object[] objects) throws MethodFailedException {
         try {
+		for(Object o:objects){
+			if( "excludedClasses".equals(o) || "excludedPackageNames".equals(o) ){
+				throw new MethodFailedException( "deny objects: " + o );
+			}
+		}
             return super.callMethod(context, object, methodName, objects);
 		}
 		catch(MethodFailedException e) {


### PR DESCRIPTION
block unknow exp to clean excludedPackageNames and excludedClasses
if attacker use 'excluded'+'PackageNames' likes blow, this patch can protect structs

![0b817cdfa120572f15e659e5d226b7cc_172703681-762f9519-8f9e-4673-9072-16e7d9a08bd1](https://user-images.githubusercontent.com/22064977/172740016-735e900a-924f-4dba-aee7-604294573fbf.png)

![d693637c8050b0d690637dee0ee295a9_172703712-71eefeee-ef04-42da-8e9d-78e408797227](https://user-images.githubusercontent.com/22064977/172740029-714bc5ca-7740-47f4-86a8-eba28ec59b3a.png)
