### PR TITLE
[WW-5191] Fixes placement of maxLength and minLength attributes in <s:textarea/> tag

### DIFF
--- a/core/src/main/java/org/apache/struts2/views/jsp/ui/TextareaTag.java
+++ b/core/src/main/java/org/apache/struts2/views/jsp/ui/TextareaTag.java
@@ -73,7 +73,7 @@ public class TextareaTag extends AbstractUITag {
     public void setWrap(String wrap) {
         this.wrap = wrap;
     }
-    
+
     public void setMaxlength(String maxlength) {
         this.maxlength = maxlength;
     }
@@ -100,6 +100,8 @@ public class TextareaTag extends AbstractUITag {
         this.readonly = null;
         this.rows = null;
         this.wrap = null;
+        this.maxlength = null;
+        this.minlength = null;
     }
 
 }

--- a/core/src/main/resources/template/simple/textarea.ftl
+++ b/core/src/main/resources/template/simple/textarea.ftl
@@ -45,17 +45,17 @@
 <#if parameters.title?has_content>
  title="${parameters.title}"<#rt/>
 </#if>
+<#if parameters.maxlength?has_content>
+ maxlength="${parameters.maxlength}"<#rt/>
+</#if>
+<#if parameters.minlength?has_content>
+ minlength="${parameters.minlength}"<#rt/>
+</#if>
 <#include "/${parameters.templateDir}/${parameters.expandTheme}/scripting-events.ftl" />
 <#include "/${parameters.templateDir}/${parameters.expandTheme}/common-attributes.ftl" />
 <#include "/${parameters.templateDir}/${parameters.expandTheme}/dynamic-attributes.ftl" />
 ><#rt/>
 <#if parameters.nameValue??>
 <@s.property value="parameters.nameValue"/><#t/>
-</#if>
-<#if parameters.maxlength?has_content>
- maxlength="${parameters.maxlength}"<#rt/>
-</#if>
-<#if parameters.minlength?has_content>
- minlength="${parameters.minlength}"<#rt/>
 </#if>
 </textarea>

--- a/core/src/test/java/org/apache/struts2/views/jsp/ui/TextareaTest.java
+++ b/core/src/test/java/org/apache/struts2/views/jsp/ui/TextareaTest.java
@@ -47,6 +47,8 @@ public class TextareaTest extends AbstractUITagTest {
         tag.setId("the_id");
         tag.setOnkeyup("alert('hello');");
         tag.setReadonly("true");
+        tag.setMaxlength("100");
+        tag.setMinlength("10");
 
         tag.doStartTag();
         tag.doEndTag();
@@ -81,6 +83,8 @@ public class TextareaTest extends AbstractUITagTest {
         tag.setId("the_id");
         tag.setOnkeyup("alert('hello');");
         tag.setReadonly("true");
+        tag.setMaxlength("100");
+        tag.setMinlength("10");
 
         tag.doStartTag();
         setComponentTagClearTagState(tag, true);  // Ensure component tag state clearing is set true (to match tag).

--- a/core/src/test/resources/org/apache/struts2/views/jsp/ui/Textarea-1.txt
+++ b/core/src/test/resources/org/apache/struts2/views/jsp/ui/Textarea-1.txt
@@ -1,4 +1,4 @@
 <tr>
     <td class="tdLabel"><label for="the_id" class="label">mylabel:</label></td>
-    <td class="tdInput"><textarea name="myname" cols="20" rows="30" disabled="disabled" readonly="readonly" tabindex="5" id="the_id" title="mytitle" onclick="alert('onclick');" onkeyup="alert('hello');" onchange="alert('goodbye');">bar</textarea></td>
+    <td class="tdInput"><textarea name="myname" cols="20" rows="30" disabled="disabled" readonly="readonly" tabindex="5" id="the_id" title="mytitle" maxlength="100" minlength="10" onclick="alert('onclick');" onkeyup="alert('hello');" onchange="alert('goodbye');">bar</textarea></td>
 </tr>


### PR DESCRIPTION
Fixes [WW-5191](https://issues.apache.org/jira/browse/WW-5191)