### PR TITLE
WW-5288 follow-up test case updates

### DIFF
--- a/core/src/main/java/com/opensymphony/xwork2/ognl/SecurityMemberAccess.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/SecurityMemberAccess.java
@@ -129,7 +129,8 @@ public class SecurityMemberAccess implements MemberAccess {
             return false;
         }
 
-        if (isClassExcluded(targetClass)) {
+        if (targetClass != memberClass && isClassExcluded(targetClass)) {
+            // Optimization: Already checked memberClass exclusion, so if-and-only-if targetClass == memberClass, this check is redundant.
             LOG.warn("Target class [{}] of target [{}] is excluded!", targetClass, target);
             return false;
         }


### PR DESCRIPTION
Update:
- Add a few additional tests to SecurityMemberAccessTest.
- Rename some existing tests involving non-static methods to more accurately reflect that.
- Add one minor optimization to SecurityMemberAccess.