### PR TITLE
WW-5340 Preliminary refactor of OgnlUtil

### DIFF
--- a/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlReflectionProvider.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlReflectionProvider.java
@@ -21,7 +21,6 @@ package com.opensymphony.xwork2.ognl;
 import com.opensymphony.xwork2.inject.Inject;
 import com.opensymphony.xwork2.util.reflection.ReflectionException;
 import com.opensymphony.xwork2.util.reflection.ReflectionProvider;
-import ognl.Ognl;
 import ognl.OgnlException;
 import ognl.OgnlRuntime;
 
@@ -33,9 +32,9 @@ import java.util.Collection;
 import java.util.Map;
 
 public class OgnlReflectionProvider implements ReflectionProvider {
-    
+
     private OgnlUtil ognlUtil;
-    
+
     @Inject
     public void setOgnlUtil(OgnlUtil ognlUtil) {
         this.ognlUtil = ognlUtil;
@@ -69,7 +68,6 @@ public class OgnlReflectionProvider implements ReflectionProvider {
 
     public void setProperties(Map<String, ?> props, Object o, Map<String, Object> context, boolean throwPropertyExceptions) throws ReflectionException{
         ognlUtil.setProperties(props, o, context, throwPropertyExceptions);
-        
     }
 
     public void setProperties(Map<String, ?> properties, Object o) {
@@ -134,7 +132,7 @@ public class OgnlReflectionProvider implements ReflectionProvider {
     public void setValue(String expression, Map<String, Object> context, Object root,
             Object value) throws ReflectionException {
         try {
-            Ognl.setValue(expression, context, root, value);
+            ognlUtil.setValue(expression, context, root, value);
         } catch (OgnlException e) {
             throw new ReflectionException(e);
         }

--- a/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlUtil.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlUtil.java
@@ -597,18 +597,18 @@ public class OgnlUtil {
         return compile(expression, null);
     }
 
-    private void ognlSet(String expr, Map<String, Object> context, Object root, Object value, Map<String, Object> checkContext, TreeCheck ...treeChecks) throws OgnlException {
+    private void ognlSet(String expr, Map<String, Object> context, Object root, Object value, Map<String, Object> checkContext, TreeValidator... treeValidators) throws OgnlException {
         Object tree = toTree(expr);
-        for (TreeCheck check : treeChecks) {
-            check.consume(tree, checkContext);
+        for (TreeValidator validator : treeValidators) {
+            validator.validate(tree, checkContext);
         }
         Ognl.setValue(tree, context, root, value);
     }
 
-    private <T> T ognlGet(String expr, Map<String, Object> context, Object root, Class<T> resultType, Map<String, Object> checkContext, TreeCheck ...treeChecks) throws OgnlException {
+    private <T> T ognlGet(String expr, Map<String, Object> context, Object root, Class<T> resultType, Map<String, Object> checkContext, TreeValidator... treeValidators) throws OgnlException {
         Object tree = toTree(expr);
-        for (TreeCheck check : treeChecks) {
-            check.consume(tree, checkContext);
+        for (TreeValidator validator : treeValidators) {
+            validator.validate(tree, checkContext);
         }
         return (T) Ognl.getValue(tree, context, root, resultType);
     }
@@ -895,7 +895,7 @@ public class OgnlUtil {
     }
 
     @FunctionalInterface
-    private interface TreeCheck {
-        void consume(Object tree, Map<String, Object> context) throws OgnlException;
+    private interface TreeValidator {
+        void validate(Object tree, Map<String, Object> context) throws OgnlException;
     }
 }

--- a/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlUtil.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlUtil.java
@@ -539,7 +539,7 @@ public class OgnlUtil {
      * @throws OgnlException in case of ognl errors
      */
     public void setValue(final String name, final Map<String, Object> context, final Object root, final Object value) throws OgnlException {
-        ognlSet(name, context, root, value, context, this::checkEnableEvalExpression, this::checkEvalExpression, this::checkArithmeticExpression);
+        ognlSet(name, context, root, value, context, this::checkEvalExpression, this::checkArithmeticExpression);
     }
 
     private boolean isEvalExpression(Object tree, Map<String, Object> context) throws OgnlException {

--- a/core/src/test/java/com/opensymphony/xwork2/ognl/OgnlUtilTest.java
+++ b/core/src/test/java/com/opensymphony/xwork2/ognl/OgnlUtilTest.java
@@ -1312,7 +1312,7 @@ public class OgnlUtilTest extends XWorkTestCase {
         }
         assertNotNull(expected);
         assertSame(OgnlException.class, expected.getClass());
-        assertEquals(expected.getMessage(), "Eval expressions/chained expressions have been disabled!");
+        assertEquals("Eval expression/chained expressions cannot be used as parameter name", expected.getMessage());
     }
 
     public void testCallMethod() {


### PR DESCRIPTION
WW-5340
--
I've refactored this class to improve both readability and maintainability.

My primary goal was to consolidate calls to ognl.Ognl, specifically the following functions:
* `#getValue`: 5 calls to 1
* `#setValue`: 2 calls to 1
* `#parseExpression`: 4 calls to 1

Functionally, there are only 2 changes:
* Removed redundant tree validation from `OgnlUtil#setValue`
* Cache expressions prior to tree validation (i.e. even if validation fails)