### PR TITLE
WW-5363 Remove redundant method from VelocityManager

### DIFF
--- a/plugins/velocity/src/main/java/org/apache/struts2/views/velocity/StrutsVelocityContext.java
+++ b/plugins/velocity/src/main/java/org/apache/struts2/views/velocity/StrutsVelocityContext.java
@@ -77,7 +77,7 @@ public class StrutsVelocityContext extends VelocityContext {
     }
 
     protected List<Function<String, Object>> contextGetterList() {
-        return Arrays.asList(this::superGet, this::chainedContextGet, this::stackGet, this::stackContextGet);
+        return Arrays.asList(this::superGet, this::chainedContextGet, this::stackGet);
     }
 
     protected Object superGet(String key) {
@@ -89,13 +89,6 @@ public class StrutsVelocityContext extends VelocityContext {
             return null;
         }
         return stack.findValue(key);
-    }
-
-    protected Object stackContextGet(String key) {
-        if (stack == null) {
-            return null;
-        }
-        return stack.getContext().get(key);
     }
 
     protected Object chainedContextGet(String key) {

--- a/plugins/velocity/src/test/java/org/apache/struts2/views/velocity/StrutsVelocityContextTest.java
+++ b/plugins/velocity/src/test/java/org/apache/struts2/views/velocity/StrutsVelocityContextTest.java
@@ -27,9 +27,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
@@ -49,12 +47,8 @@ public class StrutsVelocityContextTest {
     @Mock
     private ValueStack stack;
 
-    private Map<String, Object> stackContext;
-
     @Before
     public void setUp() throws Exception {
-        stackContext = new HashMap<>();
-        when(stack.getContext()).thenReturn(stackContext);
         strutsVelocityContext = new StrutsVelocityContext(singletonList(chainedContext), stack);
     }
 
@@ -71,12 +65,6 @@ public class StrutsVelocityContextTest {
     }
 
     @Test
-    public void getStackContextValue() {
-        stackContext.put("foo", "bar");
-        assertEquals("bar", strutsVelocityContext.internalGet("foo"));
-    }
-
-    @Test
     public void getSuperValue() {
         strutsVelocityContext.put("foo", "bar");
         assertEquals("bar", strutsVelocityContext.internalGet("foo"));
@@ -84,9 +72,6 @@ public class StrutsVelocityContextTest {
 
     @Test
     public void getValuePrecedence() {
-        stackContext.put("foo", "quux");
-        assertEquals("quux", strutsVelocityContext.internalGet("foo"));
-
         when(stack.findValue("foo")).thenReturn("qux");
         assertEquals("qux", strutsVelocityContext.internalGet("foo"));
 


### PR DESCRIPTION
WW-5363
--
This method is redundant because `com.opensymphony.xwork2.ognl.OgnlValueStack#tryFindValue(java.lang.String)` already falls back to looking in the context.