### PR TITLE
[WW-5235] Uses debug log level when setting expression max length to avoid cluttering logs

### DIFF
--- a/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlUtil.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlUtil.java
@@ -268,10 +268,10 @@ public class OgnlUtil {
         try {
             if (maxLength == null || maxLength.isEmpty()) {
                 Ognl.applyExpressionMaxLength(null);
-                LOG.info("OGNL Expression Max Length disabled.");
+                LOG.warn("OGNL Expression Max Length disabled.");
             } else {
                 Ognl.applyExpressionMaxLength(Integer.parseInt(maxLength));
-                LOG.info("OGNL Expression Max Length enabled with {}.", maxLength);
+                LOG.debug("OGNL Expression Max Length enabled with {}.", maxLength);
             }
         } catch (Exception ex) {
             LOG.error("Unable to set OGNL Expression Max Length {}.", maxLength);  // Help configuration debugging.


### PR DESCRIPTION
Fixes [WW-5235](https://issues.apache.org/jira/browse/WW-5235)