### PR TITLE
WW-5349 Remove Struts core dependency on OGNL VarRefs

### DIFF
--- a/core/src/main/java/org/apache/struts2/components/UIBean.java
+++ b/core/src/main/java/org/apache/struts2/components/UIBean.java
@@ -601,12 +601,6 @@ public abstract class UIBean extends Component {
             result = findString(this.templateDir);
         }
 
-        // If templateDir is not explicitly given,
-        // try to find attribute which states the dir set to use
-        if (StringUtils.isBlank(result)) {
-            result = stack.findString("#attr.templateDir");
-        }
-
         // Default template set
         if (StringUtils.isBlank(result)) {
             result = defaultTemplateDir;
@@ -632,12 +626,6 @@ public abstract class UIBean extends Component {
             if (form != null) {
                 result = form.getTheme();
             }
-        }
-
-        // If theme set is not explicitly given,
-        // try to find attribute which states the theme set to use
-        if (StringUtils.isBlank(result)) {
-            result = stack.findString("#attr.theme");
         }
 
         // Default theme set

--- a/core/src/test/java/org/apache/struts2/components/UIBeanTest.java
+++ b/core/src/test/java/org/apache/struts2/components/UIBeanTest.java
@@ -29,7 +29,6 @@ import org.apache.struts2.dispatcher.StaticContentLoader;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
-
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -144,28 +143,6 @@ public class UIBeanTest extends StrutsInternalTestCase {
         assertEquals("foo", txtFld.getTheme());
     }
 
-    public void testGetThemeFromContext() {
-        ValueStack stack = ActionContext.getContext().getValueStack();
-        MockHttpServletRequest req = new MockHttpServletRequest();
-        MockHttpServletResponse res = new MockHttpServletResponse();
-        Map<String, Object> context = Collections.singletonMap("theme", "bar");
-        ActionContext.getContext().put("attr", context);
-
-        TextField txtFld = new TextField(stack, req, res);
-        assertEquals("bar", txtFld.getTheme());
-    }
-
-    public void testGetThemeFromContextNonString() {
-        ValueStack stack = ActionContext.getContext().getValueStack();
-        MockHttpServletRequest req = new MockHttpServletRequest();
-        MockHttpServletResponse res = new MockHttpServletResponse();
-        Map<String, Object> context = Collections.singletonMap("theme", 12);
-        ActionContext.getContext().put("attr", context);
-
-        TextField txtFld = new TextField(stack, req, res);
-        assertEquals("12", txtFld.getTheme());
-    }
-
     public void testMergeTemplateNullEngineException() {
         ValueStack stack = ActionContext.getContext().getValueStack();
         MockHttpServletRequest req = new MockHttpServletRequest();
@@ -219,21 +196,6 @@ public class UIBeanTest extends StrutsInternalTestCase {
         txtFld.setDefaultTemplateDir(defaultTemplateDir);
 
         assertEquals(explicitTemplateDir, txtFld.getTemplateDir());
-    }
-
-    public void testGetTemplateDirAttr() {
-        String attrTemplateDir = "attrTemplateDirectory";
-        String defaultTemplateDir = "defaultTemplateDirectory";
-        ValueStack stack = ActionContext.getContext().getValueStack();
-        MockHttpServletRequest req = new MockHttpServletRequest();
-        MockHttpServletResponse res = new MockHttpServletResponse();
-        Map<String, Object> context = Collections.singletonMap("templateDir", attrTemplateDir);
-        ActionContext.getContext().put("attr", context);
-
-        TextField txtFld = new TextField(stack, req, res);
-        txtFld.setDefaultTemplateDir(defaultTemplateDir);
-
-        assertEquals(attrTemplateDir, txtFld.getTemplateDir());
     }
 
     public void testGetTemplateDirDefault() {


### PR DESCRIPTION
WW-5349
--
For applications that don't use components such as Action and Set, or templates which leverage OGNL variable references, `#attr.templateDir` and `#attr.theme` are the only 2 dependencies on this OGNL capability.

By removing this functionality, applications can block `ognl.ASTVarRef` using `struts.ognl.excludedNodeTypes` for strengthened security. This is a commonly used gadget by attackers.