### PR TITLE
[WW-5335] Reverts adding release/struts-7-0-x branch to scorecards analysis

### DIFF
--- a/.github/workflows/scorecards-analysis.yaml
+++ b/.github/workflows/scorecards-analysis.yaml
@@ -22,7 +22,6 @@ on:
   push:
     branches:
       - master
-      - release/struts-7-0-x
 
 permissions: read-all
 


### PR DESCRIPTION
Only the main branch is supported by this action, partially reverts changes introduced in #785 

Refs [WW-5335](https://issues.apache.org/jira/browse/WW-5335)