### PR TITLE
[WW-5285] Limits max number of files to upload at once

### DIFF
--- a/core/src/main/java/org/apache/struts2/StrutsConstants.java
+++ b/core/src/main/java/org/apache/struts2/StrutsConstants.java
@@ -142,6 +142,9 @@ public final class StrutsConstants {
     /** The maximize size of a multipart request (file upload) */
     public static final String STRUTS_MULTIPART_MAXSIZE = "struts.multipart.maxSize";
 
+    /** The maximized number of files allowed to upload */
+    public static final String STRUTS_MULTIPART_MAXFILES = "struts.multipart.maxFiles";
+
     /** The directory to use for storing uploaded files */
     public static final String STRUTS_MULTIPART_SAVEDIR = "struts.multipart.saveDir";
 

--- a/core/src/main/java/org/apache/struts2/config/entities/ConstantConfig.java
+++ b/core/src/main/java/org/apache/struts2/config/entities/ConstantConfig.java
@@ -64,6 +64,7 @@ public class ConstantConfig {
     private String uiTheme;
     private String uiThemeExpansionToken;
     private Long multipartMaxSize;
+    private Long multipartMaxFiles;
     private String multipartSaveDir;
     private Integer multipartBufferSize;
     private BeanConfig multipartParser;
@@ -195,6 +196,7 @@ public class ConstantConfig {
         map.put(StrutsConstants.STRUTS_UI_THEME, uiTheme);
         map.put(StrutsConstants.STRUTS_UI_THEME_EXPANSION_TOKEN, uiThemeExpansionToken);
         map.put(StrutsConstants.STRUTS_MULTIPART_MAXSIZE, Objects.toString(multipartMaxSize, null));
+        map.put(StrutsConstants.STRUTS_MULTIPART_MAXFILES, Objects.toString(multipartMaxFiles, null));
         map.put(StrutsConstants.STRUTS_MULTIPART_SAVEDIR, multipartSaveDir);
         map.put(StrutsConstants.STRUTS_MULTIPART_BUFFERSIZE, Objects.toString(multipartBufferSize, null));
         map.put(StrutsConstants.STRUTS_MULTIPART_PARSER, beanConfToString(multipartParser));
@@ -577,6 +579,14 @@ public class ConstantConfig {
 
     public void setMultipartMaxSize(Long multipartMaxSize) {
         this.multipartMaxSize = multipartMaxSize;
+    }
+
+    public Long getMultipartMaxFiles() {
+        return multipartMaxFiles;
+    }
+
+    public void setMultipartMaxFiles(Long multipartMaxFiles) {
+        this.multipartMaxFiles = multipartMaxFiles;
     }
 
     public String getMultipartSaveDir() {

--- a/core/src/main/java/org/apache/struts2/dispatcher/multipart/AbstractMultiPartRequest.java
+++ b/core/src/main/java/org/apache/struts2/dispatcher/multipart/AbstractMultiPartRequest.java
@@ -55,6 +55,12 @@ public abstract class AbstractMultiPartRequest implements MultiPartRequest {
     protected boolean maxSizeProvided;
 
     /**
+     * Specifies the maximum number of files in one request.
+     */
+    protected long maxFiles;
+    protected boolean maxFilesProvided;
+
+    /**
      * Specifies the buffer size to use during streaming.
      */
     protected int bufferSize = BUFFER_SIZE;
@@ -86,6 +92,12 @@ public abstract class AbstractMultiPartRequest implements MultiPartRequest {
     public void setMaxSize(String maxSize) {
         this.maxSizeProvided = true;
         this.maxSize = Long.parseLong(maxSize);
+    }
+
+    @Inject(StrutsConstants.STRUTS_MULTIPART_MAXFILES)
+    public void setMaxFiles(String maxFiles) {
+        this.maxFilesProvided = true;
+        this.maxFiles = Long.parseLong(maxFiles);
     }
 
     @Inject

--- a/core/src/main/java/org/apache/struts2/dispatcher/multipart/AbstractMultiPartRequest.java
+++ b/core/src/main/java/org/apache/struts2/dispatcher/multipart/AbstractMultiPartRequest.java
@@ -51,14 +51,12 @@ public abstract class AbstractMultiPartRequest implements MultiPartRequest {
     /**
      * Specifies the maximum size of the entire request.
      */
-    protected long maxSize;
-    protected boolean maxSizeProvided;
+    protected Long maxSize;
 
     /**
      * Specifies the maximum number of files in one request.
      */
-    protected long maxFiles;
-    protected boolean maxFilesProvided;
+    protected Long maxFiles;
 
     /**
      * Specifies the buffer size to use during streaming.
@@ -90,13 +88,11 @@ public abstract class AbstractMultiPartRequest implements MultiPartRequest {
      */
     @Inject(StrutsConstants.STRUTS_MULTIPART_MAXSIZE)
     public void setMaxSize(String maxSize) {
-        this.maxSizeProvided = true;
         this.maxSize = Long.parseLong(maxSize);
     }
 
     @Inject(StrutsConstants.STRUTS_MULTIPART_MAXFILES)
     public void setMaxFiles(String maxFiles) {
-        this.maxFilesProvided = true;
         this.maxFiles = Long.parseLong(maxFiles);
     }
 
@@ -146,9 +142,9 @@ public abstract class AbstractMultiPartRequest implements MultiPartRequest {
         int forwardSlash = fileName.lastIndexOf('/');
         int backwardSlash = fileName.lastIndexOf('\\');
         if (forwardSlash != -1 && forwardSlash > backwardSlash) {
-            fileName = fileName.substring(forwardSlash + 1, fileName.length());
+            fileName = fileName.substring(forwardSlash + 1);
         } else {
-            fileName = fileName.substring(backwardSlash + 1, fileName.length());
+            fileName = fileName.substring(backwardSlash + 1);
         }
         return fileName;
     }

--- a/core/src/main/java/org/apache/struts2/dispatcher/multipart/JakartaMultiPartRequest.java
+++ b/core/src/main/java/org/apache/struts2/dispatcher/multipart/JakartaMultiPartRequest.java
@@ -160,8 +160,12 @@ public class JakartaMultiPartRequest extends AbstractMultiPartRequest {
 
     protected ServletFileUpload createServletFileUpload(DiskFileItemFactory fac) {
         ServletFileUpload upload = new ServletFileUpload(fac);
-        upload.setSizeMax(maxSize);
-        upload.setFileCountMax(maxFiles);
+        if (maxSize != null) {
+            upload.setSizeMax(maxSize);
+        }
+        if (maxFiles != null) {
+            upload.setFileCountMax(maxFiles);
+        }
         return upload;
     }
 

--- a/core/src/main/java/org/apache/struts2/dispatcher/multipart/JakartaMultiPartRequest.java
+++ b/core/src/main/java/org/apache/struts2/dispatcher/multipart/JakartaMultiPartRequest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.struts2.dispatcher.multipart;
 
+import org.apache.commons.fileupload.FileCountLimitExceededException;
 import org.apache.commons.fileupload.FileItem;
 import org.apache.commons.fileupload.FileUploadBase;
 import org.apache.commons.fileupload.FileUploadException;
@@ -35,7 +36,13 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Multipart form data request adapter for Jakarta Commons Fileupload package.
@@ -65,9 +72,12 @@ public class JakartaMultiPartRequest extends AbstractMultiPartRequest {
         } catch (FileUploadException e) {
             LOG.warn("Request exceeded size limit!", e);
             LocalizedMessage errorMessage;
-            if(e instanceof FileUploadBase.SizeLimitExceededException) {
+            if (e instanceof FileUploadBase.SizeLimitExceededException) {
                 FileUploadBase.SizeLimitExceededException ex = (FileUploadBase.SizeLimitExceededException) e;
                 errorMessage = buildErrorMessage(e, new Object[]{ex.getPermittedSize(), ex.getActualSize()});
+            } else if (e instanceof FileCountLimitExceededException) {
+                FileCountLimitExceededException ex = (FileCountLimitExceededException) e;
+                errorMessage = buildErrorMessage(e, new Object[]{ex.getLimit()});
             } else {
                 errorMessage = buildErrorMessage(e, new Object[]{});
             }
@@ -151,6 +161,7 @@ public class JakartaMultiPartRequest extends AbstractMultiPartRequest {
     protected ServletFileUpload createServletFileUpload(DiskFileItemFactory fac) {
         ServletFileUpload upload = new ServletFileUpload(fac);
         upload.setSizeMax(maxSize);
+        upload.setFileCountMax(maxFiles);
         return upload;
     }
 
@@ -316,14 +327,14 @@ public class JakartaMultiPartRequest extends AbstractMultiPartRequest {
     }
 
     /* (non-Javadoc)
-    * @see org.apache.struts2.dispatcher.multipart.MultiPartRequest#cleanUp()
-    */
+     * @see org.apache.struts2.dispatcher.multipart.MultiPartRequest#cleanUp()
+     */
     public void cleanUp() {
         Set<String> names = files.keySet();
         for (String name : names) {
             List<FileItem> items = files.get(name);
             for (FileItem item : items) {
-                LOG.debug("Removing file {} {}", name, item );
+                LOG.debug("Removing file {} {}", name, item);
                 if (!item.isInMemory()) {
                     item.delete();
                 }

--- a/core/src/main/java/org/apache/struts2/dispatcher/multipart/JakartaStreamMultiPartRequest.java
+++ b/core/src/main/java/org/apache/struts2/dispatcher/multipart/JakartaStreamMultiPartRequest.java
@@ -212,6 +212,9 @@ public class JakartaStreamMultiPartRequest extends AbstractMultiPartRequest {
             if (maxSizeProvided) {
                 servletFileUpload.setSizeMax(maxSize);
             }
+            if (maxFilesProvided) {
+                servletFileUpload.setFileCountMax(maxFiles);
+            }
             FileItemIterator i = servletFileUpload.getItemIterator(request);
 
             // Iterate the file items

--- a/core/src/main/resources/org/apache/struts2/default.properties
+++ b/core/src/main/resources/org/apache/struts2/default.properties
@@ -68,6 +68,7 @@ struts.multipart.parser=jakarta
 ### Uses javax.servlet.context.tempdir by default
 struts.multipart.saveDir=
 struts.multipart.maxSize=2097152
+struts.multipart.maxFiles=256
 
 ### Load custom property files (does not override struts.properties!)
 # struts.custom.properties=application,org/apache/struts2/extension/custom

--- a/core/src/main/resources/org/apache/struts2/struts-messages.properties
+++ b/core/src/main/resources/org/apache/struts2/struts-messages.properties
@@ -31,6 +31,7 @@ struts.messages.error.file.extension.not.allowed=File extension not allowed: {0}
 
 # dedicated messages used to handle various problems with file upload - check {@link JakartaMultiPartRequest#parse(HttpServletRequest, String)}
 struts.messages.upload.error.SizeLimitExceededException=Request exceeded allowed size limit! Max size allowed is: {0} but request was: {1}!
+struts.messages.upload.error.FileCountLimitExceededException=Request exceeded allowed number of files! Max allowed files number is: {0}!
 struts.messages.upload.error.IOException=Error uploading: {0}!
 
 devmode.notification=Developer Notification (set struts.devMode to false to disable this message):\n{0}

--- a/plugins/pell-multipart/src/main/java/org/apache/struts2/dispatcher/multipart/PellMultiPartRequest.java
+++ b/plugins/pell-multipart/src/main/java/org/apache/struts2/dispatcher/multipart/PellMultiPartRequest.java
@@ -51,15 +51,15 @@ public class PellMultiPartRequest extends AbstractMultiPartRequest {
         //calling the constructor.  See javadoc for MultipartRequest.setEncoding().
         synchronized (this) {
             setEncoding();
-            if (maxSizeProvided){
-                int intMaxSize = (maxSize >= Integer.MAX_VALUE ? Integer.MAX_VALUE : Long.valueOf(maxSize).intValue());
+            if (maxSize != null && maxSize > -1){
+                int intMaxSize = (maxSize >= Integer.MAX_VALUE ? Integer.MAX_VALUE : maxSize.intValue());
             	multi = new ServletMultipartRequest(servletRequest, saveDir, intMaxSize);
             }else{
             	multi = new ServletMultipartRequest(servletRequest, saveDir);
             }
         }
     }
-    
+
     public Enumeration getFileParameterNames() {
         return multi.getFileParameterNames();
     }

--- a/pom.xml
+++ b/pom.xml
@@ -917,7 +917,7 @@
             <dependency>
                 <groupId>commons-fileupload</groupId>
                 <artifactId>commons-fileupload</artifactId>
-                <version>1.4</version>
+                <version>1.5</version>
             </dependency>
             <dependency>
                 <groupId>commons-io</groupId>


### PR DESCRIPTION
Upgrades commons-fileupload to ver. 1.5 and sets default limit to 256 files

Closes [WW-5285](https://issues.apache.org/jira/browse/WW-5285)