### PR TITLE
Improved the StrutsUrlDecoder so that charset retrieval is performed only once.

### DIFF
--- a/core/src/main/java/org/apache/struts2/url/StrutsUrlDecoder.java
+++ b/core/src/main/java/org/apache/struts2/url/StrutsUrlDecoder.java
@@ -33,7 +33,7 @@ public class StrutsUrlDecoder implements UrlDecoder {
 
     private static final Logger LOG = LogManager.getLogger(StrutsUrlDecoder.class);
 
-    private static final Collection<Charset> AVAILAVLE_CHARSETS = Charset.availableCharsets().values();
+    private static final Collection<Charset> AVAILABLE_CHARSETS = Charset.availableCharsets().values();
 
     private String encoding = "UTF-8";
 

--- a/core/src/main/java/org/apache/struts2/url/StrutsUrlDecoder.java
+++ b/core/src/main/java/org/apache/struts2/url/StrutsUrlDecoder.java
@@ -110,7 +110,7 @@ public class StrutsUrlDecoder implements UrlDecoder {
     }
 
     private Charset getCharset(String encoding) throws UnsupportedEncodingException {
-        for (Charset charset : AVAILAVLE_CHARSETS) {
+        for (Charset charset : AVAILABLE_CHARSETS) {
             if (encoding.equalsIgnoreCase(charset.name())) {
                 return charset;
             }

--- a/core/src/main/java/org/apache/struts2/url/StrutsUrlDecoder.java
+++ b/core/src/main/java/org/apache/struts2/url/StrutsUrlDecoder.java
@@ -27,10 +27,13 @@ import org.apache.struts2.StrutsConstants;
 
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
+import java.util.Collection;
 
 public class StrutsUrlDecoder implements UrlDecoder {
 
     private static final Logger LOG = LogManager.getLogger(StrutsUrlDecoder.class);
+
+    private static final Collection<Charset> AVAILAVLE_CHARSETS = Charset.availableCharsets().values();
 
     private String encoding = "UTF-8";
 
@@ -107,7 +110,7 @@ public class StrutsUrlDecoder implements UrlDecoder {
     }
 
     private Charset getCharset(String encoding) throws UnsupportedEncodingException {
-        for (Charset charset : Charset.availableCharsets().values()) {
+        for (Charset charset : AVAILAVLE_CHARSETS) {
             if (encoding.equalsIgnoreCase(charset.name())) {
                 return charset;
             }


### PR DESCRIPTION
- StutsUrlDecoder has performance problems when run from multiple threads, because [Charset#availavleCharts(...)](https://github.com/openjdk/jdk/blob/jdk-11%2B28/src/java.base/share/classes/java/nio/charset/Charset.java#L569-L588) called `StrutsUrlDecoder#getCharset(...)` is synchronized blocked.
  - Root causes is synchronized blocked at [AbstractCharsetProvider#charsets()](https://github.com/openjdk/jdk/blob/jdk-11%2B28/src/jdk.charsets/share/classes/sun/nio/cs/ext/AbstractCharsetProvider.java#L174-L177) .
  - StutsUrlDecoder is used to evaluate custom tag [<s:url>](https://struts.apache.org/tag-developers/url-tag), it will have performance problems if it receives too many requests.
- Therefore, `Charset#availavleCharts(...)` to be executed only once during the StrutsUrlDecoder initialization.
