### PR TITLE
WW-5264 Removes XSLTResult from struts-default.xml as it was moved in to plugin

### DIFF
--- a/core/src/main/resources/struts-default.xml
+++ b/core/src/main/resources/struts-default.xml
@@ -38,7 +38,6 @@
             <result-type name="redirect" class="org.apache.struts2.result.ServletRedirectResult"/>
             <result-type name="redirectAction" class="org.apache.struts2.result.ServletActionRedirectResult"/>
             <result-type name="stream" class="org.apache.struts2.result.StreamResult"/>
-            <result-type name="xslt" class="org.apache.struts2.result.xslt.XSLTResult"/>
             <result-type name="plainText" class="org.apache.struts2.result.PlainTextResult"/>
             <result-type name="postback" class="org.apache.struts2.result.PostbackResult"/>
         </result-types>


### PR DESCRIPTION
Refs [WW-5264](https://issues.apache.org/jira/browse/WW-5264)