### PR TITLE
[WW-5310] Properly parses param value with equal sign

### DIFF
--- a/core/src/main/java/org/apache/struts2/url/StrutsQueryStringParser.java
+++ b/core/src/main/java/org/apache/struts2/url/StrutsQueryStringParser.java
@@ -55,19 +55,16 @@ public class StrutsQueryStringParser implements QueryStringParser {
                 LOG.debug("Param [{}] is blank, skipping", param);
                 continue;
             }
-
-            String[] tmpParams = param.split("=");
-            String paramName = null;
+            String paramName;
             String paramValue = "";
-            if (tmpParams.length > 0) {
-                paramName = tmpParams[0];
+            int index = param.indexOf("=");
+            if (index > -1) {
+                paramName = param.substring(0, index);
+                paramValue = param.substring(index + 1);
+            } else {
+                paramName = param;
             }
-            if (tmpParams.length > 1) {
-                paramValue = tmpParams[1];
-            }
-            if (paramName != null) {
-                extractParam(paramName, paramValue, queryParams, forceValueArray);
-            }
+            extractParam(paramName, paramValue, queryParams, forceValueArray);
         }
         return queryParams;
     }

--- a/core/src/test/java/org/apache/struts2/url/StrutsQueryStringParserTest.java
+++ b/core/src/test/java/org/apache/struts2/url/StrutsQueryStringParserTest.java
@@ -76,6 +76,33 @@ public class StrutsQueryStringParserTest {
         assertEquals("value with space", queryParameters.get("name"));
     }
 
+    @Test
+    public void shouldProperlySplitParamsWithDoubleEqualSign() {
+        Map<String, Object> queryParameters = parser.parse("id1=n123=&id2=n3456", false);
+
+        assertTrue(queryParameters.containsKey("id1"));
+        assertTrue(queryParameters.containsKey("id2"));
+        assertEquals("n123=", queryParameters.get("id1"));
+        assertEquals("n3456", queryParameters.get("id2"));
+    }
+
+    @Test
+    public void shouldHandleParamWithNoValue1() {
+        Map<String, Object> queryParameters = parser.parse("paramNoValue", false);
+
+        assertTrue(queryParameters.containsKey("paramNoValue"));
+        assertEquals("", queryParameters.get("paramNoValue"));
+    }
+
+    @Test
+    public void shouldHandleParamWithNoValue2() {
+        Map<String, Object> queryParameters = parser.parse("paramNoValue&param1=1234", false);
+
+        assertTrue(queryParameters.containsKey("paramNoValue"));
+        assertTrue(queryParameters.containsKey("param1"));
+        assertEquals("1234", queryParameters.get("param1"));
+    }
+
     @Before
     public void setUp() throws Exception {
         this.parser = new StrutsQueryStringParser(new StrutsUrlDecoder());


### PR DESCRIPTION
Fixes [WW-5310](https://issues.apache.org/jira/browse/WW-5310)