### PR TITLE
[WW-4514] Fixes building query string with empty parameters

### DIFF
--- a/core/src/main/java/com/opensymphony/xwork2/config/providers/StrutsDefaultConfigurationProvider.java
+++ b/core/src/main/java/com/opensymphony/xwork2/config/providers/StrutsDefaultConfigurationProvider.java
@@ -118,6 +118,8 @@ import org.apache.struts2.conversion.StrutsTypeConverterCreator;
 import org.apache.struts2.conversion.StrutsTypeConverterHolder;
 import org.apache.struts2.dispatcher.HttpParameters;
 import org.apache.struts2.dispatcher.Parameter;
+import org.apache.struts2.url.ParametersStringBuilder;
+import org.apache.struts2.url.StrutsParametersStringBuilder;
 import org.apache.struts2.url.StrutsUrlDecoder;
 import org.apache.struts2.url.StrutsUrlEncoder;
 import org.apache.struts2.url.UrlDecoder;
@@ -234,6 +236,7 @@ public class StrutsDefaultConfigurationProvider implements ConfigurationProvider
 
             .factory(ValueSubstitutor.class, EnvsValueSubstitutor.class, Scope.SINGLETON)
 
+            .factory(ParametersStringBuilder.class, StrutsParametersStringBuilder.class, Scope.SINGLETON)
             .factory(UrlEncoder.class, StrutsUrlEncoder.class, Scope.SINGLETON)
             .factory(UrlDecoder.class, StrutsUrlDecoder.class, Scope.SINGLETON)
         ;

--- a/core/src/main/java/org/apache/struts2/StrutsConstants.java
+++ b/core/src/main/java/org/apache/struts2/StrutsConstants.java
@@ -458,6 +458,7 @@ public final class StrutsConstants {
     /** See {@link org.apache.struts2.components.Date#setDateFormatter(DateFormatter)} */
     public static final String STRUTS_DATE_FORMATTER = "struts.date.formatter";
 
+    public static final String STRUTS_URL_PARAMETERS_STRING_BUILDER = "struts.url.parametersStringBuilder";
     public static final String STRUTS_URL_ENCODER = "struts.url.encoder";
     public static final String STRUTS_URL_DECODER = "struts.url.decoder";
 }

--- a/core/src/main/java/org/apache/struts2/config/StrutsBeanSelectionProvider.java
+++ b/core/src/main/java/org/apache/struts2/config/StrutsBeanSelectionProvider.java
@@ -66,6 +66,7 @@ import org.apache.struts2.dispatcher.DispatcherErrorHandler;
 import org.apache.struts2.dispatcher.StaticContentLoader;
 import org.apache.struts2.dispatcher.mapper.ActionMapper;
 import org.apache.struts2.dispatcher.multipart.MultiPartRequest;
+import org.apache.struts2.url.ParametersStringBuilder;
 import org.apache.struts2.url.UrlDecoder;
 import org.apache.struts2.url.UrlEncoder;
 import org.apache.struts2.util.ContentTypeMatcher;
