### PR TITLE
WW-5208 Update hibernate-validator to 6.2.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
         <tiles.version>3.0.8</tiles.version>
         <tiles-request.version>1.0.7</tiles-request.version>
         <maven-surefire-plugin.version>3.0.0-M4</maven-surefire-plugin.version>
-        <hibernate-validator.version>6.1.3.Final</hibernate-validator.version>
+        <hibernate-validator.version>6.2.4.Final</hibernate-validator.version>
 
         <!-- Site generation -->
         <fluido-skin.version>1.9</fluido-skin.version>


### PR DESCRIPTION
b/c 6.1 has reached its end-of-life according to
https://hibernate.org/validator/releases/6.1/

6.2 is compatible with the given Java and Jakarta
versions and supports `javax.validation.*` according to
https://hibernate.org/validator/releases/6.2/