### PR TITLE
[WW-5205] - Reverting injection refactor of internal bean

### DIFF
--- a/plugins/rest/src/main/java/org/apache/struts2/rest/ContentTypeInterceptor.java
+++ b/plugins/rest/src/main/java/org/apache/struts2/rest/ContentTypeInterceptor.java
@@ -34,10 +34,10 @@ import java.io.InputStreamReader;
  */
 public class ContentTypeInterceptor extends AbstractInterceptor {
 
-    private final ContentTypeHandlerManager selector;
+    private ContentTypeHandlerManager selector;
 
     @Inject
-    public ContentTypeInterceptor(ContentTypeHandlerManager selector) {
+    public void setContentTypeHandlerSelector(ContentTypeHandlerManager selector) {
         this.selector = selector;
     }
 


### PR DESCRIPTION
In commit e9d0a5518cd0671d9ad0353a2c87246ef0d2061b ContentTypeHandlerManager has been changed from setter-injected to constructor-injected.
However, at least with spring as the object factory, that bean was an internal bean not available from the factory, injected post construction.
In the 6.0.0 implementation ContentTypeInterceptor cannot be instantiated since its dependency cannot be resolved:
```
org.springframework.beans.factory.UnsatisfiedDependencyException

Error creating bean with name 'org.apache.struts2.rest.ContentTypeInterceptor': Unsatisfied dependency expressed through constructor parameter 0; nested exception is org.springframework.beans.factory.NoSuchBeanDefinitionException: No qualifying bean of type 'org.apache.struts2.rest.ContentTypeHandlerManager' available: expected at least 1 bean which qualifies as autowire candidate. Dependency annotations: {}
```
This commit attempts to revert that change.