### PR TITLE
[WW-5242] Marks struts.mapper.action.prefix.crossNamespaces as deprecated

### DIFF
--- a/core/src/main/java/org/apache/struts2/dispatcher/mapper/DefaultActionMapper.java
+++ b/core/src/main/java/org/apache/struts2/dispatcher/mapper/DefaultActionMapper.java
@@ -236,6 +236,11 @@ public class DefaultActionMapper implements ActionMapper {
         this.allowActionPrefix = BooleanUtils.toBoolean(allowActionPrefix);
     }
 
+    /**
+     * @deprecated since 6.1.0 - please refactor your application to avoid using this functionality
+     * @param allowActionCrossNamespaceAccess true to enable cross namespace action access
+     */
+    @Deprecated
     @Inject(value = StrutsConstants.STRUTS_MAPPER_ACTION_PREFIX_CROSSNAMESPACES)
     public void setAllowActionCrossNamespaceAccess(String allowActionCrossNamespaceAccess) {
         this.allowActionCrossNamespaceAccess = BooleanUtils.toBoolean(allowActionCrossNamespaceAccess);


### PR DESCRIPTION
Fixes [WW-5242](https://issues.apache.org/jira/browse/WW-5242)