### PR TITLE
[WW-5274] Marks the Pell multipart plugin as deprecated

### DIFF
--- a/plugins/pell-multipart/pom.xml
+++ b/plugins/pell-multipart/pom.xml
@@ -29,7 +29,7 @@
 
     <artifactId>struts2-pell-multipart-plugin</artifactId>
     <packaging>jar</packaging>
-    <name>Struts 2 Pell Multipart Plugin</name>
+    <name>DEPRECATED: Struts 2 Pell Multipart Plugin - since 6.2.0</name>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
Closes [WW-5274](https://issues.apache.org/jira/browse/WW-5274)