### PR TITLE
WW-5267 Add option to generate ActionContext for excluded URLs

### DIFF
--- a/core/src/main/java/org/apache/struts2/StrutsConstants.java
+++ b/core/src/main/java/org/apache/struts2/StrutsConstants.java
@@ -465,4 +465,10 @@ public final class StrutsConstants {
 
     /** A global flag to set property {@link org.apache.struts2.components.Checkbox#setSubmitUnchecked(String)} */
     public static final String STRUTS_UI_CHECKBOX_SUBMIT_UNCHECKED = "struts.ui.checkbox.submitUnchecked";
+
+    /**
+     * Create ActionContext even for excluded urls, i.e. defined by struts.action.excludePattern.
+     * This is needed when running SiteMesh on excluded urls.
+     */
+    public static final String STRUTS_ALWAYS_CREATE_ACTION_CONTEXT = "struts.alwaysCreateActionContext";
 }

--- a/core/src/main/java/org/apache/struts2/dispatcher/PrepareOperations.java
+++ b/core/src/main/java/org/apache/struts2/dispatcher/PrepareOperations.java
@@ -229,13 +229,14 @@ public class PrepareOperations {
      *
      * @return <tt>true</tt> if the request URI matches one of the given patterns
      */
-    public boolean isUrlExcluded( HttpServletRequest request, List<Pattern> excludedPatterns ) {
-        if (excludedPatterns != null) {
-            String uri = RequestUtils.getUri(request);
-            for ( Pattern pattern : excludedPatterns ) {
-                if (pattern.matcher(uri).matches()) {
-                    return true;
-                }
+    public boolean isUrlExcluded(HttpServletRequest request, List<Pattern> excludedPatterns) {
+        if (excludedPatterns == null) {
+            return false;
+        }
+        String uri = RequestUtils.getUri(request);
+        for (Pattern pattern : excludedPatterns) {
+            if (pattern.matcher(uri).matches()) {
+                return true;
             }
         }
         return false;

--- a/core/src/main/java/org/apache/struts2/dispatcher/filter/StrutsExecuteFilter.java
+++ b/core/src/main/java/org/apache/struts2/dispatcher/filter/StrutsExecuteFilter.java
@@ -20,12 +20,17 @@ package org.apache.struts2.dispatcher.filter;
 
 import org.apache.struts2.StrutsStatics;
 import org.apache.struts2.dispatcher.Dispatcher;
-import org.apache.struts2.dispatcher.mapper.ActionMapping;
 import org.apache.struts2.dispatcher.ExecuteOperations;
 import org.apache.struts2.dispatcher.InitOperations;
 import org.apache.struts2.dispatcher.PrepareOperations;
+import org.apache.struts2.dispatcher.mapper.ActionMapping;
 
-import javax.servlet.*;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -46,14 +51,43 @@ public class StrutsExecuteFilter implements StrutsStatics, Filter {
 
     protected synchronized void lazyInit() {
         if (execute == null) {
-            InitOperations init = new InitOperations();
+            InitOperations init = createInitOperations();
             Dispatcher dispatcher = init.findDispatcherOnThread();
             init.initStaticContentLoader(new FilterHostConfig(filterConfig), dispatcher);
 
-            prepare = new PrepareOperations(dispatcher);
-            execute = new ExecuteOperations(dispatcher);
+            prepare = createPrepareOperations(dispatcher);
+            execute = createExecuteOperations(dispatcher);
         }
+    }
 
+    /**
+     * Creates a new instance of {@link InitOperations} to be used during
+     * initialising {@link Dispatcher}
+     *
+     * @return instance of {@link InitOperations}
+     */
+    protected InitOperations createInitOperations() {
+        return new InitOperations();
+    }
+
+    /**
+     * Creates a new instance of {@link PrepareOperations} to be used during
+     * initialising {@link Dispatcher}
+     *
+     * @return instance of {@link PrepareOperations}
+     */
+    protected PrepareOperations createPrepareOperations(Dispatcher dispatcher) {
+        return new PrepareOperations(dispatcher);
+    }
+
+    /**
+     * Creates a new instance of {@link ExecuteOperations} to be used during
+     * initialising {@link Dispatcher}
+     *
+     * @return instance of {@link ExecuteOperations}
+     */
+    protected ExecuteOperations createExecuteOperations(Dispatcher dispatcher) {
+        return new ExecuteOperations(dispatcher);
     }
 
     public void doFilter(ServletRequest req, ServletResponse res, FilterChain chain) throws IOException, ServletException {

--- a/core/src/main/java/org/apache/struts2/dispatcher/filter/StrutsPrepareFilter.java
+++ b/core/src/main/java/org/apache/struts2/dispatcher/filter/StrutsPrepareFilter.java
@@ -45,7 +45,7 @@ public class StrutsPrepareFilter implements StrutsStatics, Filter {
 
     protected PrepareOperations prepare;
     protected List<Pattern> excludedPatterns = null;
-    protected boolean alwaysCreateActionContext = false;
+    private Dispatcher dispatcher;
 
     public void init(FilterConfig filterConfig) throws ServletException {
         InitOperations init = createInitOperations();
@@ -107,7 +107,7 @@ public class StrutsPrepareFilter implements StrutsStatics, Filter {
             prepare.trackRecursion(request);
             if (excludedPatterns != null && prepare.isUrlExcluded(request, excludedPatterns)) {
                 request.setAttribute(REQUEST_EXCLUDED_FROM_ACTION_MAPPING, true);
-                if (alwaysCreateActionContext) {
+                if (alwaysCreateActionContext()) {
                     prepare.createActionContext(request, response);
                 }
             } else {
@@ -126,6 +126,11 @@ public class StrutsPrepareFilter implements StrutsStatics, Filter {
             }
             prepare.cleanupRequest(request);
         }
+    }
+
+    private boolean alwaysCreateActionContext() {
+        return Boolean.parseBoolean(dispatcher.getContainer()
+                .getInstance(String.class, StrutsConstants.STRUTS_ALWAYS_CREATE_ACTION_CONTEXT));
     }
 
     public void destroy() {

--- a/core/src/main/java/org/apache/struts2/dispatcher/filter/StrutsPrepareFilter.java
+++ b/core/src/main/java/org/apache/struts2/dispatcher/filter/StrutsPrepareFilter.java
@@ -44,20 +44,18 @@ public class StrutsPrepareFilter implements StrutsStatics, Filter {
     protected static final String REQUEST_EXCLUDED_FROM_ACTION_MAPPING = StrutsPrepareFilter.class.getName() + ".REQUEST_EXCLUDED_FROM_ACTION_MAPPING";
 
     protected PrepareOperations prepare;
-    protected List<Pattern> excludedPatterns = null;
+    protected List<Pattern> excludedPatterns;
     private Dispatcher dispatcher;
 
     public void init(FilterConfig filterConfig) throws ServletException {
         InitOperations init = createInitOperations();
-        Dispatcher dispatcher = null;
         try {
             FilterHostConfig config = new FilterHostConfig(filterConfig);
             dispatcher = init.initDispatcher(config);
 
             prepare = createPrepareOperations(dispatcher);
+            // Note: Currently, excluded patterns are not refreshed following an XWork config reload
             this.excludedPatterns = init.buildExcludedPatternsList(dispatcher);
-            this.alwaysCreateActionContext = Boolean.parseBoolean(dispatcher.getContainer()
-                    .getInstance(String.class, StrutsConstants.STRUTS_ALWAYS_CREATE_ACTION_CONTEXT));
 
             postInit(dispatcher, filterConfig);
         } finally {
@@ -105,7 +103,7 @@ public class StrutsPrepareFilter implements StrutsStatics, Filter {
         boolean didWrap = false;
         try {
             prepare.trackRecursion(request);
-            if (excludedPatterns != null && prepare.isUrlExcluded(request, excludedPatterns)) {
+            if (prepare.isUrlExcluded(request, excludedPatterns)) {
                 request.setAttribute(REQUEST_EXCLUDED_FROM_ACTION_MAPPING, true);
                 if (alwaysCreateActionContext()) {
                     prepare.createActionContext(request, response);

--- a/core/src/main/java/org/apache/struts2/dispatcher/filter/StrutsPrepareFilter.java
+++ b/core/src/main/java/org/apache/struts2/dispatcher/filter/StrutsPrepareFilter.java
@@ -48,13 +48,13 @@ public class StrutsPrepareFilter implements StrutsStatics, Filter {
     protected boolean alwaysCreateActionContext = false;
 
     public void init(FilterConfig filterConfig) throws ServletException {
-        InitOperations init = new InitOperations();
+        InitOperations init = createInitOperations();
         Dispatcher dispatcher = null;
         try {
             FilterHostConfig config = new FilterHostConfig(filterConfig);
             dispatcher = init.initDispatcher(config);
 
-            prepare = new PrepareOperations(dispatcher);
+            prepare = createPrepareOperations(dispatcher);
             this.excludedPatterns = init.buildExcludedPatternsList(dispatcher);
             this.alwaysCreateActionContext = Boolean.parseBoolean(dispatcher.getContainer()
                     .getInstance(String.class, StrutsConstants.STRUTS_ALWAYS_CREATE_ACTION_CONTEXT));
@@ -66,6 +66,26 @@ public class StrutsPrepareFilter implements StrutsStatics, Filter {
             }
             init.cleanup();
         }
+    }
+
+    /**
+     * Creates a new instance of {@link InitOperations} to be used during
+     * initialising {@link Dispatcher}
+     *
+     * @return instance of {@link InitOperations}
+     */
+    protected InitOperations createInitOperations() {
+        return new InitOperations();
+    }
+
+    /**
+     * Creates a new instance of {@link PrepareOperations} to be used during
+     * initialising {@link Dispatcher}
+     *
+     * @return instance of {@link PrepareOperations}
+     */
+    protected PrepareOperations createPrepareOperations(Dispatcher dispatcher) {
+        return new PrepareOperations(dispatcher);
     }
 
     /**

--- a/core/src/main/java/org/apache/struts2/dispatcher/filter/StrutsPrepareFilter.java
+++ b/core/src/main/java/org/apache/struts2/dispatcher/filter/StrutsPrepareFilter.java
@@ -18,6 +18,7 @@
  */
 package org.apache.struts2.dispatcher.filter;
 
+import org.apache.struts2.StrutsConstants;
 import org.apache.struts2.StrutsStatics;
 import org.apache.struts2.dispatcher.Dispatcher;
 import org.apache.struts2.dispatcher.InitOperations;
@@ -44,6 +45,7 @@ public class StrutsPrepareFilter implements StrutsStatics, Filter {
 
     protected PrepareOperations prepare;
     protected List<Pattern> excludedPatterns = null;
+    protected boolean alwaysCreateActionContext = false;
 
     public void init(FilterConfig filterConfig) throws ServletException {
         InitOperations init = new InitOperations();
@@ -54,6 +56,8 @@ public class StrutsPrepareFilter implements StrutsStatics, Filter {
 
             prepare = new PrepareOperations(dispatcher);
             this.excludedPatterns = init.buildExcludedPatternsList(dispatcher);
+            this.alwaysCreateActionContext = Boolean.parseBoolean(dispatcher.getContainer()
+                    .getInstance(String.class, StrutsConstants.STRUTS_ALWAYS_CREATE_ACTION_CONTEXT));
 
             postInit(dispatcher, filterConfig);
         } finally {
@@ -83,6 +87,9 @@ public class StrutsPrepareFilter implements StrutsStatics, Filter {
             prepare.trackRecursion(request);
             if (excludedPatterns != null && prepare.isUrlExcluded(request, excludedPatterns)) {
                 request.setAttribute(REQUEST_EXCLUDED_FROM_ACTION_MAPPING, true);
+                if (alwaysCreateActionContext) {
+                    prepare.createActionContext(request, response);
+                }
             } else {
                 request.setAttribute(REQUEST_EXCLUDED_FROM_ACTION_MAPPING, false);
                 prepare.setEncodingAndLocale(request, response);

--- a/core/src/test/java/org/apache/struts2/dispatcher/PrepareOperationsTest.java
+++ b/core/src/test/java/org/apache/struts2/dispatcher/PrepareOperationsTest.java
@@ -73,6 +73,7 @@ public class PrepareOperationsTest extends StrutsInternalTestCase {
         });
         IntStream.range(0, mockedRecursions - 1).forEach(i -> prepare.cleanupWrappedRequest(req));
 
+        // Assert org.apache.struts2.dispatcher.Dispatcher#cleanUpRequest has not yet run
         assertNotNull(ContainerHolder.get());
 
         prepare.cleanupWrappedRequest(req);

--- a/core/src/test/java/org/apache/struts2/dispatcher/StrutsPrepareAndExecuteFilterIntegrationTest.java
+++ b/core/src/test/java/org/apache/struts2/dispatcher/StrutsPrepareAndExecuteFilterIntegrationTest.java
@@ -19,28 +19,33 @@
 package org.apache.struts2.dispatcher;
 
 import com.opensymphony.xwork2.ActionContext;
-import junit.framework.TestCase;
-import org.apache.struts2.dispatcher.Dispatcher;
 import org.apache.struts2.dispatcher.filter.StrutsPrepareAndExecuteFilter;
+import org.junit.Test;
 import org.springframework.mock.web.MockFilterChain;
 import org.springframework.mock.web.MockFilterConfig;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
+import javax.servlet.FilterConfig;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
-import javax.servlet.FilterConfig;
-import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
-import java.util.regex.Pattern;
 import java.util.ArrayList;
+import java.util.regex.Pattern;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Integration tests for the filter
  */
-public class StrutsPrepareAndExecuteFilterIntegrationTest extends TestCase {
+public class StrutsPrepareAndExecuteFilterIntegrationTest {
 
+    @Test
     public void test404() throws ServletException, IOException {
         MockHttpServletRequest request = new MockHttpServletRequest();
         MockHttpServletResponse response = new MockHttpServletResponse();
@@ -61,6 +66,7 @@ public class StrutsPrepareAndExecuteFilterIntegrationTest extends TestCase {
         assertNull(Dispatcher.getInstance());
     }
 
+    @Test
     public void test200() throws ServletException, IOException {
         MockHttpServletRequest request = new MockHttpServletRequest();
         MockHttpServletResponse response = new MockHttpServletResponse();
@@ -81,6 +87,7 @@ public class StrutsPrepareAndExecuteFilterIntegrationTest extends TestCase {
         assertNull(Dispatcher.getInstance());
     }
 
+    @Test
     public void testActionMappingLookup() throws ServletException, IOException {
         MockHttpServletRequest request = new MockHttpServletRequest();
         MockHttpServletResponse response = new MockHttpServletResponse();
@@ -115,6 +122,7 @@ public class StrutsPrepareAndExecuteFilterIntegrationTest extends TestCase {
         assertTrue((Boolean) request.getAttribute("__invoked"));
     }
 
+    @Test
     public void testUriPatternExclusion() throws ServletException, IOException {
         MockHttpServletRequest request = new MockHttpServletRequest();
         MockHttpServletResponse response = new MockHttpServletResponse();
@@ -131,7 +139,7 @@ public class StrutsPrepareAndExecuteFilterIntegrationTest extends TestCase {
             @Override
             public void init( FilterConfig filterConfig ) throws ServletException {
                 super.init(filterConfig);
-                excludedPatterns = new ArrayList<Pattern>();
+                excludedPatterns = new ArrayList<>();
                 excludedPatterns.add(Pattern.compile(".*hello.*"));
             }
         };
@@ -141,6 +149,7 @@ public class StrutsPrepareAndExecuteFilterIntegrationTest extends TestCase {
         assertEquals("invoked", request.getAttribute("i_was"));
     }
 
+    @Test
     public void testStaticFallthrough() throws ServletException, IOException {
         MockHttpServletRequest request = new MockHttpServletRequest();
         MockHttpServletResponse response = new MockHttpServletResponse();
@@ -168,6 +177,7 @@ public class StrutsPrepareAndExecuteFilterIntegrationTest extends TestCase {
         assertNull(Dispatcher.getInstance());
     }
 
+    @Test
     public void testStaticExecute() throws ServletException, IOException {
         MockHttpServletRequest request = new MockHttpServletRequest();
         MockHttpServletResponse response = new MockHttpServletResponse();
@@ -189,6 +199,7 @@ public class StrutsPrepareAndExecuteFilterIntegrationTest extends TestCase {
         assertNull(Dispatcher.getInstance());
     }
 
+    @Test
     public void testDestroy() throws ServletException {
         MockFilterConfig filterConfig = new MockFilterConfig();
         final MockPrepareOperations[] prepareOperations = {null};
@@ -208,7 +219,7 @@ public class StrutsPrepareAndExecuteFilterIntegrationTest extends TestCase {
         assertTrue(prepareOperations[0].isCleaned());
     }
 
-    private class MockPrepareOperations extends PrepareOperations {
+    private static class MockPrepareOperations extends PrepareOperations {
         private boolean cleaned;
 
         public MockPrepareOperations(Dispatcher dispatcher) {

--- a/core/src/test/java/org/apache/struts2/dispatcher/TwoFilterIntegrationTest.java
+++ b/core/src/test/java/org/apache/struts2/dispatcher/TwoFilterIntegrationTest.java
@@ -19,27 +19,41 @@
 package org.apache.struts2.dispatcher;
 
 import com.opensymphony.xwork2.ActionContext;
-import junit.framework.TestCase;
-import org.apache.struts2.dispatcher.Dispatcher;
-import org.apache.struts2.dispatcher.PrepareOperations;
 import org.apache.struts2.dispatcher.filter.StrutsExecuteFilter;
 import org.apache.struts2.dispatcher.filter.StrutsPrepareFilter;
-import org.springframework.mock.web.*;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockFilterConfig;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
 
-import javax.servlet.*;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
 import java.io.IOException;
-import java.util.LinkedList;
 import java.util.Arrays;
+import java.util.LinkedList;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Integration tests for the filter
  */
-public class TwoFilterIntegrationTest extends TestCase {
-    StrutsExecuteFilter filterExecute;
-    StrutsPrepareFilter filterPrepare;
-    Filter failFilter;
+public class TwoFilterIntegrationTest {
+    private StrutsExecuteFilter filterExecute;
+    private StrutsPrepareFilter filterPrepare;
+    private Filter failFilter;
     private Filter stringFilter;
 
+    @Before
     public void setUp() {
         filterPrepare = new StrutsPrepareFilter();
         filterExecute = new StrutsExecuteFilter();
@@ -61,16 +75,19 @@ public class TwoFilterIntegrationTest extends TestCase {
         };
     }
 
+    @Test
     public void test404() throws ServletException, IOException {
         MockHttpServletResponse response = run("/foo.action", filterPrepare, filterExecute, failFilter);
         assertEquals(404, response.getStatus());
     }
 
+    @Test
     public void test200() throws ServletException, IOException {
         MockHttpServletResponse response = run("/hello.action", filterPrepare, filterExecute, failFilter);
         assertEquals(200, response.getStatus());
     }
 
+    @Test
     public void testStaticFallthrough() throws ServletException, IOException {
         MockHttpServletResponse response = run("/foo.txt", filterPrepare, filterExecute, stringFilter);
         assertEquals(200, response.getStatus());
@@ -78,12 +95,14 @@ public class TwoFilterIntegrationTest extends TestCase {
 
     }
 
+    @Test
     public void testStaticExecute() throws ServletException, IOException {
         MockHttpServletResponse response = run("/static/utils.js", filterPrepare, filterExecute, failFilter);
         assertEquals(200, response.getStatus());
         assertTrue(response.getContentAsString().contains("StrutsUtils"));
     }
 
+    @Test
     public void testFilterInMiddle() throws ServletException, IOException {
         Filter middle = new Filter() {
             public void init(FilterConfig filterConfig) throws ServletException {}
@@ -129,6 +148,4 @@ public class TwoFilterIntegrationTest extends TestCase {
         assertNull(Dispatcher.getInstance());
         return response;
     }
-
-
 }

--- a/core/src/test/java/org/apache/struts2/dispatcher/TwoFilterIntegrationTest.java
+++ b/core/src/test/java/org/apache/struts2/dispatcher/TwoFilterIntegrationTest.java
@@ -36,6 +36,7 @@ import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Map;
 
@@ -104,6 +105,26 @@ public class TwoFilterIntegrationTest {
             assertEquals("hello", ActionContext.getContext().getActionInvocation().getProxy().getActionName());
         });
         MockHttpServletResponse response = run("/hello.action", filterPrepare, middle, filterExecute, failFilter);
+        assertEquals(200, response.getStatus());
+    }
+
+    @Test
+    public void testActionContextCreatedForExcludedUrlWhenEnabled() throws ServletException, IOException {
+        Filter middle = newFilter((req, res, chain) -> {
+            assertNotNull(ActionContext.getContext());
+            chain.doFilter(req, res);
+            assertNotNull(ActionContext.getContext());
+        });
+
+        MockHttpServletResponse response = run(
+                "/excluded/hello.action",
+                new HashMap<String, String>() {{
+                    put("struts.alwaysCreateActionContext", "true");
+                    put("struts.action.excludePattern", "^/excluded/hello.action");
+                }},
+                filterPrepare,
+                middle,
+                filterExecute);
         assertEquals(200, response.getStatus());
     }
 

--- a/core/src/test/java/org/apache/struts2/dispatcher/TwoFilterIntegrationTest.java
+++ b/core/src/test/java/org/apache/struts2/dispatcher/TwoFilterIntegrationTest.java
@@ -41,6 +41,7 @@ import java.util.LinkedList;
 import java.util.Map;
 
 import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonMap;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -105,6 +106,43 @@ public class TwoFilterIntegrationTest {
             assertEquals("hello", ActionContext.getContext().getActionInvocation().getProxy().getActionName());
         });
         MockHttpServletResponse response = run("/hello.action", filterPrepare, middle, filterExecute, failFilter);
+        assertEquals(200, response.getStatus());
+    }
+
+    /**
+     * It is possible for a Struts excluded URL to be forwarded to a Struts URL. If this happens, the ActionContext
+     * should not be cleared until the very first execution of the StrutsPrepareFilter, otherwise SiteMesh will malfunction.
+     */
+    @Test
+    public void testActionContextNotClearedUntilEndWhenForwardedFromExcludedUrl() throws ServletException, IOException {
+        Filter firstFilter = newFilter((req, res, chain) -> {
+            chain.doFilter(req, res);
+            // Assert ActionContext cleared at end of request lifecycle
+            assertNull(ActionContext.getContext());
+        });
+        Filter dummySiteMesh = newFilter((req, res, chain) -> {
+            // Assert ActionContext not created initially, as URL is Struts excluded
+            assertNull(ActionContext.getContext());
+            chain.doFilter(req, res);
+            // Assert ActionContext not cleared by second StrutsPrepareFilter even though it created it
+            assertNotNull(ActionContext.getContext());
+        });
+        Filter dummyForward = newFilter((req, res, chain) -> {
+            MockHttpServletRequest castReq = (MockHttpServletRequest) req;
+            String oldUri = castReq.getRequestURI();
+            castReq.setRequestURI("/hello.action");
+            chain.doFilter(castReq, res);
+            castReq.setRequestURI(oldUri);
+        });
+        MockHttpServletResponse response = run(
+                "/excluded/hello.action",
+                singletonMap("struts.action.excludePattern", "^/excluded/hello.action"),
+                firstFilter,
+                filterPrepare,
+                dummySiteMesh,
+                filterExecute,
+                dummyForward,
+                filterPrepare);
         assertEquals(200, response.getStatus());
     }
 


### PR DESCRIPTION
WW-5267
--
SiteMesh can be applied to URLs that are not Struts actions, in which case we need to still ensure the ActionContext exists.