### PR TITLE
Split SonarCloud into separate action

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Java Maven
+name: SonarCloud
 
 on:
   pull_request:
@@ -28,19 +28,19 @@ env:
   LANG: en_US.utf8
 
 jobs:
-  build:
-    name: Build and Test
+  sonarcloud:
+    name: Scan
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        java: [ '8', '11', '17' ]
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: ${{ matrix.java }}
+          java-version: 17
           cache: 'maven'
-      - name: Build with Maven on Java ${{ matrix.java }}
-        run: mvn -B -V -DskipAssembly verify --no-transfer-progress
+      - env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
+        run: mvn -B -V -Pcoverage -DskipAssembly verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar --no-transfer-progress


### PR DESCRIPTION
Pull requests from forked repos cannot run the Sonar scan due to restricted secret access. To avoid a situation where we miss a failing test on JDK17, I've split the Sonar scan into its own job. It is also less confusing for contributors.

I've additionally replaced the `cache` step with the preset cache configuration in the `setup-java` step.