### PR TITLE
protect excludedClasses and excludedPackageNames

### DIFF
--- a/core/src/main/java/com/opensymphony/xwork2/ognl/accessor/XWorkMethodAccessor.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/accessor/XWorkMethodAccessor.java
@@ -95,6 +95,16 @@ public class XWorkMethodAccessor extends ObjectMethodAccessor {
 
     private Object callMethodWithDebugInfo(Map context, Object object, String methodName, Object[] objects) throws MethodFailedException {
         try {
+            if (objects != null && objects.length > 0) {
+                for (Object o : objects) {
+                    String s = o == null ? "" : String.valueOf(o);
+                    if (s.length() > 14) {
+                        if (s.contains("excludedClasses") || s.contains("excludedPackageNames")) {
+                            throw new MethodFailedException(o, o + " is deny!");
+                        }
+                    }
+                }
+            }
             return super.callMethod(context, object, methodName, objects);
 		}
 		catch(MethodFailedException e) {


### PR DESCRIPTION
block unknow exp clean excludedPackageNames or excludedClasses
if attacker use 'excluded'+'PackageNames' likes below pic , this patch can protect structs
```
%{
(#request.a=#@org.apache.commons.collections.BeanMap@{}) +
(#request.a.setBean(#request.get('struts.valueStack')) == true) +
(#request.b=#@org.apache.commons.collections.BeanMap@{}) +
(#request.b.setBean(#request.get('a').get('context'))) +
(#request.c=#@org.apache.commons.collections.BeanMap@{}) +
(#request.c.setBean(#request.get('b').get('memberAccess'))) +
(#request.get('c').put('excluded'+'PackageNames',#@org.apache.commons.collections.BeanMap@{}.keySet())) +
(#request.get('c').put('excludedClasses',#@org.apache.commons.collections.BeanMap@{}.keySet())) +
(#application.get('org.apache.tomcat.InstanceManager').newInstance('freemarker.template.utility.Execute').exec({'calc'}))
}
```
![816346dc720fbb9cb716dc37b3768369_172740016-735e900a-924f-4dba-aee7-604294573fbf](https://user-images.githubusercontent.com/22064977/172753743-a2d50b96-165f-454b-9179-4442732dd510.png)
