### PR TITLE
Feature/update maven dependency plugin

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -41,9 +41,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>dependency-maven-plugin</artifactId>
-                <version>1.0</version>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
                     <execution>
                         <id>copy-war</id>

--- a/pom.xml
+++ b/pom.xml
@@ -292,7 +292,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>3.1.2</version>
+                    <version>3.6.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This also fixes `mvn dependency:tree` for the project b/c it failed with

`[ERROR] Could not find goal 'tree' in plugin org.codehaus.mojo:dependency-maven-plugin:1.0 among available goals copy-dependencies, copy, unpack-dependencies, unpack -> [Help 1]`

for module "Struts 2 Assembly"