### PR TITLE
WW-5350 Implement OGNL Allowlist capability

### DIFF
--- a/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlValueStack.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlValueStack.java
@@ -93,6 +93,9 @@ public class OgnlValueStack implements Serializable, ValueStack, ClearableValueS
         securityMemberAccess.useExcludedPackageNamePatterns(ognlUtil.getExcludedPackageNamePatterns());
         securityMemberAccess.useExcludedPackageNames(ognlUtil.getExcludedPackageNames());
         securityMemberAccess.useExcludedPackageExemptClasses(ognlUtil.getExcludedPackageExemptClasses());
+        securityMemberAccess.useEnforceAllowlistEnabled(ognlUtil.isEnforceAllowlistEnabled());
+        securityMemberAccess.useAllowlistClasses(ognlUtil.getAllowlistClasses());
+        securityMemberAccess.useAllowlistPackageNames(ognlUtil.getAllowlistPackageNames());
         securityMemberAccess.disallowProxyMemberAccess(ognlUtil.isDisallowProxyMemberAccess());
         securityMemberAccess.disallowDefaultPackageAccess(ognlUtil.isDisallowDefaultPackageAccess());
     }

--- a/core/src/main/java/org/apache/struts2/StrutsConstants.java
+++ b/core/src/main/java/org/apache/struts2/StrutsConstants.java
@@ -432,6 +432,12 @@ public final class StrutsConstants {
     public static final String STRUTS_DEV_MODE_EXCLUDED_PACKAGE_NAMES = "struts.devMode.excludedPackageNames";
     public static final String STRUTS_DEV_MODE_EXCLUDED_PACKAGE_EXEMPT_CLASSES = "struts.devMode.excludedPackageExemptClasses";
 
+    /** Boolean to enable strict allowlist processing of all OGNL expression calls. */
+    public static final String STRUTS_ALLOWLIST_ENABLE = "struts.allowlist.enable";
+    /** Comma delimited set of allowed classes which CAN be accessed via OGNL expressions. Both target and member classes of OGNL expression must be allowlisted. */
+    public static final String STRUTS_ALLOWLIST_CLASSES = "struts.allowlist.classes";
+    /** Comma delimited set of package names, of which all its classes, and all classes in its subpackages, CAN be accessed via OGNL expressions. Both target and member classes of OGNL expression must be allowlisted. */
+    public static final String STRUTS_ALLOWLIST_PACKAGE_NAMES = "struts.allowlist.packageNames";
 
     /** Dedicated services to check if passed string is excluded/accepted */
     public static final String STRUTS_EXCLUDED_PATTERNS_CHECKER = "struts.excludedPatterns.checker";

--- a/core/src/test/java/com/opensymphony/xwork2/ognl/SecurityMemberAccessTest.java
+++ b/core/src/test/java/com/opensymphony/xwork2/ognl/SecurityMemberAccessTest.java
@@ -18,12 +18,15 @@
  */
 package com.opensymphony.xwork2.ognl;
 
+import com.opensymphony.xwork2.TestBean;
+import com.opensymphony.xwork2.test.TestBean2;
 import com.opensymphony.xwork2.util.TextParseUtil;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Member;
+import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -32,6 +35,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Pattern;
 
+import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -792,6 +796,79 @@ public class SecurityMemberAccessTest {
 
         // then
         assertTrue("package java.lang. is accessible!", actual);
+    }
+
+    @Test
+    public void classInclusion() throws Exception {
+
+        sma.useEnforceAllowlistEnabled(true);
+
+        TestBean2 bean = new TestBean2();
+        Method method = TestBean2.class.getMethod("getData");
+
+        assertFalse(sma.checkAllowlist(bean, method));
+
+        sma.useAllowlistClasses(new HashSet<>(singletonList(TestBean2.class.getName())));
+
+        assertTrue(sma.checkAllowlist(bean, method));
+    }
+
+    @Test
+    public void packageInclusion() throws Exception {
+        sma.useEnforceAllowlistEnabled(true);
+
+        TestBean2 bean = new TestBean2();
+        Method method = TestBean2.class.getMethod("getData");
+
+        assertFalse(sma.checkAllowlist(bean, method));
+
+        sma.useAllowlistPackageNames(new HashSet<>(singletonList(TestBean2.class.getPackage().getName())));
+
+        assertTrue(sma.checkAllowlist(bean, method));
+    }
+
+    @Test
+    public void classInclusion_subclass() throws Exception {
+        sma.useEnforceAllowlistEnabled(true);
+        sma.useAllowlistClasses(new HashSet<>(singletonList(TestBean2.class.getName())));
+
+        TestBean2 bean = new TestBean2();
+        Method method = TestBean2.class.getMethod("getName");
+
+        assertFalse(sma.checkAllowlist(bean, method));
+    }
+
+    @Test
+    public void classInclusion_subclass_both() throws Exception {
+        sma.useEnforceAllowlistEnabled(true);
+        sma.useAllowlistClasses(new HashSet<>(asList(TestBean.class.getName(), TestBean2.class.getName())));
+
+        TestBean2 bean = new TestBean2();
+        Method method = TestBean2.class.getMethod("getName");
+
+        assertTrue(sma.checkAllowlist(bean, method));
+    }
+
+    @Test
+    public void packageInclusion_subclass() throws Exception {
+        sma.useEnforceAllowlistEnabled(true);
+        sma.useAllowlistPackageNames(new HashSet<>(singletonList(TestBean2.class.getPackage().getName())));
+
+        TestBean2 bean = new TestBean2();
+        Method method = TestBean2.class.getMethod("getName");
+
+        assertFalse(sma.checkAllowlist(bean, method));
+    }
+
+    @Test
+    public void packageInclusion_subclass_both() throws Exception {
+        sma.useEnforceAllowlistEnabled(true);
+        sma.useAllowlistPackageNames(new HashSet<>(asList(TestBean.class.getPackage().getName(), TestBean2.class.getPackage().getName())));
+
+        TestBean2 bean = new TestBean2();
+        Method method = TestBean2.class.getMethod("getName");
+
+        assertTrue(sma.checkAllowlist(bean, method));
     }
 
     private static String formGetterName(String propertyName) {


### PR DESCRIPTION
WW-5350
--
Implementation for strict OGNL allowlist feature. It is up to the application to determine which classes/packages need to be allowlisted. The exclusion list will still take precedence (classes on the exclusion list cannot be allowlisted).

I hope to clean this implementation up and both `OgnlUtil` and `SecurityMemberAccess` up as part of WW-5343.