### PR TITLE
update xstream to 1.4.19

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1035,7 +1035,7 @@
             <dependency>
                 <groupId>com.thoughtworks.xstream</groupId>
                 <artifactId>xstream</artifactId>
-                <version>1.4.17</version>
+                <version>1.4.19</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
vulns CVE-2021-43859
ref link:http://x-stream.github.io/changes.html