### PR TITLE
Improve [WW-4434] - add documentation and rename existing ftl to achieve the wanted behaviour

### DIFF
--- a/core/src/main/resources/template/simple/datetextfield.ftl
+++ b/core/src/main/resources/template/simple/datetextfield.ftl
@@ -18,6 +18,4 @@
  * under the License.
  */
 -->
-<#include "/${parameters.templateDir}/${parameters.expandTheme}/controlheader.ftl" />
-<#include "/${parameters.templateDir}/simple/datetext.ftl" />
-<#include "/${parameters.templateDir}/${parameters.expandTheme}/controlfooter.ftl" />
+<#lt/><div>Tag <pre style="display: inline-block">&lt;s:datetextfield/&gt;</pre> works only with the JavaTemplates Plugin!</div><#rt/>

--- a/core/src/main/resources/template/xhtml/datetextfield.ftl
+++ b/core/src/main/resources/template/xhtml/datetextfield.ftl
@@ -18,4 +18,6 @@
  * under the License.
  */
 -->
-<#lt/><div>Tag <pre style="display: inline-block">&lt;s:datetext/&gt;</pre> works only with the JavaTemplates Plugin!</div><#rt/>
+<#include "/${parameters.templateDir}/${parameters.expandTheme}/controlheader.ftl" />
+<#include "/${parameters.templateDir}/simple/datetextfield.ftl" />
+<#include "/${parameters.templateDir}/${parameters.expandTheme}/controlfooter.ftl" />

--- a/core/src/site/resources/tags/datetextfield.html
+++ b/core/src/site/resources/tags/datetextfield.html
@@ -12,7 +12,10 @@ Please do not edit it directly.
 		<h2>Description</h2>
 		<p>
 		<!-- START SNIPPET: tagdescription -->
-		Render an HTML input fields with the date time
+		Render an HTML input fields with the date time.
+		<br/>
+		<br/>
+		<b>Hint:</b> This tag works only with the JavaTemplates plugin see <a href="https://struts.apache.org/plugins/javatemplates/ for more details.">the plugin documentation</a> for more details.
 		<!-- END SNIPPET: tagdescription -->
 		</p>
 


### PR DESCRIPTION
I stumbled across the ticket https://issues.apache.org/jira/browse/WW-4434 during development, because I wanted to use the s:datetextfield.
I still got an exception In version 2.5.30 as I used the tag in the simple theme.
With this PR I want to improve the documentation and fix the current available ftl so that others will not get this error too :-)

Best regards
fischey