### PR TITLE
WW-5334 Enable usage of junit-plugin inside velocity-plugin

### DIFF
--- a/apps/rest-showcase/pom.xml
+++ b/apps/rest-showcase/pom.xml
@@ -56,12 +56,10 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>${log4j2.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>${log4j2.version}</version>
         </dependency>
 
         <dependency>

--- a/apps/showcase/pom.xml
+++ b/apps/showcase/pom.xml
@@ -130,10 +130,6 @@
             <groupId>org.directwebremoting</groupId>
             <artifactId>dwr</artifactId>
         </dependency>
-        <dependency>
-            <groupId>commons-fileupload</groupId>
-            <artifactId>commons-fileupload</artifactId>
-        </dependency>
 
        <dependency>
            <groupId>junit</groupId>

--- a/apps/showcase/pom.xml
+++ b/apps/showcase/pom.xml
@@ -108,22 +108,18 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>${log4j2.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>${log4j2.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-jcl</artifactId>
-            <version>${log4j2.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>${log4j2.version}</version>
         </dependency>
 
         <dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -260,7 +260,6 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>${log4j2.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/plugins/bean-validation/pom.xml
+++ b/plugins/bean-validation/pom.xml
@@ -55,17 +55,6 @@
             <artifactId>javax.el</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <!-- this library is excluded in the parent pom as it clashes with Easymock dependencies -->
-        <dependency>
-            <groupId>org.objenesis</groupId>
-            <artifactId>objenesis</artifactId>
-            <version>3.2</version>
-        </dependency>
 
         <!--
          The Java EE API modules listed below are all marked @Deprecated(forRemoval=true), because they are scheduled

--- a/plugins/cdi/pom.xml
+++ b/plugins/cdi/pom.xml
@@ -59,13 +59,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-            <version>${log4j2.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
             <scope>test</scope>

--- a/plugins/convention/pom.xml
+++ b/plugins/convention/pom.xml
@@ -68,11 +68,6 @@
             <artifactId>easymock</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>javax.servlet.jsp</groupId>
-            <artifactId>jsp-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
     </dependencies>
 
     <properties>

--- a/plugins/convention/pom.xml
+++ b/plugins/convention/pom.xml
@@ -50,10 +50,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm</artifactId>
         </dependency>

--- a/plugins/embeddedjsp/pom.xml
+++ b/plugins/embeddedjsp/pom.xml
@@ -66,11 +66,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.servlet.jsp</groupId>
-            <artifactId>jsp-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.tomcat</groupId>
             <artifactId>tomcat-juli</artifactId>
         </dependency>

--- a/plugins/embeddedjsp/pom.xml
+++ b/plugins/embeddedjsp/pom.xml
@@ -33,10 +33,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.struts</groupId>
             <artifactId>struts2-velocity-plugin</artifactId>
         </dependency>

--- a/plugins/jasperreports/pom.xml
+++ b/plugins/jasperreports/pom.xml
@@ -63,11 +63,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.servlet.jsp</groupId>
-            <artifactId>jsp-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
             <scope>test</scope>

--- a/plugins/jasperreports/pom.xml
+++ b/plugins/jasperreports/pom.xml
@@ -33,10 +33,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-        </dependency>
-        <dependency>
             <groupId>net.sf.jasperreports</groupId>
             <artifactId>jasperreports</artifactId>
             <version>6.20.5</version>

--- a/plugins/javatemplates/pom.xml
+++ b/plugins/javatemplates/pom.xml
@@ -35,10 +35,6 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
             <artifactId>commons-text</artifactId>
         </dependency>
         <dependency>

--- a/plugins/javatemplates/pom.xml
+++ b/plugins/javatemplates/pom.xml
@@ -34,10 +34,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-text</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.easymock</groupId>
             <artifactId>easymock</artifactId>
             <scope>test</scope>

--- a/plugins/jfreechart/pom.xml
+++ b/plugins/jfreechart/pom.xml
@@ -62,11 +62,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.servlet.jsp</groupId>
-            <artifactId>jsp-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.easymock</groupId>
             <artifactId>easymock</artifactId>
             <scope>test</scope>

--- a/plugins/json/pom.xml
+++ b/plugins/json/pom.xml
@@ -56,11 +56,6 @@
 
         <dependency>
             <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.commons</groupId>
             <artifactId>commons-text</artifactId>
         </dependency>
 

--- a/plugins/json/pom.xml
+++ b/plugins/json/pom.xml
@@ -65,12 +65,6 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.servlet.jsp</groupId>
-            <artifactId>jsp-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.easymock</groupId>
             <artifactId>easymock</artifactId>
             <scope>test</scope>

--- a/plugins/json/pom.xml
+++ b/plugins/json/pom.xml
@@ -55,11 +55,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-text</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.easymock</groupId>
             <artifactId>easymock</artifactId>
             <scope>test</scope>

--- a/plugins/junit/README.md
+++ b/plugins/junit/README.md
@@ -1,4 +1,4 @@
-# Struts 2 JFreeChart plugin
+# Struts 2 JUnit plugin
 The JUnit Plugin supports testing actions within a Struts invocation, meaning that a full request is simulated, 
 and the output of the action can be tested.
 You will find more details in [documentation](https://struts.apache.org/plugins/junit/).

--- a/plugins/junit/README.md
+++ b/plugins/junit/README.md
@@ -2,6 +2,3 @@
 The JUnit Plugin supports testing actions within a Struts invocation, meaning that a full request is simulated, 
 and the output of the action can be tested.
 You will find more details in [documentation](https://struts.apache.org/plugins/junit/).
-
-## Installation
-Just drop this plugin JAR into `WEB-INF/lib` folder or add it as a Maven dependency.

--- a/plugins/junit/pom.xml
+++ b/plugins/junit/pom.xml
@@ -60,6 +60,13 @@
             <artifactId>struts2-convention-plugin</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+            <version>1.23.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <properties>

--- a/plugins/junit/pom.xml
+++ b/plugins/junit/pom.xml
@@ -50,11 +50,6 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>javax.servlet.jsp</groupId>
-            <artifactId>jsp-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
         </dependency>

--- a/plugins/junit/src/test/java/org/apache/struts2/junit/StrutsTestCaseTest.java
+++ b/plugins/junit/src/test/java/org/apache/struts2/junit/StrutsTestCaseTest.java
@@ -21,11 +21,8 @@ package org.apache.struts2.junit;
 import com.opensymphony.xwork2.Action;
 import com.opensymphony.xwork2.ActionContext;
 import com.opensymphony.xwork2.ActionProxy;
-import org.apache.struts2.StrutsStatics;
 import org.apache.struts2.dispatcher.mapper.ActionMapping;
-import org.junit.Test;
 
-import javax.portlet.PortletContext;
 import javax.servlet.ServletException;
 import java.io.UnsupportedEncodingException;
 
@@ -63,35 +60,6 @@ public class StrutsTestCaseTest extends StrutsSpringTestCase {
         executeAction("/test/testAction.action");
         String name = (String) findValueAfterExecute("name");
         assertEquals("FD", name);
-    }
-
-    @Test
-    public void shouldPortletContextBeAvailable() throws Exception {
-        // given
-        assertNull(ActionContext.getContext().get(StrutsStatics.STRUTS_PORTLET_CONTEXT));
-
-        // when
-        String output = executeAction("/test/testAction.action");
-        assertEquals("Hello", output);
-
-        // then
-        Object portletContext = ActionContext.getContext().get(StrutsStatics.STRUTS_PORTLET_CONTEXT);
-        assertNotNull(portletContext);
-        assertTrue(portletContext instanceof PortletContext);
-    }
-
-    @Test
-    public void shouldAdditionalContextParamsBeAvailable() throws Exception {
-        // given
-        String key = "my-param";
-        assertNull(ActionContext.getContext().get(key));
-
-        // when
-        String output = executeAction("/test/testAction.action");
-        assertEquals("Hello", output);
-
-        // then
-        assertNotNull(ActionContext.getContext().get(key));
     }
 
     @Override

--- a/plugins/junit/src/test/java/org/apache/struts2/junit/StrutsTestCaseTest.java
+++ b/plugins/junit/src/test/java/org/apache/struts2/junit/StrutsTestCaseTest.java
@@ -19,7 +19,6 @@
 package org.apache.struts2.junit;
 
 import com.opensymphony.xwork2.Action;
-import com.opensymphony.xwork2.ActionContext;
 import com.opensymphony.xwork2.ActionProxy;
 import org.apache.struts2.dispatcher.mapper.ActionMapping;
 
@@ -60,10 +59,5 @@ public class StrutsTestCaseTest extends StrutsSpringTestCase {
         executeAction("/test/testAction.action");
         String name = (String) findValueAfterExecute("name");
         assertEquals("FD", name);
-    }
-
-    @Override
-    protected void applyAdditionalParams(ActionContext context) {
-        context.put("my-param", new Object());
     }
 }

--- a/plugins/osgi/pom.xml
+++ b/plugins/osgi/pom.xml
@@ -85,11 +85,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>commons-digester</groupId>
             <artifactId>commons-digester</artifactId>
         </dependency>

--- a/plugins/osgi/pom.xml
+++ b/plugins/osgi/pom.xml
@@ -105,14 +105,6 @@
             <artifactId>spring-test</artifactId>
             <scope>test</scope>
         </dependency>
-
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-            <version>${log4j2.version}</version>
-            <scope>test</scope>
-        </dependency>
-
     </dependencies>
     <properties>
     	<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/plugins/oval/pom.xml
+++ b/plugins/oval/pom.xml
@@ -50,11 +50,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>javax.persistence</groupId>
             <artifactId>persistence-api</artifactId>
             <scope>test</scope>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -75,6 +75,11 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>javax.servlet</groupId>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -83,6 +83,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>javax.servlet.jsp</groupId>
             <artifactId>jsp-api</artifactId>
             <scope>provided</scope>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -50,6 +50,7 @@
         <module>pell-multipart</module>
         <module>plexus</module>
         <module>portlet</module>
+        <module>portlet-junit</module>
         <module>portlet-mocks</module>
         <module>portlet-tiles</module>
         <module>rest</module>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -66,6 +66,7 @@
         <dependency>
             <groupId>org.apache.struts</groupId>
             <artifactId>struts2-core</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <!-- Test dependencies -->

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -83,6 +83,11 @@
         </dependency>
 
         <dependency>
+            <groupId>javax.servlet.jsp</groupId>
+            <artifactId>jsp-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
             <scope>provided</scope>

--- a/plugins/portlet-junit/README.md
+++ b/plugins/portlet-junit/README.md
@@ -1,5 +1,2 @@
 # Struts 2 Portlet JUnit plugin
 The Portlet JUnit Plugin supports testing applications that use the Portlet Plugin.
-
-## Installation
-Just drop this plugin JAR into `WEB-INF/lib` folder or add it as a Maven dependency.

--- a/plugins/portlet-junit/README.md
+++ b/plugins/portlet-junit/README.md
@@ -1,0 +1,5 @@
+# Struts 2 Portlet JUnit plugin
+The Portlet JUnit Plugin supports testing applications that use the Portlet Plugin.
+
+## Installation
+Just drop this plugin JAR into `WEB-INF/lib` folder or add it as a Maven dependency.

--- a/plugins/portlet-junit/pom.xml
+++ b/plugins/portlet-junit/pom.xml
@@ -27,43 +27,28 @@
         <version>6.3.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>struts2-junit-plugin</artifactId>
+    <artifactId>struts2-portlet-junit-plugin</artifactId>
     <packaging>jar</packaging>
-    <name>Struts 2 JUnit Plugin</name>
+    <name>DEPRECATED: Struts 2 Portlet JUnit Plugin - since 6.4.0</name>
 
     <dependencies>
         <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-test</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-context</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.struts</groupId>
-            <artifactId>struts2-spring-plugin</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>javax.servlet.jsp</groupId>
-            <artifactId>jsp-api</artifactId>
-            <scope>provided</scope>
+            <artifactId>struts2-junit-plugin</artifactId>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
         </dependency>
 
-        <!-- Convention Plugin tests -->
         <dependency>
             <groupId>org.apache.struts</groupId>
-            <artifactId>struts2-convention-plugin</artifactId>
-            <scope>test</scope>
+            <artifactId>struts2-portlet-plugin</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.struts</groupId>
+            <artifactId>struts2-portlet-mocks-plugin</artifactId>
         </dependency>
     </dependencies>
 

--- a/plugins/portlet-junit/pom.xml
+++ b/plugins/portlet-junit/pom.xml
@@ -29,7 +29,7 @@
 
     <artifactId>struts2-portlet-junit-plugin</artifactId>
     <packaging>jar</packaging>
-    <name>DEPRECATED: Struts 2 Portlet JUnit Plugin - since 6.4.0</name>
+    <name>DEPRECATED: Struts 2 Portlet JUnit Plugin - since 6.3.0</name>
 
     <dependencies>
         <dependency>

--- a/plugins/portlet-junit/src/main/java/org/apache/struts2/junit/StrutsPortletTestCase.java
+++ b/plugins/portlet-junit/src/main/java/org/apache/struts2/junit/StrutsPortletTestCase.java
@@ -35,19 +35,6 @@ import javax.portlet.PortletMode;
 import java.util.HashMap;
 import java.util.Map;
 
-/*
- * Changes:  This is a copy of org.apache.struts2.StrutsPortletTestCase from the Struts 2 portlet-plugin, moved
- *           into the junit-plugin (same package org.apache.struts2).
- *           The import order above was changed to alphabetical.
- *
- * Note:     The assumption is that anyone utilizing StrutsPortletTestCase currently from the portlet-plugin will almost
- *           certainly be using the junit-plugin.  Under that assumption, the refactored-move of StrutsPortletTestCase
- *           should not cause issues for pre-existing usage of StrutsPortletTestCase.
- */
-
-/**
- * Base class used to test action in portlet environment
- */
 public abstract class StrutsPortletTestCase extends StrutsTestCase {
 
     private static final Logger LOG = LogManager.getLogger(StrutsPortletTestCase.class);
@@ -95,7 +82,7 @@ public abstract class StrutsPortletTestCase extends StrutsTestCase {
      * @return Map with session parameters
      */
     private Map<String, Object> createSession() {
-        return new HashMap<String, Object>(portletRequest.getPortletSession().getAttributeMap());
+        return new HashMap<>(portletRequest.getPortletSession().getAttributeMap());
     }
 
 }

--- a/plugins/portlet-junit/src/site/site.xml
+++ b/plugins/portlet-junit/src/site/site.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+-->
+<project name="Apache Struts">
+    <skin>
+        <groupId>org.apache.maven.skins</groupId>
+        <artifactId>maven-fluido-skin</artifactId>
+        <version>${fluido-skin.version}</version>
+    </skin>
+    <bannerLeft>
+        <name>Apache Software Foundation</name>
+        <src>http://www.apache.org/images/asf-logo.gif</src>
+        <href>http://www.apache.org/</href>
+    </bannerLeft>
+    <bannerRight>
+        <name>Apache Struts</name>
+        <src>http://struts.apache.org/img/struts-logo.svg</src>
+        <href>http://struts.apache.org/</href>
+    </bannerRight>
+    <publishDate position="left"/>
+    <version position="right"/>
+    <body>
+        <links>
+            <item name="Apache" href="http://www.apache.org/"/>
+            <item name="Struts" href="http://struts.apache.org/"/>
+        </links>
+
+        <menu ref="parent"/>
+        <menu ref="reports"/>
+
+        <footer>
+            <![CDATA[<div class="row span12">
+            Apache Struts, Struts, Apache, the Apache feather logo, and the Apache Struts project
+            logos are trademarks of The Apache Software Foundation.
+            </div>]]>
+        </footer>
+    </body>
+</project>

--- a/plugins/portlet-junit/src/test/java/org/apache/struts2/junit/StrutsPortletTestCaseTest.java
+++ b/plugins/portlet-junit/src/test/java/org/apache/struts2/junit/StrutsPortletTestCaseTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.struts2.junit;
+
+import com.opensymphony.xwork2.Action;
+import com.opensymphony.xwork2.ActionContext;
+import com.opensymphony.xwork2.ActionProxy;
+import org.apache.struts2.StrutsStatics;
+
+import javax.portlet.PortletContext;
+
+public class StrutsPortletTestCaseTest extends StrutsPortletTestCase {
+
+    String KEY = "my-param";
+
+    public void testShouldPortletContextBeAvailable() throws Exception {
+        // given
+        assertNull(ActionContext.getContext().get(StrutsStatics.STRUTS_PORTLET_CONTEXT));
+
+        // when
+        ActionProxy proxy = getActionProxy("/test/testAction.action");
+        String result = proxy.execute();
+
+        // then
+        assertEquals(Action.SUCCESS, result);
+        Object portletContext = ActionContext.getContext().get(StrutsStatics.STRUTS_PORTLET_CONTEXT);
+        assertNotNull(portletContext);
+        assertTrue(portletContext instanceof PortletContext);
+    }
+
+    public void testShouldAdditionalContextParamsBeAvailable() throws Exception {
+        // given
+        assertNull(ActionContext.getContext().get(KEY));
+
+        // when
+        ActionProxy proxy = getActionProxy("/test/testAction.action");
+        String result = proxy.execute();
+
+        // then
+        assertEquals(Action.SUCCESS, result);
+        assertNotNull(ActionContext.getContext().get(KEY));
+    }
+
+    @Override
+    protected void applyAdditionalParams(ActionContext context) {
+        context.put(KEY, new Object());
+    }
+}

--- a/plugins/portlet-junit/src/test/resources/struts.xml
+++ b/plugins/portlet-junit/src/test/resources/struts.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+-->
+<!DOCTYPE struts PUBLIC
+        "-//Apache Software Foundation//DTD Struts Configuration 2.1.7//EN"
+        "https://struts.apache.org/dtds/struts-2.1.dtd">
+
+<struts>
+    <package name="test" namespace="/test" extends="struts-default">
+        <action name="testAction" class="com.opensymphony.xwork2.ActionSupport">
+            <result name="success" type="httpheader">
+                <param name="status">200</param>
+            </result>
+        </action>
+    </package>
+</struts>

--- a/plugins/portlet-tiles/pom.xml
+++ b/plugins/portlet-tiles/pom.xml
@@ -41,11 +41,6 @@
              <artifactId>struts2-portlet-plugin</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.servlet.jsp</groupId>
-            <artifactId>jsp-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>javax.portlet</groupId>
             <artifactId>portlet-api</artifactId>
             <scope>provided</scope>

--- a/plugins/portlet/pom.xml
+++ b/plugins/portlet/pom.xml
@@ -106,12 +106,6 @@
             <artifactId>spring-test</artifactId>
             <optional>true</optional>
         </dependency>
-
-        <dependency>
-            <groupId>commons-fileupload</groupId>
-            <artifactId>commons-fileupload</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <properties>

--- a/plugins/portlet/pom.xml
+++ b/plugins/portlet/pom.xml
@@ -100,13 +100,6 @@
             <scope>test</scope>
         </dependency>
 
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-            <version>${log4j2.version}</version>
-            <scope>test</scope>
-        </dependency>
-
         <!-- Mocks for unit testing (by Spring) -->
         <dependency>
             <groupId>org.springframework</groupId>

--- a/plugins/portlet/pom.xml
+++ b/plugins/portlet/pom.xml
@@ -51,11 +51,6 @@
             <optional>true</optional>
         </dependency>
 
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-        </dependency>
-
         <!-- Portlet -->
         <dependency>
             <groupId>javax.portlet</groupId>

--- a/plugins/portlet/pom.xml
+++ b/plugins/portlet/pom.xml
@@ -109,7 +109,6 @@
     </dependencies>
 
     <properties>
-        <spring.platformVersion>4.3.30.RELEASE</spring.platformVersion>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/plugins/portlet/pom.xml
+++ b/plugins/portlet/pom.xml
@@ -52,12 +52,6 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.servlet.jsp</groupId>
-            <artifactId>jsp-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>

--- a/plugins/portlet/pom.xml
+++ b/plugins/portlet/pom.xml
@@ -32,24 +32,15 @@
     <name>DEPRECATED: Struts 2 Portlet Plugin - since 6.0.0</name>
 
     <dependencies>
-        <!-- junit and related JARs are needed for 'compile'! -->
-
         <dependency>
             <groupId>org.apache.struts</groupId>
             <artifactId>struts2-portlet-mocks-plugin</artifactId>
             <scope>test</scope>
-            <optional>true</optional>
         </dependency>
 
         <dependency>
             <groupId>org.apache.struts</groupId>
             <artifactId>struts2-velocity-plugin</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <optional>true</optional>
         </dependency>
 
         <!-- spring-core is required for javadoc of jdk8 -->

--- a/plugins/portlet/pom.xml
+++ b/plugins/portlet/pom.xml
@@ -66,7 +66,6 @@
         <dependency>
             <groupId>javax.portlet</groupId>
             <artifactId>portlet-api</artifactId>
-            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/plugins/spring/pom.xml
+++ b/plugins/spring/pom.xml
@@ -72,11 +72,6 @@
 
         <dependency>
             <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.commons</groupId>
             <artifactId>commons-jci-fam</artifactId>
             <optional>true</optional>
         </dependency>

--- a/plugins/testng/pom.xml
+++ b/plugins/testng/pom.xml
@@ -44,12 +44,6 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-core</artifactId>
         </dependency>
-
-        <dependency>
-            <groupId>javax.servlet.jsp</groupId>
-            <artifactId>jsp-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
     </dependencies>
 
     <properties>

--- a/plugins/tiles/pom.xml
+++ b/plugins/tiles/pom.xml
@@ -76,11 +76,6 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>javax.servlet.jsp</groupId>
-            <artifactId>jsp-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.velocity</groupId>
             <artifactId>velocity-engine-core</artifactId>
             <optional>true</optional>

--- a/plugins/velocity/pom.xml
+++ b/plugins/velocity/pom.xml
@@ -55,6 +55,12 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.struts</groupId>
+            <artifactId>struts2-junit-plugin</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <properties>

--- a/plugins/velocity/pom.xml
+++ b/plugins/velocity/pom.xml
@@ -50,11 +50,6 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.servlet.jsp</groupId>
-            <artifactId>jsp-api</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>mockobjects</groupId>
             <artifactId>mockobjects-core</artifactId>
             <scope>test</scope>

--- a/plugins/velocity/pom.xml
+++ b/plugins/velocity/pom.xml
@@ -50,11 +50,6 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>javax.servlet.jsp</groupId>
             <artifactId>jsp-api</artifactId>
         </dependency>

--- a/plugins/xslt/pom.xml
+++ b/plugins/xslt/pom.xml
@@ -38,11 +38,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.servlet.jsp</groupId>
-            <artifactId>jsp-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
             <scope>test</scope>

--- a/plugins/xslt/pom.xml
+++ b/plugins/xslt/pom.xml
@@ -35,6 +35,7 @@
         <dependency>
             <groupId>org.apache.struts</groupId>
             <artifactId>struts2-junit-plugin</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>javax.servlet.jsp</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1000,15 +1000,6 @@
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
                 <version>4.3.1</version>
-                <exclusions>
-                    <!-- The mockito-core artifact and easymock artifact use different versions of objenesis (2.6 vs 3.1).
-                         Excluding the older version here to pass enforcer. When next upgrading mockito-core,
-                         confirm whether this exclusion is still required. -->
-                    <exclusion>
-                        <groupId>org.objenesis</groupId>
-                        <artifactId>objenesis</artifactId>
-                    </exclusion>
-                </exclusions>
                 <scope>test</scope>
             </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1026,10 +1026,19 @@
                 <artifactId>log4j-api</artifactId>
                 <version>${log4j2.version}</version>
             </dependency>
-
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-core</artifactId>
+                <version>${log4j2.version}</version>
+            </dependency>
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-jcl</artifactId>
+                <version>${log4j2.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-slf4j-impl</artifactId>
                 <version>${log4j2.version}</version>
             </dependency>
 


### PR DESCRIPTION
WW-5334
--
I extracted `StrutsPortletTestCase` into its own module from `struts-junit-plugin` to resolve the previous cyclic dependency (junit -> portlet -> velocity -> junit) which was preventing me from using `struts-junit-plugin` to write unit tests for `struts-velocity-plugin`.

See commit messages for other assorted clean up.