@@ -431,6 +432,7 @@ public class StrutsBeanSelectionProvider extends AbstractBeanSelectionProvider {
         alias(ExpressionCacheFactory.class, StrutsConstants.STRUTS_OGNL_EXPRESSION_CACHE_FACTORY, builder, props, Scope.SINGLETON);
         alias(BeanInfoCacheFactory.class, StrutsConstants.STRUTS_OGNL_BEANINFO_CACHE_FACTORY, builder, props, Scope.SINGLETON);
 
+        alias(ParametersStringBuilder.class, StrutsConstants.STRUTS_URL_PARAMETERS_STRING_BUILDER, builder, props, Scope.SINGLETON);
         alias(UrlEncoder.class, StrutsConstants.STRUTS_URL_ENCODER, builder, props, Scope.SINGLETON);
         alias(UrlDecoder.class, StrutsConstants.STRUTS_URL_DECODER, builder, props, Scope.SINGLETON);
 

--- a/core/src/main/java/org/apache/struts2/url/ParametersStringBuilder.java
+++ b/core/src/main/java/org/apache/struts2/url/ParametersStringBuilder.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.struts2.url;
+
+import java.util.Map;
+
+/**
+ * A builder used to create a proper query string out of a set of parameters
+ * @since Struts 6.1.0
+ */
+public interface ParametersStringBuilder {
+
+    void buildParametersString(Map<String, Object> params, StringBuilder link, String paramSeparator);
+
+}

--- a/core/src/main/java/org/apache/struts2/url/StrutsParametersStringBuilder.java
+++ b/core/src/main/java/org/apache/struts2/url/StrutsParametersStringBuilder.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.struts2.url;
+
+import com.opensymphony.xwork2.inject.Inject;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Map;
+
+public class StrutsParametersStringBuilder implements ParametersStringBuilder {
+
+    private static final Logger LOG = LogManager.getLogger(StrutsParametersStringBuilder.class);
+
+    private final UrlEncoder encoder;
+
+    @Inject
+    public StrutsParametersStringBuilder(UrlEncoder encoder) {
+        this.encoder = encoder;
+    }
+
+    @Override
+    public void buildParametersString(Map<String, Object> params, StringBuilder link, String paramSeparator) {
+        if ((params != null) && (params.size() > 0)) {
+            LOG.debug("Building query string out of: {}", params);
+            StringBuilder queryString = new StringBuilder();
+
+            // Set params
+            for (Map.Entry<String, Object> entry : params.entrySet()) {
+                String name = entry.getKey();
+                Object value = entry.getValue();
+
+                if (value instanceof Iterable) {
+                    for (Object o : (Iterable<?>) value) {
+                        appendParameterSubstring(queryString, paramSeparator, name, o);
+                    }
+                } else if (value instanceof Object[]) {
+                    Object[] array = (Object[]) value;
+                    for (Object o : array) {
+                        appendParameterSubstring(queryString, paramSeparator, name, o);
+                    }
+                } else {
+                    appendParameterSubstring(queryString, paramSeparator, name, value);
+                }
+            }
+
+            if (queryString.length() > 0) {
+                if (!link.toString().contains("?")) {
+                    link.append("?");
+                } else {
+                    link.append(paramSeparator);
+                }
+                link.append(queryString);
+            }
+        } else {
+            LOG.debug("Params are empty, skipping building the query string");
+        }
+    }
+
+    private void appendParameterSubstring(StringBuilder queryString, String paramSeparator, String name, Object value) {
+        if (queryString.length() > 0) {
+            queryString.append(paramSeparator);
+        }
+
+        String encodedName = encoder.encode(name);
+        queryString.append(encodedName);
+
+        queryString.append('=');
+        if (value != null) {
+            String encodedValue = encoder.encode(value.toString());
+            queryString.append(encodedValue);
+        }
+    }
+
+}

--- a/core/src/main/java/org/apache/struts2/url/StrutsParametersStringBuilder.java
+++ b/core/src/main/java/org/apache/struts2/url/StrutsParametersStringBuilder.java
@@ -38,7 +38,7 @@ public class StrutsParametersStringBuilder implements ParametersStringBuilder {
     @Override
     public void buildParametersString(Map<String, Object> params, StringBuilder link, String paramSeparator) {
         if ((params != null) && (params.size() > 0)) {
-            LOG.debug("Building query string out of: {}", params);
+            LOG.debug("Building query string out of: {} parameters", params.size());
             StringBuilder queryString = new StringBuilder();
 
             // Set params

--- a/core/src/main/resources/org/apache/struts2/default.properties
+++ b/core/src/main/resources/org/apache/struts2/default.properties
@@ -279,6 +279,12 @@ struts.ognl.expressionMaxLength=256
 ### These formatters are using a slightly different patterns, please check JavaDocs of both and more details is in WW-5016
 struts.date.formatter=dateTimeFormatter
 
+### Defines which instance of ParametersStringBuilder to use, Struts provides just one instance:
+### - strutsParametersStringBuilder
+### The builder is used by UrlHelp to create a proper query string out of provided parameters map
+struts.url.parametersStringBuilder=strutsParametersStringBuilder
+
+### Defines which instances of encoder and decoder to use, Struts provides one default implementation for each
 struts.url.encoder=strutsUrlEncoder
 struts.url.decoder=strutsUrlDecoder
 

--- a/core/src/main/resources/struts-default.xml
+++ b/core/src/main/resources/struts-default.xml
@@ -313,6 +313,8 @@
     <bean type="com.opensymphony.xwork2.ognl.BeanInfoCacheFactory" name="struts"
           class="com.opensymphony.xwork2.ognl.DefaultOgnlBeanInfoCacheFactory" scope="singleton"/>
 
+    <bean type="org.apache.struts2.url.ParametersStringBuilder" name="strutsParametersStringBuilder"
+          class="org.apache.struts2.url.StrutsParametersStringBuilder" scope="singleton"/>
     <bean type="org.apache.struts2.url.UrlEncoder" name="strutsUrlEncoder"
           class="org.apache.struts2.url.StrutsUrlEncoder" scope="singleton"/>
     <bean type="org.apache.struts2.url.UrlDecoder" name="strutsUrlDecoder"

--- a/core/src/test/java/org/apache/struts2/interceptor/exec/StrutsBackgroundProcessTest.java
+++ b/core/src/test/java/org/apache/struts2/interceptor/exec/StrutsBackgroundProcessTest.java
@@ -112,7 +112,7 @@ public class StrutsBackgroundProcessTest extends StrutsInternalTestCase {
             executor.execute(bp);
         }
 
-        Thread.sleep(300);
+        Thread.sleep(400);
 
         for (BackgroundProcess bp : bps) {
             assertTrue("Process is still active: " + bp, bp.isDone());

--- a/core/src/test/java/org/apache/struts2/url/StrutsParametersStringBuilderTest.java
+++ b/core/src/test/java/org/apache/struts2/url/StrutsParametersStringBuilderTest.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.struts2.url;
+
+import org.apache.struts2.views.util.UrlHelper;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class StrutsParametersStringBuilderTest {
+
+    private ParametersStringBuilder builder;
+
+    @Test
+    public void testBuildParametersStringWithUrlHavingSomeExistingParameters() {
+        String expectedUrl = "http://localhost:8080/myContext/myPage.jsp?initParam=initValue&amp;param1=value1&amp;param2=value2&amp;param3%22%3CsCrIpT%3Ealert%281%29%3B%3C%2FsCrIpT%3E=value3";
+
+        Map<String, Object> parameters = new LinkedHashMap<>();
+        parameters.put("param1", "value1");
+        parameters.put("param2", "value2");
+        parameters.put("param3\"<sCrIpT>alert(1);</sCrIpT>", "value3");
+
+        StringBuilder url = new StringBuilder("http://localhost:8080/myContext/myPage.jsp?initParam=initValue");
+
+        builder.buildParametersString(parameters, url, UrlHelper.AMP);
+
+        assertEquals(expectedUrl, url.toString());
+    }
+
+    @Test
+    public void testBuildParametersStringWithJavaScriptInjected() {
+        String expectedUrl = "http://localhost:8080/myContext/myPage.jsp?initParam=initValue&amp;param1=value1&amp;param2=value2&amp;param3%22%3Cscript+type%3D%22text%2Fjavascript%22%3Ealert%281%29%3B%3C%2Fscript%3E=value3";
+
+        Map<String, Object> parameters = new LinkedHashMap<>();
+        parameters.put("param1", "value1");
+        parameters.put("param2", "value2");
+        parameters.put("param3\"<script type=\"text/javascript\">alert(1);</script>", "value3");
+
+        StringBuilder url = new StringBuilder("http://localhost:8080/myContext/myPage.jsp?initParam=initValue");
+
+        builder.buildParametersString(parameters, url, UrlHelper.AMP);
+
+        assertEquals(expectedUrl, url.toString());
+    }
+
+    @Test
+    public void testBuildParametersStringWithEmptyListParameters() {
+        String expectedUrl = "https://www.nowhere.com/myworld.html";
+        Map<String, Object> parameters = new LinkedHashMap<>();
+        parameters.put("param1", new String[]{});
+        parameters.put("param2", new ArrayList<>());
+        StringBuilder url = new StringBuilder("https://www.nowhere.com/myworld.html");
+        builder.buildParametersString(parameters, url, UrlHelper.AMP);
+        assertEquals(expectedUrl, url.toString());
+    }
+
+    @Test
+    public void testBuildParametersStringWithListParameters() {
+        String expectedUrl = "https://www.nowhere.com/myworld.html?param1=x&param2=y&param2=z";
+        Map<String, Object> parameters = new LinkedHashMap<>();
+        parameters.put("param1", new String[]{"x"});
+        parameters.put("param2", new ArrayList<String>() {
+            {
+                add("y");
+                add("z");
+            }
+        });
+        StringBuilder url = new StringBuilder("https://www.nowhere.com/myworld.html");
+        builder.buildParametersString(parameters, url, "&");
+        assertEquals(expectedUrl, url.toString());
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        builder = new StrutsParametersStringBuilder(new StrutsUrlEncoder());
+    }
+
+}

--- a/core/src/test/java/org/apache/struts2/url/StrutsUrlDecoderTest.java
+++ b/core/src/test/java/org/apache/struts2/url/StrutsUrlDecoderTest.java
@@ -110,7 +110,7 @@ public class StrutsUrlDecoderTest {
     public void testDecoding() {
         String result = decoder.decode("%E6%96%B0%E8%81%9E");
 
-        assertEquals(result, "\u65b0\u805e");
+        assertEquals("\u65b0\u805e", result);
     }
 
     @Before

--- a/core/src/test/java/org/apache/struts2/url/StrutsUrlDecoderTest.java
+++ b/core/src/test/java/org/apache/struts2/url/StrutsUrlDecoderTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.struts2.url;
 
+import org.apache.struts2.StrutsConstants;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -103,6 +104,13 @@ public class StrutsUrlDecoderTest {
         decoder.setEncoding("ISO-8859-1");
         String result = decoder.decode("xxxx%41");
         assertEquals("xxxxA", result);
+    }
+
+    @Test
+    public void testDecoding() {
+        String result = decoder.decode("%E6%96%B0%E8%81%9E");
+
+        assertEquals(result, "\u65b0\u805e");
     }
 
     @Before

--- a/core/src/test/java/org/apache/struts2/url/StrutsUrlEncoderTest.java
+++ b/core/src/test/java/org/apache/struts2/url/StrutsUrlEncoderTest.java
@@ -86,7 +86,7 @@ public class StrutsUrlEncoderTest {
     public void testEncoding() {
         String result = encoder.encode("\u65b0\u805e");
 
-        assertEquals(result, "%E6%96%B0%E8%81%9E");
+        assertEquals("%E6%96%B0%E8%81%9E", result);
     }
 
     @Before

--- a/core/src/test/java/org/apache/struts2/url/StrutsUrlEncoderTest.java
+++ b/core/src/test/java/org/apache/struts2/url/StrutsUrlEncoderTest.java
@@ -82,6 +82,13 @@ public class StrutsUrlEncoderTest {
         assertEquals("%25xxxx", result);
     }
 
+    @Test
+    public void testEncoding() {
+        String result = encoder.encode("\u65b0\u805e");
+
+        assertEquals(result, "%E6%96%B0%E8%81%9E");
+    }
+
     @Before
     public void setUp() throws Exception {
         this.encoder = new StrutsUrlEncoder();

--- a/core/src/test/java/org/apache/struts2/views/util/DefaultUrlHelperTest.java
+++ b/core/src/test/java/org/apache/struts2/views/util/DefaultUrlHelperTest.java
@@ -23,14 +23,13 @@ import com.opensymphony.xwork2.ActionContext;
 import com.opensymphony.xwork2.inject.Container;
 import com.opensymphony.xwork2.inject.Scope.Strategy;
 import org.apache.struts2.StrutsInternalTestCase;
+import org.apache.struts2.url.StrutsParametersStringBuilder;
 import org.apache.struts2.url.StrutsUrlDecoder;
 import org.apache.struts2.url.StrutsUrlEncoder;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
@@ -90,63 +89,6 @@ public class DefaultUrlHelperTest extends StrutsInternalTestCase {
         String result = urlHelper.buildUrl("/path1/path2/myAction.action", (HttpServletRequest) mockHttpServletRequest.proxy(), (HttpServletResponse) mockHttpServletResponse.proxy(), null, "http", true, true, true);
         assertEquals(expectedUrl, result);
         mockHttpServletRequest.verify();
-    }
-
-    public void testBuildParametersStringWithUrlHavingSomeExistingParameters() {
-        String expectedUrl = "http://localhost:8080/myContext/myPage.jsp?initParam=initValue&amp;param1=value1&amp;param2=value2&amp;param3%22%3CsCrIpT%3Ealert%281%29%3B%3C%2FsCrIpT%3E=value3";
-
-        Map<String, Object> parameters = new LinkedHashMap<>();
-        parameters.put("param1", "value1");
-        parameters.put("param2", "value2");
-        parameters.put("param3\"<sCrIpT>alert(1);</sCrIpT>", "value3");
-
-        StringBuilder url = new StringBuilder("http://localhost:8080/myContext/myPage.jsp?initParam=initValue");
-
-        urlHelper.buildParametersString(parameters, url, UrlHelper.AMP);
-
-        assertEquals(
-            expectedUrl, url.toString());
-    }
-
-    public void testBuildParametersStringWithJavaScriptInjected() {
-        String expectedUrl = "http://localhost:8080/myContext/myPage.jsp?initParam=initValue&amp;param1=value1&amp;param2=value2&amp;param3%22%3Cscript+type%3D%22text%2Fjavascript%22%3Ealert%281%29%3B%3C%2Fscript%3E=value3";
-
-        Map<String, Object> parameters = new LinkedHashMap<>();
-        parameters.put("param1", "value1");
-        parameters.put("param2", "value2");
-        parameters.put("param3\"<script type=\"text/javascript\">alert(1);</script>", "value3");
-
-        StringBuilder url = new StringBuilder("http://localhost:8080/myContext/myPage.jsp?initParam=initValue");
-
-        urlHelper.buildParametersString(parameters, url, UrlHelper.AMP);
-
-        assertEquals(
-            expectedUrl, url.toString());
-    }
-
-    public void testBuildParametersStringWithEmptyListParameters() {
-        String expectedUrl = "https://www.nowhere.com/myworld.html";
-        Map<String, Object> parameters = new LinkedHashMap<>();
-        parameters.put("param1", new String[]{});
-        parameters.put("param2", new ArrayList<>());
-        StringBuilder url = new StringBuilder("https://www.nowhere.com/myworld.html");
-        urlHelper.buildParametersString(parameters, url, UrlHelper.AMP);
-        assertEquals(expectedUrl, url.toString());
-    }
-
-    public void testBuildParametersStringWithListParameters() {
-        String expectedUrl = "https://www.nowhere.com/myworld.html?param1=x&param2=y&param2=z";
-        Map<String, Object> parameters = new LinkedHashMap<>();
-        parameters.put("param1", new String[]{"x"});
-        parameters.put("param2", new ArrayList<String>() {
-            {
-                add("y");
-                add("z");
-            }
-        });
-        StringBuilder url = new StringBuilder("https://www.nowhere.com/myworld.html");
-        urlHelper.buildParametersString(parameters, url, "&");
-        assertEquals(expectedUrl, url.toString());
     }
 
     public void testForceAddNullSchemeHostAndPort() {
@@ -434,7 +376,9 @@ public class DefaultUrlHelperTest extends StrutsInternalTestCase {
         StubContainer stubContainer = new StubContainer(container);
         ActionContext.getContext().withContainer(stubContainer);
         urlHelper = new DefaultUrlHelper();
-        urlHelper.setEncoder(new StrutsUrlEncoder());
+        StrutsUrlEncoder encoder = new StrutsUrlEncoder();
+        urlHelper.setParametersStringBuilder(new StrutsParametersStringBuilder(encoder));
+        urlHelper.setEncoder(encoder);
         urlHelper.setDecoder(new StrutsUrlDecoder());
     }
 

--- a/plugins/json/src/test/java/org/apache/struts2/json/JSONActionRedirectResultTest.java
+++ b/plugins/json/src/test/java/org/apache/struts2/json/JSONActionRedirectResultTest.java
@@ -26,12 +26,18 @@ import com.opensymphony.xwork2.util.ValueStack;
 import org.apache.struts2.StrutsStatics;
 import org.apache.struts2.dispatcher.mapper.DefaultActionMapper;
 import org.apache.struts2.junit.StrutsTestCase;
+import org.apache.struts2.url.StrutsParametersStringBuilder;
+import org.apache.struts2.url.StrutsUrlDecoder;
+import org.apache.struts2.url.StrutsUrlEncoder;
 import org.apache.struts2.views.util.DefaultUrlHelper;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockServletContext;
 
 public class JSONActionRedirectResultTest extends StrutsTestCase {
+
+    private DefaultActionMapper actionMapper;
+    private DefaultUrlHelper urlHelper;
 
     MockActionInvocation invocation;
     MockHttpServletResponse response;
@@ -43,8 +49,8 @@ public class JSONActionRedirectResultTest extends StrutsTestCase {
     public void testNormalRedirect() throws Exception {
         JSONActionRedirectResult result = new JSONActionRedirectResult();
         result.setActionName("targetAction");
-        result.setActionMapper(new DefaultActionMapper());
-        result.setUrlHelper(new DefaultUrlHelper());
+        result.setActionMapper(actionMapper);
+        result.setUrlHelper(urlHelper);
 
         Object action = new Object();
         stack.push(action);
@@ -62,8 +68,8 @@ public class JSONActionRedirectResultTest extends StrutsTestCase {
     public void testJsonRedirect() throws Exception {
         JSONActionRedirectResult result = new JSONActionRedirectResult();
         result.setActionName("targetAction");
-        result.setActionMapper(new DefaultActionMapper());
-        result.setUrlHelper(new DefaultUrlHelper());
+        result.setActionMapper(actionMapper);
+        result.setUrlHelper(urlHelper);
 
         request.setParameter("struts.enableJSONValidation", "true");
         request.setParameter("struts.validateOnly", "false");
@@ -82,8 +88,8 @@ public class JSONActionRedirectResultTest extends StrutsTestCase {
     public void testValidateOnlyFalse() throws Exception {
         JSONActionRedirectResult result = new JSONActionRedirectResult();
         result.setActionName("targetAction");
-        result.setActionMapper(new DefaultActionMapper());
-        result.setUrlHelper(new DefaultUrlHelper());
+        result.setActionMapper(actionMapper);
+        result.setUrlHelper(urlHelper);
 
         request.setParameter("struts.enableJSONValidation", "true");
         request.setParameter("struts.validateOnly", "true");
@@ -118,5 +124,12 @@ public class JSONActionRedirectResultTest extends StrutsTestCase {
         MockActionProxy mockActionProxy = new MockActionProxy();
         mockActionProxy.setConfig(new ActionConfig.Builder(null, null, null).build());
         this.invocation.setProxy(mockActionProxy);
+
+        this.actionMapper = new DefaultActionMapper();
+        this.urlHelper = new DefaultUrlHelper();
+        StrutsUrlEncoder encoder = new StrutsUrlEncoder();
+        this.urlHelper.setParametersStringBuilder(new StrutsParametersStringBuilder(encoder));
+        this.urlHelper.setEncoder(encoder);
+        this.urlHelper.setDecoder(new StrutsUrlDecoder());
     }
 }


### PR DESCRIPTION
This PR fixes the issue plus extracts logic related to building a query string into a new class and defines a new extension point which then can be used by users to provide their own implementations.
Closes [WW-4514](https://issues.apache.org/jira/browse/WW-4514)