### PR TITLE
[WW-5327] Stop using JavaBeans notation for setters in SecurityMemberAccess & MemberAccessValueStack

### DIFF
--- a/core/src/main/java/com/opensymphony/xwork2/interceptor/ParametersInterceptor.java
+++ b/core/src/main/java/com/opensymphony/xwork2/interceptor/ParametersInterceptor.java
@@ -217,8 +217,8 @@ public class ParametersInterceptor extends MethodFilterInterceptor {
             //block or allow access to properties
             //see WW-2761 for more details
             MemberAccessValueStack accessValueStack = (MemberAccessValueStack) newStack;
-            accessValueStack.setAcceptProperties(acceptedPatterns.getAcceptedPatterns());
-            accessValueStack.setExcludeProperties(excludedPatterns.getExcludedPatterns());
+            accessValueStack.useAcceptProperties(acceptedPatterns.getAcceptedPatterns());
+            accessValueStack.useExcludeProperties(excludedPatterns.getExcludedPatterns());
         }
 
         for (Map.Entry<String, Parameter> entry : acceptableParameters.entrySet()) {

--- a/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlUtil.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlUtil.java
@@ -872,22 +872,22 @@ public class OgnlUtil {
         }
 
         SecurityMemberAccess memberAccess = new SecurityMemberAccess(allowStaticFieldAccess);
-        memberAccess.setDisallowProxyMemberAccess(disallowProxyMemberAccess);
+        memberAccess.disallowProxyMemberAccess(disallowProxyMemberAccess);
 
         if (devMode) {
             if (!warnReported.get()) {
                 warnReported.set(true);
                 LOG.warn("Working in devMode, using devMode excluded classes and packages!");
             }
-            memberAccess.setExcludedClasses(devModeExcludedClasses);
-            memberAccess.setExcludedPackageNamePatterns(devModeExcludedPackageNamePatterns);
-            memberAccess.setExcludedPackageNames(devModeExcludedPackageNames);
-            memberAccess.setExcludedPackageExemptClasses(devModeExcludedPackageExemptClasses);
+            memberAccess.useExcludedClasses(devModeExcludedClasses);
+            memberAccess.useExcludedPackageNamePatterns(devModeExcludedPackageNamePatterns);
+            memberAccess.useExcludedPackageNames(devModeExcludedPackageNames);
+            memberAccess.useExcludedPackageExemptClasses(devModeExcludedPackageExemptClasses);
         } else {
-            memberAccess.setExcludedClasses(excludedClasses);
-            memberAccess.setExcludedPackageNamePatterns(excludedPackageNamePatterns);
-            memberAccess.setExcludedPackageNames(excludedPackageNames);
-            memberAccess.setExcludedPackageExemptClasses(excludedPackageExemptClasses);
+            memberAccess.useExcludedClasses(excludedClasses);
+            memberAccess.useExcludedPackageNamePatterns(excludedPackageNamePatterns);
+            memberAccess.useExcludedPackageNames(excludedPackageNames);
+            memberAccess.useExcludedPackageExemptClasses(excludedPackageExemptClasses);
         }
 
         return Ognl.createDefaultContext(root, memberAccess, resolver, defaultConverter);

--- a/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlUtil.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlUtil.java
@@ -194,7 +194,7 @@ public class OgnlUtil {
             try {
                 classes.add(Class.forName(className));
             } catch (ClassNotFoundException e) {
-                LOG.warn("Class: {} doesn't exist, ignoring it!", className);
+                throw new ConfigurationException("Cannot load class for exclusion/exemption configuration: " + className, e);
             }
         }
 

--- a/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlUtil.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlUtil.java
@@ -194,7 +194,7 @@ public class OgnlUtil {
             try {
                 classes.add(Class.forName(className));
             } catch (ClassNotFoundException e) {
-                throw new ConfigurationException("Cannot load class for exclusion/exemption configuration: " + className, e);
+                LOG.warn("Class: {} doesn't exist, ignoring it!", className);
             }
         }
 

--- a/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlValueStack.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlValueStack.java
@@ -484,7 +484,7 @@ public class OgnlValueStack implements Serializable, ValueStack, ClearableValueS
 
     @Deprecated
     public void setAcceptProperties(Set<Pattern> acceptedProperties) {
-        throw new UnsupportedOperationException("Please use #useAcceptProperties instead!");
+        securityMemberAccess.useAcceptProperties(acceptedProperties);
     }
 
     public void useAcceptProperties(Set<Pattern> acceptedProperties) {
@@ -493,7 +493,7 @@ public class OgnlValueStack implements Serializable, ValueStack, ClearableValueS
 
     @Deprecated
     public void setExcludeProperties(Set<Pattern> excludeProperties) {
-        throw new UnsupportedOperationException("Please use #useExcludeProperties instead!");
+        securityMemberAccess.useExcludeProperties(excludeProperties);
     }
 
     public void useExcludeProperties(Set<Pattern> excludeProperties) {

--- a/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlValueStack.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlValueStack.java
@@ -89,11 +89,11 @@ public class OgnlValueStack implements Serializable, ValueStack, ClearableValueS
     @Inject
     protected void setOgnlUtil(OgnlUtil ognlUtil) {
         this.ognlUtil = ognlUtil;
-        securityMemberAccess.setExcludedClasses(ognlUtil.getExcludedClasses());
-        securityMemberAccess.setExcludedPackageNamePatterns(ognlUtil.getExcludedPackageNamePatterns());
-        securityMemberAccess.setExcludedPackageNames(ognlUtil.getExcludedPackageNames());
-        securityMemberAccess.setExcludedPackageExemptClasses(ognlUtil.getExcludedPackageExemptClasses());
-        securityMemberAccess.setDisallowProxyMemberAccess(ognlUtil.isDisallowProxyMemberAccess());
+        securityMemberAccess.useExcludedClasses(ognlUtil.getExcludedClasses());
+        securityMemberAccess.useExcludedPackageNamePatterns(ognlUtil.getExcludedPackageNamePatterns());
+        securityMemberAccess.useExcludedPackageNames(ognlUtil.getExcludedPackageNames());
+        securityMemberAccess.useExcludedPackageExemptClasses(ognlUtil.getExcludedPackageExemptClasses());
+        securityMemberAccess.disallowProxyMemberAccess(ognlUtil.isDisallowProxyMemberAccess());
     }
 
     protected void setRoot(XWorkConverter xworkConverter, CompoundRootAccessor accessor, CompoundRoot compoundRoot, boolean allowStaticFieldAccess) {
@@ -482,12 +482,22 @@ public class OgnlValueStack implements Serializable, ValueStack, ClearableValueS
         ((OgnlContext) context).getValues().clear();
     }
 
+    @Deprecated
     public void setAcceptProperties(Set<Pattern> acceptedProperties) {
-        securityMemberAccess.setAcceptProperties(acceptedProperties);
+        throw new UnsupportedOperationException("Please use #useAcceptProperties instead!");
     }
 
+    public void useAcceptProperties(Set<Pattern> acceptedProperties) {
+        securityMemberAccess.useAcceptProperties(acceptedProperties);
+    }
+
+    @Deprecated
     public void setExcludeProperties(Set<Pattern> excludeProperties) {
-        securityMemberAccess.setExcludeProperties(excludeProperties);
+        throw new UnsupportedOperationException("Please use #useExcludeProperties instead!");
+    }
+
+    public void useExcludeProperties(Set<Pattern> excludeProperties) {
+        securityMemberAccess.useExcludeProperties(excludeProperties);
     }
 
     @Inject

--- a/core/src/main/java/com/opensymphony/xwork2/ognl/SecurityMemberAccess.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/SecurityMemberAccess.java
@@ -304,7 +304,7 @@ public class SecurityMemberAccess implements MemberAccess {
      */
     @Deprecated
     public void setExcludeProperties(Set<Pattern> excludeProperties) {
-        throw new UnsupportedOperationException("Please use #useExcludeProperties() instead!");
+        this.excludeProperties = excludeProperties;
     }
 
     public void useExcludeProperties(Set<Pattern> excludeProperties) {
@@ -316,7 +316,7 @@ public class SecurityMemberAccess implements MemberAccess {
      */
     @Deprecated
     public void setAcceptProperties(Set<Pattern> acceptedProperties) {
-        throw new UnsupportedOperationException("Please use #useAcceptProperties() instead!");
+        this.acceptProperties = acceptedProperties;
     }
 
     public void useAcceptProperties(Set<Pattern> acceptedProperties) {
@@ -328,7 +328,7 @@ public class SecurityMemberAccess implements MemberAccess {
      */
     @Deprecated
     public void setExcludedClasses(Set<Class<?>> excludedClasses) {
-        throw new UnsupportedOperationException("Please use #useExcludedClasses() instead!");
+        this.excludedClasses = excludedClasses;
     }
 
     public void useExcludedClasses(Set<Class<?>> excludedClasses) {
@@ -340,7 +340,7 @@ public class SecurityMemberAccess implements MemberAccess {
      */
     @Deprecated
     public void setExcludedPackageNamePatterns(Set<Pattern> excludedPackageNamePatterns) {
-        throw new UnsupportedOperationException("Please use #useExcludedPackageNamePatterns() instead!");
+        this.excludedPackageNamePatterns = excludedPackageNamePatterns;
     }
 
     public void useExcludedPackageNamePatterns(Set<Pattern> excludedPackageNamePatterns) {
@@ -352,7 +352,7 @@ public class SecurityMemberAccess implements MemberAccess {
      */
     @Deprecated
     public void setExcludedPackageNames(Set<String> excludedPackageNames) {
-        throw new UnsupportedOperationException("Please use #useExcludedPackageNames() instead!");
+        this.excludedPackageNames = excludedPackageNames;
     }
 
     public void useExcludedPackageNames(Set<String> excludedPackageNames) {
@@ -364,7 +364,7 @@ public class SecurityMemberAccess implements MemberAccess {
      */
     @Deprecated
     public void setExcludedPackageExemptClasses(Set<Class<?>> excludedPackageExemptClasses) {
-        throw new UnsupportedOperationException("Please use #useExcludedPackageExemptClasses() instead!");
+        this.excludedPackageExemptClasses = excludedPackageExemptClasses;
     }
 
     public void useExcludedPackageExemptClasses(Set<Class<?>> excludedPackageExemptClasses) {
@@ -376,7 +376,7 @@ public class SecurityMemberAccess implements MemberAccess {
      */
     @Deprecated
     public void setDisallowProxyMemberAccess(boolean disallowProxyMemberAccess) {
-        throw new UnsupportedOperationException("Please use #disallowProxyMemberAccess() instead!");
+        this.disallowProxyMemberAccess = disallowProxyMemberAccess;
     }
 
     public void disallowProxyMemberAccess(boolean disallowProxyMemberAccess) {

--- a/core/src/main/java/com/opensymphony/xwork2/ognl/SecurityMemberAccess.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/SecurityMemberAccess.java
@@ -299,31 +299,87 @@ public class SecurityMemberAccess implements MemberAccess {
         return false;
     }
 
+    /**
+     * @deprecated please use {@link #useExcludeProperties(Set)}
+     */
+    @Deprecated
     public void setExcludeProperties(Set<Pattern> excludeProperties) {
+        throw new UnsupportedOperationException("Please use #useExcludeProperties() instead!");
+    }
+
+    public void useExcludeProperties(Set<Pattern> excludeProperties) {
         this.excludeProperties = excludeProperties;
     }
 
+    /**
+     * @deprecated please use {@link #useAcceptProperties(Set)}
+     */
+    @Deprecated
     public void setAcceptProperties(Set<Pattern> acceptedProperties) {
+        throw new UnsupportedOperationException("Please use #useAcceptProperties() instead!");
+    }
+
+    public void useAcceptProperties(Set<Pattern> acceptedProperties) {
         this.acceptProperties = acceptedProperties;
     }
 
+    /**
+     * @deprecated please use {@link #useExcludedClasses(Set)}
+     */
+    @Deprecated
     public void setExcludedClasses(Set<Class<?>> excludedClasses) {
+        throw new UnsupportedOperationException("Please use #useExcludedClasses() instead!");
+    }
+
+    public void useExcludedClasses(Set<Class<?>> excludedClasses) {
         this.excludedClasses = excludedClasses;
     }
 
+    /**
+     * @deprecated please use {@link #useExcludedPackageNamePatterns(Set)}
+     */
+    @Deprecated
     public void setExcludedPackageNamePatterns(Set<Pattern> excludedPackageNamePatterns) {
+        throw new UnsupportedOperationException("Please use #useExcludedPackageNamePatterns() instead!");
+    }
+
+    public void useExcludedPackageNamePatterns(Set<Pattern> excludedPackageNamePatterns) {
         this.excludedPackageNamePatterns = excludedPackageNamePatterns;
     }
 
+    /**
+     * @deprecated please use {@link #useExcludedPackageNames(Set)}
+     */
+    @Deprecated
     public void setExcludedPackageNames(Set<String> excludedPackageNames) {
+        throw new UnsupportedOperationException("Please use #useExcludedPackageNames() instead!");
+    }
+
+    public void useExcludedPackageNames(Set<String> excludedPackageNames) {
         this.excludedPackageNames = excludedPackageNames;
     }
 
+    /**
+     * @deprecated please use {@link #useExcludedPackageExemptClasses(Set)}
+     */
+    @Deprecated
     public void setExcludedPackageExemptClasses(Set<Class<?>> excludedPackageExemptClasses) {
+        throw new UnsupportedOperationException("Please use #useExcludedPackageExemptClasses() instead!");
+    }
+
+    public void useExcludedPackageExemptClasses(Set<Class<?>> excludedPackageExemptClasses) {
         this.excludedPackageExemptClasses = excludedPackageExemptClasses;
     }
 
+    /**
+     * @deprecated please use {@link #disallowProxyMemberAccess(boolean)}
+     */
+    @Deprecated
     public void setDisallowProxyMemberAccess(boolean disallowProxyMemberAccess) {
+        throw new UnsupportedOperationException("Please use #disallowProxyMemberAccess() instead!");
+    }
+
+    public void disallowProxyMemberAccess(boolean disallowProxyMemberAccess) {
         this.disallowProxyMemberAccess = disallowProxyMemberAccess;
     }
 }

--- a/core/src/main/java/com/opensymphony/xwork2/util/MemberAccessValueStack.java
+++ b/core/src/main/java/com/opensymphony/xwork2/util/MemberAccessValueStack.java
@@ -27,8 +27,20 @@ import java.util.regex.Pattern;
  */
 public interface MemberAccessValueStack {
 
+    /**
+     * @deprecated please use {@link #useExcludeProperties(Set)}
+     */
+    @Deprecated
     void setExcludeProperties(Set<Pattern> excludeProperties);
 
+    void useExcludeProperties(Set<Pattern> excludeProperties);
+
+    /**
+     * @deprecated please use {@link #useAcceptProperties(Set)}
+     */
+    @Deprecated
     void setAcceptProperties(Set<Pattern> acceptedProperties);
+
+    void useAcceptProperties(Set<Pattern> acceptedProperties);
 
 }

--- a/core/src/main/resources/struts-excluded-classes.xml
+++ b/core/src/main/resources/struts-excluded-classes.xml
@@ -2,19 +2,19 @@
 <!--
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
+ * or more contributor license agreements. See the NOTICE file
  * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
+ * regarding copyright ownership. The ASF licenses this file
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * with the License. You may obtain a copy of the License at
  *
  *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
+ * KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations
  * under the License.
  */
@@ -37,7 +37,9 @@
                 java.lang.ProcessBuilder,
                 java.lang.Thread,
                 sun.misc.Unsafe,
-                com.opensymphony.xwork2.ActionContext"/>
+                com.opensymphony.xwork2.ActionContext,
+                org.apache.commons.collections.BeanMap,
+                org.apache.commons.beanutils.BeanMap"/>
 
     <constant name="struts.devMode.excludedClasses"
               value="

--- a/core/src/main/resources/struts-excluded-classes.xml
+++ b/core/src/main/resources/struts-excluded-classes.xml
@@ -38,8 +38,8 @@
                 java.lang.Thread,
                 sun.misc.Unsafe,
                 com.opensymphony.xwork2.ActionContext,
-                org.apache.commons.collections.BeanMap,
-                org.apache.commons.beanutils.BeanMap"/>
+                com.opensymphony.xwork2.ognl.SecurityMemberAccess,
+                com.opensymphony.xwork2.ognl.OgnlValueStack"/>
 
     <constant name="struts.devMode.excludedClasses"
               value="

--- a/core/src/test/java/com/opensymphony/xwork2/ognl/SecurityMemberAccessTest.java
+++ b/core/src/test/java/com/opensymphony/xwork2/ognl/SecurityMemberAccessTest.java
@@ -75,7 +75,7 @@ public class SecurityMemberAccessTest {
 
         Set<Class<?>> excluded = new HashSet<>();
         excluded.add(FooBar.class);
-        sma.setExcludedClasses(excluded);
+        sma.useExcludedClasses(excluded);
 
         // when
         boolean accessible = sma.isAccessible(context, target, member, propertyName);
@@ -118,7 +118,7 @@ public class SecurityMemberAccessTest {
 
         Set<Class<?>> excluded = new HashSet<>();
         excluded.add(BarInterface.class);
-        sma.setExcludedClasses(excluded);
+        sma.useExcludedClasses(excluded);
 
         // when
         boolean accessible = sma.isAccessible(context, target, member, propertyName);
@@ -135,7 +135,7 @@ public class SecurityMemberAccessTest {
 
         Set<Class<?>> excluded = new HashSet<>();
         excluded.add(BarInterface.class);
-        sma.setExcludedClasses(excluded);
+        sma.useExcludedClasses(excluded);
 
         // when
         boolean accessible = sma.isAccessible(context, target, member, propertyName);
@@ -152,7 +152,7 @@ public class SecurityMemberAccessTest {
 
         Set<Class<?>> excluded = new HashSet<>();
         excluded.add(BarInterface.class);
-        sma.setExcludedClasses(excluded);
+        sma.useExcludedClasses(excluded);
 
         // when
         boolean accessible = sma.isAccessible(context, target, member, propertyName);
@@ -169,7 +169,7 @@ public class SecurityMemberAccessTest {
 
         Set<Class<?>> excluded = new HashSet<>();
         excluded.add(FooInterface.class);
-        sma.setExcludedClasses(excluded);
+        sma.useExcludedClasses(excluded);
 
         // when
         boolean accessible = sma.isAccessible(context, target, member, propertyName);
@@ -186,7 +186,7 @@ public class SecurityMemberAccessTest {
 
         Set<Class<?>> excluded = new HashSet<>();
         excluded.add(FooBarInterface.class);
-        sma.setExcludedClasses(excluded);
+        sma.useExcludedClasses(excluded);
 
         // when
         boolean accessible = sma.isAccessible(context, target, member, propertyName);
@@ -200,7 +200,7 @@ public class SecurityMemberAccessTest {
         // given
         Set<Pattern> excluded = new HashSet<>();
         excluded.add(Pattern.compile("^" + FooBar.class.getPackage().getName().replaceAll("\\.", "\\\\.") + ".*"));
-        sma.setExcludedPackageNamePatterns(excluded);
+        sma.useExcludedPackageNamePatterns(excluded);
 
         String propertyName = "stringField";
         Member member = FooBar.class.getMethod(formGetterName(propertyName));
@@ -217,11 +217,11 @@ public class SecurityMemberAccessTest {
         // given
         Set<Pattern> excluded = new HashSet<>();
         excluded.add(Pattern.compile("^" + FooBar.class.getPackage().getName().replaceAll("\\.", "\\\\.") + ".*"));
-        sma.setExcludedPackageNamePatterns(excluded);
+        sma.useExcludedPackageNamePatterns(excluded);
 
         Set<Class<?>> allowed = new HashSet<>();
         allowed.add(FooBar.class);
-        sma.setExcludedPackageExemptClasses(allowed);
+        sma.useExcludedPackageExemptClasses(allowed);
 
         String propertyName = "stringField";
         Member member = FooBar.class.getMethod(formGetterName(propertyName));
@@ -238,7 +238,7 @@ public class SecurityMemberAccessTest {
         // given
         Set<String> excluded = new HashSet<>();
         excluded.add(FooBar.class.getPackage().getName());
-        sma.setExcludedPackageNames(excluded);
+        sma.useExcludedPackageNames(excluded);
 
         String propertyName = "stringField";
         Member member = FooBar.class.getMethod(formGetterName(propertyName));
@@ -255,11 +255,11 @@ public class SecurityMemberAccessTest {
         // given
         Set<String> excluded = new HashSet<>();
         excluded.add(FooBar.class.getPackage().getName());
-        sma.setExcludedPackageNames(excluded);
+        sma.useExcludedPackageNames(excluded);
 
         Set<Class<?>> allowed = new HashSet<>();
         allowed.add(FooBar.class);
-        sma.setExcludedPackageExemptClasses(allowed);
+        sma.useExcludedPackageExemptClasses(allowed);
 
         String propertyName = "stringField";
         Member member = FooBar.class.getMethod(formGetterName(propertyName));
@@ -276,12 +276,12 @@ public class SecurityMemberAccessTest {
         // given
         Set<String> excluded = new HashSet<>();
         excluded.add(FooBar.class.getPackage().getName());
-        sma.setExcludedPackageNames(excluded);
+        sma.useExcludedPackageNames(excluded);
 
         // Exemption must exist for both classes (target and member) if they both match a banned package
         Set<Class<?>> allowed = new HashSet<>();
         allowed.add(BarInterface.class);
-        sma.setExcludedPackageExemptClasses(allowed);
+        sma.useExcludedPackageExemptClasses(allowed);
 
         String propertyName = "barLogic";
         Member member = BarInterface.class.getMethod(propertyName);
@@ -298,13 +298,13 @@ public class SecurityMemberAccessTest {
         // given
         Set<String> excluded = new HashSet<>();
         excluded.add(FooBar.class.getPackage().getName());
-        sma.setExcludedPackageNames(excluded);
+        sma.useExcludedPackageNames(excluded);
 
         // Exemption must exist for both classes (target and member) if they both match a banned package
         Set<Class<?>> allowed = new HashSet<>();
         allowed.add(BarInterface.class);
         allowed.add(FooBar.class);
-        sma.setExcludedPackageExemptClasses(allowed);
+        sma.useExcludedPackageExemptClasses(allowed);
 
         String propertyName = "barLogic";
         Member member = BarInterface.class.getMethod(propertyName);
@@ -321,7 +321,7 @@ public class SecurityMemberAccessTest {
         // given
         Set<Pattern> excluded = new HashSet<>();
         excluded.add(Pattern.compile("^" + FooBar.class.getPackage().getName().replaceAll("\\.", "\\\\.") + ".*"));
-        sma.setExcludedPackageNamePatterns(excluded);
+        sma.useExcludedPackageNamePatterns(excluded);
 
         Class<?> clazz = Class.forName("PackagelessAction");
 
@@ -337,7 +337,7 @@ public class SecurityMemberAccessTest {
         // given
         Set<Pattern> excluded = new HashSet<>();
         excluded.add(Pattern.compile("^$"));
-        sma.setExcludedPackageNamePatterns(excluded);
+        sma.useExcludedPackageNamePatterns(excluded);
 
         Class<?> clazz = Class.forName("PackagelessAction");
 
@@ -361,7 +361,7 @@ public class SecurityMemberAccessTest {
     @Test
     public void testAccessStaticMethod() throws Exception {
         // given
-        sma.setExcludedClasses(new HashSet<>(Collections.singletonList(Class.class)));
+        sma.useExcludedClasses(new HashSet<>(Collections.singletonList(Class.class)));
 
         // when
         Member method = StaticTester.class.getMethod("sayHello");
@@ -374,7 +374,7 @@ public class SecurityMemberAccessTest {
     @Test
     public void testAccessStaticField() throws Exception {
         // given
-        sma.setExcludedClasses(new HashSet<>(Collections.singletonList(Class.class)));
+        sma.useExcludedClasses(new HashSet<>(Collections.singletonList(Class.class)));
 
         // when
         Member method = StaticTester.class.getField("MAX_VALUE");
@@ -388,7 +388,7 @@ public class SecurityMemberAccessTest {
     public void testBlockedStaticFieldWhenFlagIsTrue() throws Exception {
         // given
         assignNewSma(true);
-        sma.setExcludedClasses(new HashSet<>(Collections.singletonList(Class.class)));
+        sma.useExcludedClasses(new HashSet<>(Collections.singletonList(Class.class)));
 
         // when
         Member method = StaticTester.class.getField("MAX_VALUE");
@@ -400,7 +400,7 @@ public class SecurityMemberAccessTest {
         // public static final test
         // given
         assignNewSma(true);
-        sma.setExcludedClasses(new HashSet<>(Collections.singletonList(Class.class)));
+        sma.useExcludedClasses(new HashSet<>(Collections.singletonList(Class.class)));
 
         // when
         method = StaticTester.class.getField("MIN_VALUE");
@@ -412,7 +412,7 @@ public class SecurityMemberAccessTest {
         // package static test
         // given
         assignNewSma(true);
-        sma.setExcludedClasses(new HashSet<>(Collections.singletonList(Class.class)));
+        sma.useExcludedClasses(new HashSet<>(Collections.singletonList(Class.class)));
 
         // when
         method = StaticTester.getFieldByName("PACKAGE_STRING");
@@ -424,7 +424,7 @@ public class SecurityMemberAccessTest {
         // package final static test
         // given
         assignNewSma(true);
-        sma.setExcludedClasses(new HashSet<>(Collections.singletonList(Class.class)));
+        sma.useExcludedClasses(new HashSet<>(Collections.singletonList(Class.class)));
 
         // when
         method = StaticTester.getFieldByName("FINAL_PACKAGE_STRING");
@@ -436,7 +436,7 @@ public class SecurityMemberAccessTest {
         // protected static test
         // given
         assignNewSma(true);
-        sma.setExcludedClasses(new HashSet<>(Collections.singletonList(Class.class)));
+        sma.useExcludedClasses(new HashSet<>(Collections.singletonList(Class.class)));
 
         // when
         method = StaticTester.getFieldByName("PROTECTED_STRING");
@@ -448,7 +448,7 @@ public class SecurityMemberAccessTest {
         // protected final static test
         // given
         assignNewSma(true);
-        sma.setExcludedClasses(new HashSet<>(Collections.singletonList(Class.class)));
+        sma.useExcludedClasses(new HashSet<>(Collections.singletonList(Class.class)));
 
         // when
         method = StaticTester.getFieldByName("FINAL_PROTECTED_STRING");
@@ -460,7 +460,7 @@ public class SecurityMemberAccessTest {
         // private static test
         // given
         assignNewSma(true);
-        sma.setExcludedClasses(new HashSet<>(Collections.singletonList(Class.class)));
+        sma.useExcludedClasses(new HashSet<>(Collections.singletonList(Class.class)));
 
         // when
         method = StaticTester.getFieldByName("PRIVATE_STRING");
@@ -472,7 +472,7 @@ public class SecurityMemberAccessTest {
         // private final static test
         // given
         assignNewSma(true);
-        sma.setExcludedClasses(new HashSet<>(Collections.singletonList(Class.class)));
+        sma.useExcludedClasses(new HashSet<>(Collections.singletonList(Class.class)));
 
         // when
         method = StaticTester.getFieldByName("FINAL_PRIVATE_STRING");
@@ -486,7 +486,7 @@ public class SecurityMemberAccessTest {
     public void testBlockedStaticFieldWhenFlagIsFalse() throws Exception {
         // given
         assignNewSma(false);
-        sma.setExcludedClasses(new HashSet<>(Collections.singletonList(Class.class)));
+        sma.useExcludedClasses(new HashSet<>(Collections.singletonList(Class.class)));
 
         // when
         Member method = StaticTester.class.getField("MAX_VALUE");
@@ -498,7 +498,7 @@ public class SecurityMemberAccessTest {
         // public static final test
         // given
         assignNewSma(false);
-        sma.setExcludedClasses(new HashSet<>(Collections.singletonList(Class.class)));
+        sma.useExcludedClasses(new HashSet<>(Collections.singletonList(Class.class)));
 
         // when
         method = StaticTester.class.getField("MIN_VALUE");
@@ -510,7 +510,7 @@ public class SecurityMemberAccessTest {
         // package static test
         // given
         assignNewSma(false);
-        sma.setExcludedClasses(new HashSet<>(Collections.singletonList(Class.class)));
+        sma.useExcludedClasses(new HashSet<>(Collections.singletonList(Class.class)));
 
         // when
         method = StaticTester.getFieldByName("PACKAGE_STRING");
@@ -522,7 +522,7 @@ public class SecurityMemberAccessTest {
         // package final static test
         // given
         assignNewSma(false);
-        sma.setExcludedClasses(new HashSet<>(Collections.singletonList(Class.class)));
+        sma.useExcludedClasses(new HashSet<>(Collections.singletonList(Class.class)));
 
         // when
         method = StaticTester.getFieldByName("FINAL_PACKAGE_STRING");
@@ -534,7 +534,7 @@ public class SecurityMemberAccessTest {
         // protected static test
         // given
         assignNewSma(false);
-        sma.setExcludedClasses(new HashSet<>(Collections.singletonList(Class.class)));
+        sma.useExcludedClasses(new HashSet<>(Collections.singletonList(Class.class)));
 
         // when
         method = StaticTester.getFieldByName("PROTECTED_STRING");
@@ -546,7 +546,7 @@ public class SecurityMemberAccessTest {
         // protected final static test
         // given
         assignNewSma(false);
-        sma.setExcludedClasses(new HashSet<>(Collections.singletonList(Class.class)));
+        sma.useExcludedClasses(new HashSet<>(Collections.singletonList(Class.class)));
 
         // when
         method = StaticTester.getFieldByName("FINAL_PROTECTED_STRING");
@@ -558,7 +558,7 @@ public class SecurityMemberAccessTest {
         // private static test
         // given
         assignNewSma(false);
-        sma.setExcludedClasses(new HashSet<>(Collections.singletonList(Class.class)));
+        sma.useExcludedClasses(new HashSet<>(Collections.singletonList(Class.class)));
 
         // when
         method = StaticTester.getFieldByName("PRIVATE_STRING");
@@ -570,7 +570,7 @@ public class SecurityMemberAccessTest {
         // private final static test
         // given
         assignNewSma(false);
-        sma.setExcludedClasses(new HashSet<>(Collections.singletonList(Class.class)));
+        sma.useExcludedClasses(new HashSet<>(Collections.singletonList(Class.class)));
 
         // when
         method = StaticTester.getFieldByName("FINAL_PRIVATE_STRING");
@@ -583,7 +583,7 @@ public class SecurityMemberAccessTest {
     @Test
     public void testBlockedStaticFieldWhenClassIsExcluded() throws Exception {
         // given
-        sma.setExcludedClasses(new HashSet<>(Arrays.asList(Class.class, StaticTester.class)));
+        sma.useExcludedClasses(new HashSet<>(Arrays.asList(Class.class, StaticTester.class)));
 
         // when
         Member method = StaticTester.class.getField("MAX_VALUE");
@@ -596,7 +596,7 @@ public class SecurityMemberAccessTest {
     @Test
     public void testBlockStaticMethodAccess() throws Exception {
         // given
-        sma.setExcludedClasses(new HashSet<>(Collections.singletonList(Class.class)));
+        sma.useExcludedClasses(new HashSet<>(Collections.singletonList(Class.class)));
 
         // when
         Member method = StaticTester.class.getMethod("sayHello");
@@ -609,7 +609,7 @@ public class SecurityMemberAccessTest {
     @Test
     public void testBlockAccessIfClassIsExcluded() throws Exception {
         // given
-        sma.setExcludedClasses(new HashSet<>(Collections.singletonList(Class.class)));
+        sma.useExcludedClasses(new HashSet<>(Collections.singletonList(Class.class)));
 
         // when
         Member method = Class.class.getMethod("getClassLoader");
@@ -622,7 +622,7 @@ public class SecurityMemberAccessTest {
    @Test
     public void testBlockAccessIfClassIsExcluded_2() throws Exception {
         // given
-        sma.setExcludedClasses(new HashSet<>(Collections.singletonList(ClassLoader.class)));
+        sma.useExcludedClasses(new HashSet<>(Collections.singletonList(ClassLoader.class)));
 
         // when
         Member method = ClassLoader.class.getMethod("loadClass", String.class);
@@ -636,7 +636,7 @@ public class SecurityMemberAccessTest {
     @Test
     public void testAllowAccessIfClassIsNotExcluded() throws Exception {
         // given
-        sma.setExcludedClasses(new HashSet<>(Collections.singletonList(ClassLoader.class)));
+        sma.useExcludedClasses(new HashSet<>(Collections.singletonList(ClassLoader.class)));
 
         // when
         Member method = Class.class.getMethod("getClassLoader");
@@ -649,7 +649,7 @@ public class SecurityMemberAccessTest {
    @Test
     public void testIllegalArgumentExceptionExpectedForTargetMemberMismatch() throws Exception {
         // given
-        sma.setExcludedClasses(new HashSet<>(Collections.singletonList(Class.class)));
+        sma.useExcludedClasses(new HashSet<>(Collections.singletonList(Class.class)));
 
         // when
         Member method = ClassLoader.class.getMethod("loadClass", String.class);
@@ -668,7 +668,7 @@ public class SecurityMemberAccessTest {
     @Test
     public void testAccessPrimitiveInt() throws Exception {
         // given
-        sma.setExcludedPackageNames(TextParseUtil.commaDelimitedStringToSet("java.lang.,ognl,javax"));
+        sma.useExcludedPackageNames(TextParseUtil.commaDelimitedStringToSet("java.lang.,ognl,javax"));
 
         String propertyName = "intField";
         Member member = FooBar.class.getMethod(formGetterName(propertyName));
@@ -683,7 +683,7 @@ public class SecurityMemberAccessTest {
     @Test
     public void testAccessPrimitiveDoubleWithNames() throws Exception {
         // given
-        sma.setExcludedPackageNames(TextParseUtil.commaDelimitedStringToSet("ognl.,javax."));
+        sma.useExcludedPackageNames(TextParseUtil.commaDelimitedStringToSet("ognl.,javax."));
 
 
         Set<Class<?>> excluded = new HashSet<>();
@@ -692,7 +692,7 @@ public class SecurityMemberAccessTest {
         excluded.add(System.class);
         excluded.add(Class.class);
         excluded.add(ClassLoader.class);
-        sma.setExcludedClasses(excluded);
+        sma.useExcludedClasses(excluded);
 
         String propertyName = "doubleValue";
         double myDouble = 1;
@@ -738,7 +738,7 @@ public class SecurityMemberAccessTest {
         // given
         Set<Pattern> patterns = new HashSet<>();
         patterns.add(Pattern.compile("^java\\.lang\\..*"));
-        sma.setExcludedPackageNamePatterns(patterns);
+        sma.useExcludedPackageNamePatterns(patterns);
 
         String propertyName = "doubleValue";
         double myDouble = 1;
@@ -756,7 +756,7 @@ public class SecurityMemberAccessTest {
         // given
         Set<Class<?>> excluded = new HashSet<>();
         excluded.add(ognl.MemberAccess.class);
-        sma.setExcludedClasses(excluded);
+        sma.useExcludedClasses(excluded);
 
         String propertyName = "excludedClasses";
         String setter = "setExcludedClasses";
@@ -774,7 +774,7 @@ public class SecurityMemberAccessTest {
         // given
         Set<Class<?>> excluded = new HashSet<>();
         excluded.add(SecurityMemberAccess.class);
-        sma.setExcludedClasses(excluded);
+        sma.useExcludedClasses(excluded);
 
         String propertyName = "excludedClasses";
         String setter = "setExcludedClasses";
@@ -790,7 +790,7 @@ public class SecurityMemberAccessTest {
     @Test
     public void testPackageNameExclusionAsCommaDelimited() {
         // given
-        sma.setExcludedPackageNames(TextParseUtil.commaDelimitedStringToSet("java.lang."));
+        sma.useExcludedPackageNames(TextParseUtil.commaDelimitedStringToSet("java.lang."));
 
         // when
         boolean actual = sma.isPackageExcluded(String.class, String.class);

--- a/core/src/test/java/org/apache/struts2/util/SecurityMemberAccessInServletsTest.java
+++ b/core/src/test/java/org/apache/struts2/util/SecurityMemberAccessInServletsTest.java
@@ -45,7 +45,7 @@ public class SecurityMemberAccessInServletsTest extends StrutsInternalTestCase {
 
         Set<Pattern> excluded = new HashSet<Pattern>();
         excluded.add(Pattern.compile("^(?!javax\\.servlet\\..+)(javax\\..+)"));
-        sma.setExcludedPackageNamePatterns(excluded);
+        sma.useExcludedPackageNamePatterns(excluded);
 
         String propertyName = "value";
         Member member = TagSupport.class.getMethod("doStartTag");
@@ -63,7 +63,7 @@ public class SecurityMemberAccessInServletsTest extends StrutsInternalTestCase {
 
         Set<Pattern> excluded = new HashSet<>();
         excluded.add(Pattern.compile("^javax\\..+"));
-        sma.setExcludedPackageNamePatterns(excluded);
+        sma.useExcludedPackageNamePatterns(excluded);
 
         String propertyName = "value";
         Member member = TagSupport.class.getMethod("doStartTag");

--- a/plugins/spring/src/test/java/com/opensymphony/xwork2/ognl/SecurityMemberAccessProxyTest.java
+++ b/plugins/spring/src/test/java/com/opensymphony/xwork2/ognl/SecurityMemberAccessProxyTest.java
@@ -46,7 +46,7 @@ public class SecurityMemberAccessProxyTest extends XWorkTestCase {
             "chaintoAOPedTestSubBeanAction", null, context);
 
         SecurityMemberAccess sma = new SecurityMemberAccess(true);
-        sma.setDisallowProxyMemberAccess(true);
+        sma.disallowProxyMemberAccess(true);
 
         Member member = proxy.getAction().getClass().getMethod("isExposeProxy");
 

--- a/plugins/spring/src/test/java/com/test/SecurityMemberAccessProxyTest.java
+++ b/plugins/spring/src/test/java/com/test/SecurityMemberAccessProxyTest.java
@@ -47,7 +47,7 @@ public class SecurityMemberAccessProxyTest extends XWorkTestCase {
             "chaintoAOPedTestSubBeanAction", null, context);
 
         SecurityMemberAccess sma = new SecurityMemberAccess(true);
-        sma.setDisallowProxyMemberAccess(true);
+        sma.disallowProxyMemberAccess(true);
 
         Member member = proxy.getAction().getClass().getMethod("isExposeProxy");
 


### PR DESCRIPTION
Closes [WW-5327](https://issues.apache.org/jira/browse/WW-5327)
Closes #567