### PR TITLE
WW-5355 Use LRU cache by default

### DIFF
--- a/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlDefaultCache.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlDefaultCache.java
@@ -30,10 +30,10 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class OgnlDefaultCache<Key, Value> implements OgnlCache<Key, Value> {
 
     private final ConcurrentHashMap<Key, Value> ognlCache;
-    private final AtomicInteger cacheEvictionLimit = new AtomicInteger(25000);
+    private final AtomicInteger cacheEvictionLimit = new AtomicInteger();
 
     public OgnlDefaultCache(int evictionLimit, int initialCapacity, float loadFactor) {
-        this.cacheEvictionLimit.set(evictionLimit);
+        cacheEvictionLimit.set(evictionLimit);
         ognlCache = new ConcurrentHashMap<>(initialCapacity, loadFactor);
     }
 

--- a/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlLRUCache.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlLRUCache.java
@@ -36,15 +36,15 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class OgnlLRUCache<Key, Value> implements OgnlCache<Key, Value> {
 
     private final Map<Key, Value> ognlLRUCache;
-    private final AtomicInteger cacheEvictionLimit = new AtomicInteger(2500);
+    private final AtomicInteger cacheEvictionLimit = new AtomicInteger();
 
     public OgnlLRUCache(int evictionLimit, int initialCapacity, float loadFactor) {
-        this.cacheEvictionLimit.set(evictionLimit);
+        cacheEvictionLimit.set(evictionLimit);
         // Access-order mode selected (order mode true in LinkedHashMap constructor).
         ognlLRUCache = Collections.synchronizedMap (new LinkedHashMap<Key, Value>(initialCapacity, loadFactor, true) {
             @Override
             protected boolean removeEldestEntry(Map.Entry<Key,Value> eldest) {
-                return (this.size() > cacheEvictionLimit.get());
+                return size() > cacheEvictionLimit.get();
             }
         });
     }

--- a/core/src/main/resources/org/apache/struts2/default.properties
+++ b/core/src/main/resources/org/apache/struts2/default.properties
@@ -243,12 +243,12 @@ struts.ognl.enableExpressionCache=true
 ### For expressionCacheLRUMode true, the limit will ensure the cache does not exceed
 ### that size, dropping the oldest (least-recently-used) expressions to add new ones.
 ### NOTE: If not set, the default is 25000, which may be excessive.
-# struts.ognl.expressionCacheMaxSize=1000
+struts.ognl.expressionCacheMaxSize=10000
 
 ### Indicates if the OGNL expressionCache should use LRU mode.
 ### NOTE: When true, make sure to set the expressionCacheMaxSize to a reasonable value
 ###       for your application.  Otherwise the default limit will never (practically) be reached.
-# struts.ognl.expressionCacheLRUMode=false
+struts.ognl.expressionCacheLRUMode=true
 
 ### Specify a limit to the number of entries in the OGNL beanInfoCache.
 ### For the standard beanInfoCache mode, when the limit is exceeded the entire cache's
@@ -256,12 +256,12 @@ struts.ognl.enableExpressionCache=true
 ### For beanInfoCacheLRUMode true, the limit will ensure the cache does not exceed
 ### that size, dropping the oldest (least-recently-used) expressions to add new ones.
 ### NOTE: If not set, the default is 25000, which may be excessive.
-# struts.ognl.beanInfoCacheMaxSize=1000
+struts.ognl.beanInfoCacheMaxSize=5000
 
 ### Indicates if the OGNL beanInfoCache should use LRU mode.
 ### NOTE: When true, make sure to set the beanInfoCacheMaxSize to a reasonable value
 ###       for your application.  Otherwise the default limit will never (practically) be reached.
-# struts.ognl.beanInfoCacheLRUMode=false
+struts.ognl.beanInfoCacheLRUMode=true
 
 ### Indicates if Dispatcher should handle unexpected exceptions by calling sendError()
 ### or simply rethrow it as a ServletException to allow future processing by other frameworks like Spring Security


### PR DESCRIPTION
WW-5355
--
I see very limited advantage to using the default cache over the LRU one? The eviction process is faster but at the cost of having to repopulate the whole cache from scratch!
Keen to hear other thoughts or anything I may have missed

Perhaps in the future we can move to a more advanced algorithm such as the ones provided by [Caffeine](https://github.com/ben-manes/caffeine/wiki/Efficiency), although I'm not sure how effective they'd be given the cache can be easily attacked.