### PR TITLE
WW-5292 Allow overriding of Operations classes in two filter setup and assorted clean up

### DIFF
--- a/core/src/main/java/com/opensymphony/xwork2/config/ConfigurationManager.java
+++ b/core/src/main/java/com/opensymphony/xwork2/config/ConfigurationManager.java
@@ -210,7 +210,7 @@ public class ConfigurationManager {
     private boolean needReloadContainerProviders() {
         Optional<ContainerProvider> provider = containerProviders.stream().filter(ContainerProvider::needsReload).findAny();
         if (provider.isPresent()) {
-            LOG.info("Detected container provider [{}] needs to be reloaded.", provider);
+            LOG.info("Detected container provider [{}] needs to be reloaded.", provider.get());
             return true;
         }
         return false;

--- a/core/src/main/java/org/apache/struts2/dispatcher/PrepareOperations.java
+++ b/core/src/main/java/org/apache/struts2/dispatcher/PrepareOperations.java
@@ -229,13 +229,14 @@ public class PrepareOperations {
      *
      * @return <tt>true</tt> if the request URI matches one of the given patterns
      */
-    public boolean isUrlExcluded( HttpServletRequest request, List<Pattern> excludedPatterns ) {
-        if (excludedPatterns != null) {
-            String uri = RequestUtils.getUri(request);
-            for ( Pattern pattern : excludedPatterns ) {
-                if (pattern.matcher(uri).matches()) {
-                    return true;
-                }
+    public boolean isUrlExcluded(HttpServletRequest request, List<Pattern> excludedPatterns) {
+        if (excludedPatterns == null) {
+            return false;
+        }
+        String uri = RequestUtils.getUri(request);
+        for (Pattern pattern : excludedPatterns) {
+            if (pattern.matcher(uri).matches()) {
+                return true;
             }
         }
         return false;

--- a/core/src/main/java/org/apache/struts2/dispatcher/filter/StrutsExecuteFilter.java
+++ b/core/src/main/java/org/apache/struts2/dispatcher/filter/StrutsExecuteFilter.java
@@ -20,12 +20,17 @@ package org.apache.struts2.dispatcher.filter;
 
 import org.apache.struts2.StrutsStatics;
 import org.apache.struts2.dispatcher.Dispatcher;
-import org.apache.struts2.dispatcher.mapper.ActionMapping;
 import org.apache.struts2.dispatcher.ExecuteOperations;
 import org.apache.struts2.dispatcher.InitOperations;
 import org.apache.struts2.dispatcher.PrepareOperations;
+import org.apache.struts2.dispatcher.mapper.ActionMapping;
 
-import javax.servlet.*;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -46,14 +51,43 @@ public class StrutsExecuteFilter implements StrutsStatics, Filter {
 
     protected synchronized void lazyInit() {
         if (execute == null) {
-            InitOperations init = new InitOperations();
+            InitOperations init = createInitOperations();
             Dispatcher dispatcher = init.findDispatcherOnThread();
             init.initStaticContentLoader(new FilterHostConfig(filterConfig), dispatcher);
 
-            prepare = new PrepareOperations(dispatcher);
-            execute = new ExecuteOperations(dispatcher);
+            prepare = createPrepareOperations(dispatcher);
+            execute = createExecuteOperations(dispatcher);
         }
+    }
 
+    /**
+     * Creates a new instance of {@link InitOperations} to be used during
+     * initialising {@link Dispatcher}
+     *
+     * @return instance of {@link InitOperations}
+     */
+    protected InitOperations createInitOperations() {
+        return new InitOperations();
+    }
+
+    /**
+     * Creates a new instance of {@link PrepareOperations} to be used during
+     * initialising {@link Dispatcher}
+     *
+     * @return instance of {@link PrepareOperations}
+     */
+    protected PrepareOperations createPrepareOperations(Dispatcher dispatcher) {
+        return new PrepareOperations(dispatcher);
+    }
+
+    /**
+     * Creates a new instance of {@link ExecuteOperations} to be used during
+     * initialising {@link Dispatcher}
+     *
+     * @return instance of {@link ExecuteOperations}
+     */
+    protected ExecuteOperations createExecuteOperations(Dispatcher dispatcher) {
+        return new ExecuteOperations(dispatcher);
     }
 
     public void doFilter(ServletRequest req, ServletResponse res, FilterChain chain) throws IOException, ServletException {

--- a/core/src/main/java/org/apache/struts2/dispatcher/filter/StrutsPrepareFilter.java
+++ b/core/src/main/java/org/apache/struts2/dispatcher/filter/StrutsPrepareFilter.java
@@ -43,7 +43,7 @@ public class StrutsPrepareFilter implements StrutsStatics, Filter {
     protected static final String REQUEST_EXCLUDED_FROM_ACTION_MAPPING = StrutsPrepareFilter.class.getName() + ".REQUEST_EXCLUDED_FROM_ACTION_MAPPING";
 
     protected PrepareOperations prepare;
-    protected List<Pattern> excludedPatterns = null;
+    protected List<Pattern> excludedPatterns;
 
     public void init(FilterConfig filterConfig) throws ServletException {
         InitOperations init = createInitOperations();
@@ -53,6 +53,7 @@ public class StrutsPrepareFilter implements StrutsStatics, Filter {
             dispatcher = init.initDispatcher(config);
 
             prepare = createPrepareOperations(dispatcher);
+            // Note: Currently, excluded patterns are not refreshed following an XWork config reload
             this.excludedPatterns = init.buildExcludedPatternsList(dispatcher);
 
             postInit(dispatcher, filterConfig);
@@ -101,7 +102,7 @@ public class StrutsPrepareFilter implements StrutsStatics, Filter {
         boolean didWrap = false;
         try {
             prepare.trackRecursion(request);
-            if (excludedPatterns != null && prepare.isUrlExcluded(request, excludedPatterns)) {
+            if (prepare.isUrlExcluded(request, excludedPatterns)) {
                 request.setAttribute(REQUEST_EXCLUDED_FROM_ACTION_MAPPING, true);
             } else {
                 request.setAttribute(REQUEST_EXCLUDED_FROM_ACTION_MAPPING, false);

--- a/core/src/main/java/org/apache/struts2/dispatcher/filter/StrutsPrepareFilter.java
+++ b/core/src/main/java/org/apache/struts2/dispatcher/filter/StrutsPrepareFilter.java
@@ -46,13 +46,13 @@ public class StrutsPrepareFilter implements StrutsStatics, Filter {
     protected List<Pattern> excludedPatterns = null;
 
     public void init(FilterConfig filterConfig) throws ServletException {
-        InitOperations init = new InitOperations();
+        InitOperations init = createInitOperations();
         Dispatcher dispatcher = null;
         try {
             FilterHostConfig config = new FilterHostConfig(filterConfig);
             dispatcher = init.initDispatcher(config);
 
-            prepare = new PrepareOperations(dispatcher);
+            prepare = createPrepareOperations(dispatcher);
             this.excludedPatterns = init.buildExcludedPatternsList(dispatcher);
 
             postInit(dispatcher, filterConfig);
@@ -62,6 +62,26 @@ public class StrutsPrepareFilter implements StrutsStatics, Filter {
             }
             init.cleanup();
         }
+    }
+
+    /**
+     * Creates a new instance of {@link InitOperations} to be used during
+     * initialising {@link Dispatcher}
+     *
+     * @return instance of {@link InitOperations}
+     */
+    protected InitOperations createInitOperations() {
+        return new InitOperations();
+    }
+
+    /**
+     * Creates a new instance of {@link PrepareOperations} to be used during
+     * initialising {@link Dispatcher}
+     *
+     * @return instance of {@link PrepareOperations}
+     */
+    protected PrepareOperations createPrepareOperations(Dispatcher dispatcher) {
+        return new PrepareOperations(dispatcher);
     }
 
     /**

--- a/core/src/test/java/org/apache/struts2/dispatcher/PrepareOperationsTest.java
+++ b/core/src/test/java/org/apache/struts2/dispatcher/PrepareOperationsTest.java
@@ -73,10 +73,12 @@ public class PrepareOperationsTest extends StrutsInternalTestCase {
         });
         IntStream.range(0, mockedRecursions - 1).forEach(i -> prepare.cleanupWrappedRequest(req));
 
+        // Assert org.apache.struts2.dispatcher.Dispatcher#cleanUpRequest has not yet run
         assertNotNull(ContainerHolder.get());
 
         prepare.cleanupWrappedRequest(req);
 
+        // Assert org.apache.struts2.dispatcher.Dispatcher#cleanUpRequest has run after final #cleanupWrappedRequest
         assertNull(ContainerHolder.get());
     }
 }

--- a/core/src/test/java/org/apache/struts2/dispatcher/StrutsPrepareAndExecuteFilterIntegrationTest.java
+++ b/core/src/test/java/org/apache/struts2/dispatcher/StrutsPrepareAndExecuteFilterIntegrationTest.java
@@ -19,28 +19,33 @@
 package org.apache.struts2.dispatcher;
 
 import com.opensymphony.xwork2.ActionContext;
-import junit.framework.TestCase;
-import org.apache.struts2.dispatcher.Dispatcher;
 import org.apache.struts2.dispatcher.filter.StrutsPrepareAndExecuteFilter;
+import org.junit.Test;
 import org.springframework.mock.web.MockFilterChain;
 import org.springframework.mock.web.MockFilterConfig;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
+import javax.servlet.FilterConfig;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
-import javax.servlet.FilterConfig;
-import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
-import java.util.regex.Pattern;
 import java.util.ArrayList;
+import java.util.regex.Pattern;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Integration tests for the filter
  */
-public class StrutsPrepareAndExecuteFilterIntegrationTest extends TestCase {
+public class StrutsPrepareAndExecuteFilterIntegrationTest {
 
+    @Test
     public void test404() throws ServletException, IOException {
         MockHttpServletRequest request = new MockHttpServletRequest();
         MockHttpServletResponse response = new MockHttpServletResponse();
@@ -61,6 +66,7 @@ public class StrutsPrepareAndExecuteFilterIntegrationTest extends TestCase {
         assertNull(Dispatcher.getInstance());
     }
 
+    @Test
     public void test200() throws ServletException, IOException {
         MockHttpServletRequest request = new MockHttpServletRequest();
         MockHttpServletResponse response = new MockHttpServletResponse();
@@ -81,6 +87,7 @@ public class StrutsPrepareAndExecuteFilterIntegrationTest extends TestCase {
         assertNull(Dispatcher.getInstance());
     }
 
+    @Test
     public void testActionMappingLookup() throws ServletException, IOException {
         MockHttpServletRequest request = new MockHttpServletRequest();
         MockHttpServletResponse response = new MockHttpServletResponse();
@@ -115,6 +122,7 @@ public class StrutsPrepareAndExecuteFilterIntegrationTest extends TestCase {
         assertTrue((Boolean) request.getAttribute("__invoked"));
     }
 
+    @Test
     public void testUriPatternExclusion() throws ServletException, IOException {
         MockHttpServletRequest request = new MockHttpServletRequest();
         MockHttpServletResponse response = new MockHttpServletResponse();
@@ -131,7 +139,7 @@ public class StrutsPrepareAndExecuteFilterIntegrationTest extends TestCase {
             @Override
             public void init( FilterConfig filterConfig ) throws ServletException {
                 super.init(filterConfig);
-                excludedPatterns = new ArrayList<Pattern>();
+                excludedPatterns = new ArrayList<>();
                 excludedPatterns.add(Pattern.compile(".*hello.*"));
             }
         };
@@ -141,6 +149,7 @@ public class StrutsPrepareAndExecuteFilterIntegrationTest extends TestCase {
         assertEquals("invoked", request.getAttribute("i_was"));
     }
 
+    @Test
     public void testStaticFallthrough() throws ServletException, IOException {
         MockHttpServletRequest request = new MockHttpServletRequest();
         MockHttpServletResponse response = new MockHttpServletResponse();
@@ -168,6 +177,7 @@ public class StrutsPrepareAndExecuteFilterIntegrationTest extends TestCase {
         assertNull(Dispatcher.getInstance());
     }
 
+    @Test
     public void testStaticExecute() throws ServletException, IOException {
         MockHttpServletRequest request = new MockHttpServletRequest();
         MockHttpServletResponse response = new MockHttpServletResponse();
@@ -189,6 +199,7 @@ public class StrutsPrepareAndExecuteFilterIntegrationTest extends TestCase {
         assertNull(Dispatcher.getInstance());
     }
 
+    @Test
     public void testDestroy() throws ServletException {
         MockFilterConfig filterConfig = new MockFilterConfig();
         final MockPrepareOperations[] prepareOperations = {null};
@@ -208,7 +219,7 @@ public class StrutsPrepareAndExecuteFilterIntegrationTest extends TestCase {
         assertTrue(prepareOperations[0].isCleaned());
     }
 
-    private class MockPrepareOperations extends PrepareOperations {
+    private static class MockPrepareOperations extends PrepareOperations {
         private boolean cleaned;
 
         public MockPrepareOperations(Dispatcher dispatcher) {

--- a/core/src/test/java/org/apache/struts2/dispatcher/TwoFilterIntegrationTest.java
+++ b/core/src/test/java/org/apache/struts2/dispatcher/TwoFilterIntegrationTest.java
@@ -19,27 +19,41 @@
 package org.apache.struts2.dispatcher;
 
 import com.opensymphony.xwork2.ActionContext;
-import junit.framework.TestCase;
-import org.apache.struts2.dispatcher.Dispatcher;
-import org.apache.struts2.dispatcher.PrepareOperations;
 import org.apache.struts2.dispatcher.filter.StrutsExecuteFilter;
 import org.apache.struts2.dispatcher.filter.StrutsPrepareFilter;
-import org.springframework.mock.web.*;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockFilterConfig;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
 
-import javax.servlet.*;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
 import java.io.IOException;
-import java.util.LinkedList;
 import java.util.Arrays;
+import java.util.LinkedList;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Integration tests for the filter
  */
-public class TwoFilterIntegrationTest extends TestCase {
-    StrutsExecuteFilter filterExecute;
-    StrutsPrepareFilter filterPrepare;
-    Filter failFilter;
+public class TwoFilterIntegrationTest {
+    private StrutsExecuteFilter filterExecute;
+    private StrutsPrepareFilter filterPrepare;
+    private Filter failFilter;
     private Filter stringFilter;
 
+    @Before
     public void setUp() {
         filterPrepare = new StrutsPrepareFilter();
         filterExecute = new StrutsExecuteFilter();
@@ -61,16 +75,19 @@ public class TwoFilterIntegrationTest extends TestCase {
         };
     }
 
+    @Test
     public void test404() throws ServletException, IOException {
         MockHttpServletResponse response = run("/foo.action", filterPrepare, filterExecute, failFilter);
         assertEquals(404, response.getStatus());
     }
 
+    @Test
     public void test200() throws ServletException, IOException {
         MockHttpServletResponse response = run("/hello.action", filterPrepare, filterExecute, failFilter);
         assertEquals(200, response.getStatus());
     }
 
+    @Test
     public void testStaticFallthrough() throws ServletException, IOException {
         MockHttpServletResponse response = run("/foo.txt", filterPrepare, filterExecute, stringFilter);
         assertEquals(200, response.getStatus());
@@ -78,12 +95,14 @@ public class TwoFilterIntegrationTest extends TestCase {
 
     }
 
+    @Test
     public void testStaticExecute() throws ServletException, IOException {
         MockHttpServletResponse response = run("/static/utils.js", filterPrepare, filterExecute, failFilter);
         assertEquals(200, response.getStatus());
         assertTrue(response.getContentAsString().contains("StrutsUtils"));
     }
 
+    @Test
     public void testFilterInMiddle() throws ServletException, IOException {
         Filter middle = new Filter() {
             public void init(FilterConfig filterConfig) throws ServletException {}
@@ -129,6 +148,4 @@ public class TwoFilterIntegrationTest extends TestCase {
         assertNull(Dispatcher.getInstance());
         return response;
     }
-
-
 }


### PR DESCRIPTION
WW-5292
--
I copied this [existing commit](https://github.com/apache/struts/commit/6651089e823d2d2934f0597ab690ea9322f584e3) to the two filter setup.

I also included some assorted fixes in this PR, including cherry-picks from the rejected #663.