### PR TITLE
WW-5350 Refactor SecurityMemberAccess

### DIFF
--- a/core/src/main/java/com/opensymphony/xwork2/ognl/SecurityMemberAccess.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/SecurityMemberAccess.java
@@ -105,14 +105,18 @@ public class SecurityMemberAccess implements MemberAccess {
     public boolean isAccessible(Map context, Object target, Member member, String propertyName) {
         LOG.debug("Checking access for [target: {}, member: {}, property: {}]", target, member, propertyName);
 
-        if (target instanceof Class) { // Target may be of type Class for static members
-            if (!member.getDeclaringClass().equals(target)) {
-                throw new IllegalArgumentException("Target class does not match static member!");
-            }
-            target = null;
-        } else {
-            if (target != null && !member.getDeclaringClass().isAssignableFrom(target.getClass())) {
-                throw new IllegalArgumentException("Target does not match member!");
+        if (target != null) {
+            // Special case: Target is a Class object but not Class.class
+            if (Class.class.equals(target.getClass()) && !Class.class.equals(target)) {
+                if (!isStatic(member)) {
+                    throw new IllegalArgumentException("Member expected to be static!");
+                }
+                if (!member.getDeclaringClass().equals(target)) {
+                    throw new IllegalArgumentException("Target class does not match static member!");
+                }
+            // Standard case: Member should exist on target
+            } else if (!member.getDeclaringClass().isAssignableFrom(target.getClass())) {
+                throw new IllegalArgumentException("Member does not exist on target!");
             }
         }
 

--- a/core/src/main/java/com/opensymphony/xwork2/ognl/SecurityMemberAccess.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/SecurityMemberAccess.java
@@ -166,7 +166,7 @@ public class SecurityMemberAccess implements MemberAccess {
             return false;
         }
         if (isPackageExcluded(memberClass)) {
-            LOG.warn("Package [{}] of target class [{}] of target [{}] is excluded!",
+            LOG.warn("Package [{}] of member class [{}] of member [{}] is excluded!",
                     memberClass.getPackage(),
                     memberClass,
                     target);
@@ -181,7 +181,7 @@ public class SecurityMemberAccess implements MemberAccess {
             return false;
         }
         if (isPackageExcluded(targetClass)) {
-            LOG.warn("Package [{}] of member [{}] are excluded!", targetClass.getPackage(), member);
+            LOG.warn("Package [{}] of target [{}] is excluded!", targetClass.getPackage(), member);
             return false;
         }
         return true;

--- a/core/src/main/java/com/opensymphony/xwork2/ognl/SecurityMemberAccess.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/SecurityMemberAccess.java
@@ -311,32 +311,14 @@ public class SecurityMemberAccess implements MemberAccess {
     }
 
     protected boolean isAccepted(String paramName) {
-        if (!this.acceptProperties.isEmpty()) {
-            for (Pattern pattern : acceptProperties) {
-                Matcher matcher = pattern.matcher(paramName);
-                if (matcher.matches()) {
-                    return true;
-                }
-            }
-
-            //no match, but acceptedParams is not empty
-            return false;
+        if (acceptProperties.isEmpty()) {
+            return true;
         }
-
-        //empty acceptedParams
-        return true;
+        return acceptProperties.stream().map(pattern -> pattern.matcher(paramName)).anyMatch(Matcher::matches);
     }
 
     protected boolean isExcluded(String paramName) {
-        if (!this.excludeProperties.isEmpty()) {
-            for (Pattern pattern : excludeProperties) {
-                Matcher matcher = pattern.matcher(paramName);
-                if (matcher.matches()) {
-                    return true;
-                }
-            }
-        }
-        return false;
+        return excludeProperties.stream().map(pattern -> pattern.matcher(paramName)).anyMatch(Matcher::matches);
     }
 
     /**

--- a/core/src/main/java/com/opensymphony/xwork2/ognl/SecurityMemberAccess.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/SecurityMemberAccess.java
@@ -114,6 +114,7 @@ public class SecurityMemberAccess implements MemberAccess {
                 if (!member.getDeclaringClass().equals(target)) {
                     throw new IllegalArgumentException("Target class does not match static member!");
                 }
+                target = null; // This information is not useful to us and conflicts with following logic which expects target to be null or an instance containing the member
             // Standard case: Member should exist on target
             } else if (!member.getDeclaringClass().isAssignableFrom(target.getClass())) {
                 throw new IllegalArgumentException("Member does not exist on target!");

--- a/core/src/test/java/com/opensymphony/xwork2/interceptor/ParametersInterceptorTest.java
+++ b/core/src/test/java/com/opensymphony/xwork2/interceptor/ParametersInterceptorTest.java
@@ -350,7 +350,7 @@ public class ParametersInterceptorTest extends XWorkTestCase {
         //then
         assertEquals("This is blah", ((SimpleAction) proxy.getAction()).getBlah());
         Field field = ReflectionContextState.class.getField("DENY_METHOD_EXECUTION");
-        boolean allowStaticFieldAccess = ((OgnlContext) stack.getContext()).getMemberAccess().isAccessible(stack.getContext(), proxy.getAction(), field, "");
+        boolean allowStaticFieldAccess = ((OgnlContext) stack.getContext()).getMemberAccess().isAccessible(stack.getContext(), ReflectionContextState.class, field, "");
         assertFalse(allowStaticFieldAccess);
     }
 

--- a/core/src/test/java/com/opensymphony/xwork2/ognl/SecurityMemberAccessTest.java
+++ b/core/src/test/java/com/opensymphony/xwork2/ognl/SecurityMemberAccessTest.java
@@ -352,6 +352,16 @@ public class SecurityMemberAccessTest {
     }
 
     @Test
+    public void testAccessEnum_alternateValues() throws Exception {
+        // when
+        Member alternateValues = MyValues.class.getMethod("values", String.class);
+        boolean actual = sma.isAccessible(context, MyValues.class, alternateValues, null);
+
+        // then
+        assertFalse("Access to unrelated #values method not blocked!", actual);
+    }
+
+    @Test
     public void testAccessStaticMethod() throws Exception {
         // given
         sma.useExcludedClasses(new HashSet<>(singletonList(Class.class.getName())));
@@ -875,7 +885,11 @@ interface FooBarInterface extends FooInterface, BarInterface {
 }
 
 enum MyValues {
-    ONE, TWO, THREE
+    ONE, TWO, THREE;
+
+    public static MyValues[] values(String notUsed) {
+        return new MyValues[] {ONE, TWO, THREE};
+    }
 }
 
 class StaticTester {

--- a/core/src/test/java/com/opensymphony/xwork2/ognl/SecurityMemberAccessTest.java
+++ b/core/src/test/java/com/opensymphony/xwork2/ognl/SecurityMemberAccessTest.java
@@ -368,7 +368,7 @@ public class SecurityMemberAccessTest {
 
         // when
         Member method = StaticTester.class.getMethod("sayHello");
-        boolean actual = sma.isAccessible(context, Class.class, method, null);
+        boolean actual = sma.isAccessible(context, StaticTester.class, method, null);
 
         // then
         assertFalse("Access to static method is not blocked!", actual);
@@ -595,7 +595,7 @@ public class SecurityMemberAccessTest {
 
         // when
         Member method = StaticTester.class.getMethod("sayHello");
-        boolean actual = sma.isAccessible(context, Class.class, method, null);
+        boolean actual = sma.isAccessible(context, StaticTester.class, method, null);
 
         // then
         assertFalse("Access to static isn't blocked!", actual);
@@ -704,7 +704,7 @@ public class SecurityMemberAccessTest {
         member = System.class.getMethod(propertyName, int.class);
 
         // when
-        accessible = sma.isAccessible(context, target, member, propertyName);
+        accessible = sma.isAccessible(context, System.class, member, propertyName);
 
         // then
         assertFalse(accessible);


### PR DESCRIPTION
WW-5350
--
See comments.

I didn't deprecate methods for which I've changed the signature as from what I can tell `SecurityMemberAccess` is not considered public API (no reasonable situation in which a Struts applications would need to override or instantiate the class themselves, nor is it a defined extensible bean) (WW-5343 aims to make it a configurable bean and thus public API).