### PR TITLE
[WW-5371] Modern upload

### DIFF
--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/fileupload/FileUploadAction.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/fileupload/FileUploadAction.java
@@ -24,15 +24,12 @@ import com.opensymphony.xwork2.ActionSupport;
 import org.apache.struts2.action.UploadedFilesAware;
 import org.apache.struts2.dispatcher.multipart.UploadedFile;
 
-import java.io.File;
 import java.util.List;
 
 /**
  * Show case File Upload example's action. <code>FileUploadAction</code>
  */
 public class FileUploadAction extends ActionSupport implements UploadedFilesAware {
-
-    private static final long serialVersionUID = 5156288255337069381L;
 
     private String contentType;
     private UploadedFile uploadedFile;

--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/fileupload/FileUploadAction.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/fileupload/FileUploadAction.java
@@ -21,75 +21,70 @@
 package org.apache.struts2.showcase.fileupload;
 
 import com.opensymphony.xwork2.ActionSupport;
+import org.apache.struts2.action.UploadedFilesAware;
+import org.apache.struts2.dispatcher.multipart.UploadedFile;
 
 import java.io.File;
+import java.util.List;
 
 /**
  * Show case File Upload example's action. <code>FileUploadAction</code>
  */
-public class FileUploadAction extends ActionSupport {
+public class FileUploadAction extends ActionSupport implements UploadedFilesAware {
 
-	private static final long serialVersionUID = 5156288255337069381L;
+    private static final long serialVersionUID = 5156288255337069381L;
 
-	private String contentType;
-	private File upload;
-	private String fileName;
-	private String caption;
+    private String contentType;
+    private UploadedFile uploadedFile;
+    private String fileName;
+    private String caption;
+    private String originalName;
 
-	public String input() throws Exception {
-		return SUCCESS;
-	}
+    public String input() throws Exception {
+        return SUCCESS;
+    }
 
-	public String upload() throws Exception {
-		return SUCCESS;
-	}
+    public String upload() throws Exception {
+        return SUCCESS;
+    }
 
-	// since we are using <s:file name="upload" .../> the file name will be
-	// obtained through getter/setter of <file-tag-name>FileName
-	public String getUploadFileName() {
-		return fileName;
-	}
+    public String getContentType() {
+        return contentType;
+    }
 
-	public void setUploadFileName(String fileName) {
-		this.fileName = fileName;
-	}
+    public String getFileName() {
+        return fileName;
+    }
 
+    public String getOriginalName() {
+        return originalName;
+    }
 
-	// since we are using <s:file name="upload" ... /> the content type will be
-	// obtained through getter/setter of <file-tag-name>ContentType
-	public String getUploadContentType() {
-		return contentType;
-	}
+    public Object getUploadedFile() {
+        return uploadedFile.getContent();
+    }
 
-	public void setUploadContentType(String contentType) {
-		this.contentType = contentType;
-	}
+    public String getCaption() {
+        return caption;
+    }
 
+    public void setCaption(String caption) {
+        this.caption = caption;
+    }
 
-	// since we are using <s:file name="upload" ... /> the File itself will be
-	// obtained through getter/setter of <file-tag-name>
-	public File getUpload() {
-		return upload;
-	}
-
-	public void setUpload(File upload) {
-		this.upload = upload;
-	}
-
-
-	public String getCaption() {
-		return caption;
-	}
-
-	public void setCaption(String caption) {
-		this.caption = caption;
-	}
-
-        public long getUploadSize() {
-            if (upload != null) {
-                return upload.length();
-            } else {
-                return 0;
-            }
+    public long getUploadSize() {
+        if (uploadedFile != null) {
+            return uploadedFile.length();
+        } else {
+            return 0;
         }
+    }
+
+    @Override
+    public void withUploadedFiles(List<UploadedFile> uploadedFiles) {
+        this.uploadedFile = uploadedFiles.get(0);
+        this.fileName = uploadedFile.getName();
+        this.contentType = uploadedFile.getContentType();
+        this.originalName = uploadedFile.getOriginalName();
+    }
 }

--- a/apps/showcase/src/main/webapp/WEB-INF/fileupload/upload-success.jsp
+++ b/apps/showcase/src/main/webapp/WEB-INF/fileupload/upload-success.jsp
@@ -19,7 +19,7 @@
 */
 -->
 <%@ page
-	language="java" 
+	language="java"
 	contentType="text/html; charset=UTF-8"
     pageEncoding="UTF-8"%>
 <%@ taglib prefix="s" uri="/struts-tags" %>
@@ -37,9 +37,10 @@
 	<div class="row">
 		<div class="col-md-12">
 			<ul>
-		        <li>ContentType: <s:property value="uploadContentType" /></li>
-		        <li>FileName: <s:property value="uploadFileName" /></li>
-		        <li>File: <s:property value="upload" /></li>
+		        <li>ContentType: <s:property value="contentType" /></li>
+		        <li>FileName: <s:property value="fileName" /></li>
+		        <li>Original FileName: <s:property value="originalName" /></li>
+		        <li>File: <s:property value="uploadedFile" /></li>
 		        <li>Caption:<s:property value="caption" /></li>
 	        </ul>
 		</div>

--- a/core/src/main/java/org/apache/struts2/action/UploadedFilesAware.java
+++ b/core/src/main/java/org/apache/struts2/action/UploadedFilesAware.java
@@ -33,7 +33,7 @@ public interface UploadedFilesAware {
      * Notifies action about the multiple uploaded files, when a single file is uploaded
      * the list will have just one element
      *
-     * @param uploadedFiles a list of {@link UploadedFile}.
+     * @param uploadedFiles a list of {@link UploadedFile}, cannot be null. It can be empty.
      */
     void withUploadedFiles(List<UploadedFile> uploadedFiles);
 

--- a/core/src/main/java/org/apache/struts2/action/UploadedFilesAware.java
+++ b/core/src/main/java/org/apache/struts2/action/UploadedFilesAware.java
@@ -16,27 +16,25 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.struts2.dispatcher.multipart;
+package org.apache.struts2.action;
+
+import org.apache.struts2.dispatcher.multipart.UploadedFile;
+
+import java.util.List;
 
 /**
- * Virtual representation of a uploaded file used by {@link MultiPartRequest}
+ * Actions that want to be aware of all the uploaded file should implement this interface.
+ * The {@link org.apache.struts2.interceptor.ActionFileUploadInterceptor} will use the interface
+ * to notify action about the multiple uploaded files.
  */
-public interface UploadedFile {
+public interface UploadedFilesAware {
 
-    Long length();
-
-    String getName();
-
-    String getOriginalName();
-
-    boolean isFile();
-
-    boolean delete();
-
-    String getAbsolutePath();
-
-    Object getContent();
-
-    String getContentType();
+    /**
+     * Notifies action about the multiple uploaded files, when a single file is uploaded
+     * the list will have just one element
+     *
+     * @param uploadedFiles a list of {@link UploadedFile}.
+     */
+    void withUploadedFiles(List<UploadedFile> uploadedFiles);
 
 }

--- a/core/src/main/java/org/apache/struts2/dispatcher/multipart/JakartaMultiPartRequest.java
+++ b/core/src/main/java/org/apache/struts2/dispatcher/multipart/JakartaMultiPartRequest.java
@@ -243,7 +243,11 @@ public class JakartaMultiPartRequest extends AbstractMultiPartRequest {
                     LOG.error("Cannot write uploaded empty file to disk: {}", storeLocation.getAbsolutePath(), e);
                 }
             }
-            fileList.add(new StrutsUploadedFile(storeLocation));
+            UploadedFile uploadedFile = StrutsUploadedFile.Builder.create(storeLocation)
+                .withContentType(fileItem.getContentType())
+                .withOriginalName(fileItem.getName())
+                .build();
+            fileList.add(uploadedFile);
         }
 
         return fileList.toArray(new UploadedFile[0]);

--- a/core/src/main/java/org/apache/struts2/dispatcher/multipart/JakartaStreamMultiPartRequest.java
+++ b/core/src/main/java/org/apache/struts2/dispatcher/multipart/JakartaStreamMultiPartRequest.java
@@ -44,6 +44,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * Multi-part form data request adapter for Jakarta Commons FileUpload package that
@@ -109,16 +110,12 @@ public class JakartaStreamMultiPartRequest extends AbstractMultiPartRequest {
             return null;
         }
 
-        List<UploadedFile> files = new ArrayList<>(infos.size());
-        for (FileInfo fileInfo : infos) {
-            UploadedFile file = StrutsUploadedFile.Builder.create(fileInfo.getFile())
+        return infos.stream().map(fileInfo ->
+            StrutsUploadedFile.Builder.create(fileInfo.getFile())
                 .withContentType(fileInfo.contentType)
                 .withOriginalName(fileInfo.originalName)
-                .build();
-            files.add(file);
-        }
-
-        return files.toArray(new UploadedFile[0]);
+                .build()
+        ).toArray(UploadedFile[]::new);
     }
 
     /* (non-Javadoc)

--- a/core/src/main/java/org/apache/struts2/dispatcher/multipart/JakartaStreamMultiPartRequest.java
+++ b/core/src/main/java/org/apache/struts2/dispatcher/multipart/JakartaStreamMultiPartRequest.java
@@ -44,7 +44,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 /**
  * Multi-part form data request adapter for Jakarta Commons FileUpload package that

--- a/core/src/main/java/org/apache/struts2/dispatcher/multipart/StrutsUploadedFile.java
+++ b/core/src/main/java/org/apache/struts2/dispatcher/multipart/StrutsUploadedFile.java
@@ -79,6 +79,14 @@ public class StrutsUploadedFile implements UploadedFile {
         return originalName;
     }
 
+    @Override
+    public String toString() {
+        return "StrutsUploadedFile{" +
+            "contentType='" + contentType + '\'' +
+            ", originalName='" + originalName + '\'' +
+            '}';
+    }
+
     public static class Builder {
         private final File file;
         private String contentType;

--- a/core/src/main/java/org/apache/struts2/dispatcher/multipart/StrutsUploadedFile.java
+++ b/core/src/main/java/org/apache/struts2/dispatcher/multipart/StrutsUploadedFile.java
@@ -26,6 +26,11 @@ public class StrutsUploadedFile implements UploadedFile {
     private final String contentType;
     private final String originalName;
 
+    /**
+     * Use builder instead of constructor
+     * @param file an uploaded file
+     * @deprecated since Struts 6.4.0
+     */
     @Deprecated
     public StrutsUploadedFile(File file) {
         this.file = file;

--- a/core/src/main/java/org/apache/struts2/dispatcher/multipart/StrutsUploadedFile.java
+++ b/core/src/main/java/org/apache/struts2/dispatcher/multipart/StrutsUploadedFile.java
@@ -22,10 +22,21 @@ import java.io.File;
 
 public class StrutsUploadedFile implements UploadedFile {
 
-    private File file;
+    private final File file;
+    private final String contentType;
+    private final String originalName;
 
+    @Deprecated
     public StrutsUploadedFile(File file) {
         this.file = file;
+        this.contentType = null;
+        this.originalName = null;
+    }
+
+    private StrutsUploadedFile(File file, String contentType, String originalName) {
+        this.file = file;
+        this.contentType = contentType;
+        this.originalName = originalName;
     }
 
     @Override
@@ -56,5 +67,43 @@ public class StrutsUploadedFile implements UploadedFile {
     @Override
     public File getContent() {
         return file;
+    }
+
+    @Override
+    public String getContentType() {
+        return this.contentType;
+    }
+
+    @Override
+    public String getOriginalName() {
+        return originalName;
+    }
+
+    public static class Builder {
+        private final File file;
+        private String contentType;
+        private String originalName;
+
+        private Builder(File file) {
+            this.file = file;
+        }
+
+        public static Builder create(File file) {
+            return new Builder(file);
+        }
+
+        public Builder withContentType(String contentType) {
+            this.contentType = contentType;
+            return this;
+        }
+
+        public Builder withOriginalName(String originalName) {
+            this.originalName = originalName;
+            return this;
+        }
+
+        public UploadedFile build() {
+            return new StrutsUploadedFile(this.file, this.contentType, this.originalName);
+        }
     }
 }

--- a/core/src/main/java/org/apache/struts2/dispatcher/multipart/UploadedFile.java
+++ b/core/src/main/java/org/apache/struts2/dispatcher/multipart/UploadedFile.java
@@ -18,10 +18,12 @@
  */
 package org.apache.struts2.dispatcher.multipart;
 
+import java.io.Serializable;
+
 /**
  * Virtual representation of a uploaded file used by {@link MultiPartRequest}
  */
-public interface UploadedFile {
+public interface UploadedFile extends Serializable {
 
     Long length();
 

--- a/core/src/main/java/org/apache/struts2/interceptor/AbstractFileUploadInterceptor.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/AbstractFileUploadInterceptor.java
@@ -45,6 +45,14 @@ public abstract class AbstractFileUploadInterceptor extends AbstractInterceptor 
 
     private static final Logger LOG = LogManager.getLogger(AbstractFileUploadInterceptor.class);
 
+    public static final String STRUTS_MESSAGES_BYPASS_REQUEST_KEY = "struts.messages.bypass.request";
+    public static final String STRUTS_MESSAGES_ERROR_UPLOADING_KEY = "struts.messages.error.uploading";
+    public static final String STRUTS_MESSAGES_ERROR_FILE_TOO_LARGE_KEY = "struts.messages.error.file.too.large";
+    public static final String STRUTS_MESSAGES_INVALID_FILE_KEY = "struts.messages.invalid.file";
+    public static final String STRUTS_MESSAGES_INVALID_CONTENT_TYPE_KEY = "struts.messages.invalid.content.type";
+    public static final String STRUTS_MESSAGES_ERROR_CONTENT_TYPE_NOT_ALLOWED_KEY = "struts.messages.error.content.type.not.allowed";
+    public static final String STRUTS_MESSAGES_ERROR_FILE_EXTENSION_NOT_ALLOWED_KEY = "struts.messages.error.file.extension.not.allowed";
+
     protected Long maximumSize;
     protected Set<String> allowedTypesSet = Collections.emptySet();
     protected Set<String> allowedExtensionsSet = Collections.emptySet();
@@ -109,31 +117,31 @@ public abstract class AbstractFileUploadInterceptor extends AbstractInterceptor 
 
         // If it's null the upload failed
         if (file == null) {
-            String errMsg = getTextMessage(action, "struts.messages.error.uploading", new String[]{inputName});
+            String errMsg = getTextMessage(action, STRUTS_MESSAGES_ERROR_UPLOADING_KEY, new String[]{inputName});
             if (validation != null) {
                 validation.addFieldError(inputName, errMsg);
             }
             LOG.warn(errMsg);
         } else if (file.getContent() == null) {
-            String errMsg = getTextMessage(action, "struts.messages.error.uploading", new String[]{filename});
+            String errMsg = getTextMessage(action, STRUTS_MESSAGES_ERROR_UPLOADING_KEY, new String[]{filename});
             if (validation != null) {
                 validation.addFieldError(inputName, errMsg);
             }
             LOG.warn(errMsg);
         } else if (maximumSize != null && maximumSize < file.length()) {
-            String errMsg = getTextMessage(action, "struts.messages.error.file.too.large", new String[]{inputName, filename, file.getName(), "" + file.length(), getMaximumSizeStr(action)});
+            String errMsg = getTextMessage(action, STRUTS_MESSAGES_ERROR_FILE_TOO_LARGE_KEY, new String[]{inputName, filename, file.getName(), "" + file.length(), getMaximumSizeStr(action)});
             if (validation != null) {
                 validation.addFieldError(inputName, errMsg);
             }
             LOG.warn(errMsg);
         } else if ((!allowedTypesSet.isEmpty()) && (!containsItem(allowedTypesSet, contentType))) {
-            String errMsg = getTextMessage(action, "struts.messages.error.content.type.not.allowed", new String[]{inputName, filename, file.getName(), contentType});
+            String errMsg = getTextMessage(action, STRUTS_MESSAGES_ERROR_CONTENT_TYPE_NOT_ALLOWED_KEY, new String[]{inputName, filename, file.getName(), contentType});
             if (validation != null) {
                 validation.addFieldError(inputName, errMsg);
             }
             LOG.warn(errMsg);
         } else if ((!allowedExtensionsSet.isEmpty()) && (!hasAllowedExtension(allowedExtensionsSet, filename))) {
-            String errMsg = getTextMessage(action, "struts.messages.error.file.extension.not.allowed", new String[]{inputName, filename, file.getName(), contentType});
+            String errMsg = getTextMessage(action, STRUTS_MESSAGES_ERROR_FILE_EXTENSION_NOT_ALLOWED_KEY, new String[]{inputName, filename, file.getName(), contentType});
             if (validation != null) {
                 validation.addFieldError(inputName, errMsg);
             }
@@ -237,7 +245,7 @@ public abstract class AbstractFileUploadInterceptor extends AbstractInterceptor 
                 if (textProvider.hasKey(error.getTextKey())) {
                     errorMessage = textProvider.getText(error.getTextKey(), Arrays.asList(error.getArgs()));
                 } else {
-                    errorMessage = textProvider.getText("struts.messages.error.uploading", error.getDefaultMessage());
+                    errorMessage = textProvider.getText(STRUTS_MESSAGES_ERROR_UPLOADING_KEY, error.getDefaultMessage());
                 }
                 validation.addActionError(errorMessage);
             }

--- a/core/src/main/java/org/apache/struts2/interceptor/AbstractFileUploadInterceptor.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/AbstractFileUploadInterceptor.java
@@ -1,0 +1,247 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.struts2.interceptor;
+
+import com.opensymphony.xwork2.LocaleProvider;
+import com.opensymphony.xwork2.LocaleProviderFactory;
+import com.opensymphony.xwork2.TextProvider;
+import com.opensymphony.xwork2.TextProviderFactory;
+import com.opensymphony.xwork2.inject.Container;
+import com.opensymphony.xwork2.inject.Inject;
+import com.opensymphony.xwork2.interceptor.AbstractInterceptor;
+import com.opensymphony.xwork2.interceptor.ValidationAware;
+import com.opensymphony.xwork2.util.TextParseUtil;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.struts2.dispatcher.LocalizedMessage;
+import org.apache.struts2.dispatcher.multipart.MultiPartRequestWrapper;
+import org.apache.struts2.dispatcher.multipart.UploadedFile;
+import org.apache.struts2.util.ContentTypeMatcher;
+
+import java.text.NumberFormat;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Set;
+
+public abstract class AbstractFileUploadInterceptor extends AbstractInterceptor {
+
+    private static final Logger LOG = LogManager.getLogger(AbstractFileUploadInterceptor.class);
+
+    protected Long maximumSize;
+    protected Set<String> allowedTypesSet = Collections.emptySet();
+    protected Set<String> allowedExtensionsSet = Collections.emptySet();
+
+    private ContentTypeMatcher<Object> matcher;
+    private Container container;
+
+    @Inject
+    public void setMatcher(ContentTypeMatcher<Object> matcher) {
+        this.matcher = matcher;
+    }
+
+    @Inject
+    public void setContainer(Container container) {
+        this.container = container;
+    }
+
+    /**
+     * Sets the allowed extensions
+     *
+     * @param allowedExtensions A comma-delimited list of extensions
+     */
+    public void setAllowedExtensions(String allowedExtensions) {
+        allowedExtensionsSet = TextParseUtil.commaDelimitedStringToSet(allowedExtensions);
+    }
+
+    /**
+     * Sets the allowed mimetypes
+     *
+     * @param allowedTypes A comma-delimited list of types
+     */
+    public void setAllowedTypes(String allowedTypes) {
+        allowedTypesSet = TextParseUtil.commaDelimitedStringToSet(allowedTypes);
+    }
+
+    /**
+     * Sets the maximum size of an uploaded file
+     *
+     * @param maximumSize The maximum size in bytes
+     */
+    public void setMaximumSize(Long maximumSize) {
+        this.maximumSize = maximumSize;
+    }
+
+    /**
+     * Override for added functionality. Checks if the proposed file is acceptable based on contentType and size.
+     *
+     * @param action      - uploading action for message retrieval.
+     * @param file        - proposed upload file.
+     * @param filename    - name of the file.
+     * @param contentType - contentType of the file.
+     * @param inputName   - inputName of the file.
+     * @return true if the proposed file is acceptable by contentType and size.
+     */
+    protected boolean acceptFile(Object action, UploadedFile file, String filename, String contentType, String inputName) {
+        boolean fileIsAcceptable = false;
+
+        ValidationAware validation = null;
+        if (action instanceof ValidationAware) {
+            validation = (ValidationAware) action;
+        }
+
+        // If it's null the upload failed
+        if (file == null) {
+            String errMsg = getTextMessage(action, "struts.messages.error.uploading", new String[]{inputName});
+            if (validation != null) {
+                validation.addFieldError(inputName, errMsg);
+            }
+            LOG.warn(errMsg);
+        } else if (file.getContent() == null) {
+            String errMsg = getTextMessage(action, "struts.messages.error.uploading", new String[]{filename});
+            if (validation != null) {
+                validation.addFieldError(inputName, errMsg);
+            }
+            LOG.warn(errMsg);
+        } else if (maximumSize != null && maximumSize < file.length()) {
+            String errMsg = getTextMessage(action, "struts.messages.error.file.too.large", new String[]{inputName, filename, file.getName(), "" + file.length(), getMaximumSizeStr(action)});
+            if (validation != null) {
+                validation.addFieldError(inputName, errMsg);
+            }
+            LOG.warn(errMsg);
+        } else if ((!allowedTypesSet.isEmpty()) && (!containsItem(allowedTypesSet, contentType))) {
+            String errMsg = getTextMessage(action, "struts.messages.error.content.type.not.allowed", new String[]{inputName, filename, file.getName(), contentType});
+            if (validation != null) {
+                validation.addFieldError(inputName, errMsg);
+            }
+            LOG.warn(errMsg);
+        } else if ((!allowedExtensionsSet.isEmpty()) && (!hasAllowedExtension(allowedExtensionsSet, filename))) {
+            String errMsg = getTextMessage(action, "struts.messages.error.file.extension.not.allowed", new String[]{inputName, filename, file.getName(), contentType});
+            if (validation != null) {
+                validation.addFieldError(inputName, errMsg);
+            }
+            LOG.warn(errMsg);
+        } else {
+            fileIsAcceptable = true;
+        }
+
+        return fileIsAcceptable;
+    }
+
+    private String getMaximumSizeStr(Object action) {
+        return NumberFormat.getNumberInstance(getLocaleProvider(action).getLocale()).format(maximumSize);
+    }
+
+    /**
+     * @param extensionCollection - Collection of extensions (all lowercase).
+     * @param filename            - filename to check.
+     * @return true if the filename has an allowed extension, false otherwise.
+     */
+    private boolean hasAllowedExtension(Collection<String> extensionCollection, String filename) {
+        if (filename == null) {
+            return false;
+        }
+
+        String lowercaseFilename = filename.toLowerCase();
+        for (String extension : extensionCollection) {
+            if (lowercaseFilename.endsWith(extension)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param itemCollection - Collection of string items (all lowercase).
+     * @param item           - Item to search for.
+     * @return true if itemCollection contains the item, false otherwise.
+     */
+    private boolean containsItem(Collection<String> itemCollection, String item) {
+        for (String pattern : itemCollection)
+            if (matchesWildcard(pattern, item))
+                return true;
+        return false;
+    }
+
+    private boolean matchesWildcard(String pattern, String text) {
+        Object o = matcher.compilePattern(pattern);
+        return matcher.match(new HashMap<>(), text, o);
+    }
+
+    protected boolean isNonEmpty(Object[] objArray) {
+        boolean result = false;
+        for (Object o : objArray) {
+            if (o != null) {
+                result = true;
+                break;
+            }
+        }
+        return result;
+    }
+
+    protected String getTextMessage(String messageKey, String[] args) {
+        return getTextMessage(this, messageKey, args);
+    }
+
+    protected String getTextMessage(Object action, String messageKey, String[] args) {
+        if (action instanceof TextProvider) {
+            return ((TextProvider) action).getText(messageKey, args);
+        }
+        return getTextProvider(action).getText(messageKey, args);
+    }
+
+    protected TextProvider getTextProvider(Object action) {
+        TextProviderFactory tpf = container.getInstance(TextProviderFactory.class);
+        return tpf.createInstance(action.getClass());
+    }
+
+    private LocaleProvider getLocaleProvider(Object action) {
+        LocaleProvider localeProvider;
+        if (action instanceof LocaleProvider) {
+            localeProvider = (LocaleProvider) action;
+        } else {
+            LocaleProviderFactory localeProviderFactory = container.getInstance(LocaleProviderFactory.class);
+            localeProvider = localeProviderFactory.createLocaleProvider();
+        }
+        return localeProvider;
+    }
+
+    protected void applyValidation(Object action, MultiPartRequestWrapper multiWrapper) {
+        ValidationAware validation = null;
+        if (action instanceof ValidationAware) {
+            validation = (ValidationAware) action;
+        }
+
+        if (multiWrapper.hasErrors() && validation != null) {
+            TextProvider textProvider = getTextProvider(action);
+            for (LocalizedMessage error : multiWrapper.getErrors()) {
+                String errorMessage;
+                if (textProvider.hasKey(error.getTextKey())) {
+                    errorMessage = textProvider.getText(error.getTextKey(), Arrays.asList(error.getArgs()));
+                } else {
+                    errorMessage = textProvider.getText("struts.messages.error.uploading", error.getDefaultMessage());
+                }
+                validation.addActionError(errorMessage);
+            }
+        }
+    }
+
+}

--- a/core/src/main/java/org/apache/struts2/interceptor/ActionFileUploadInterceptor.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/ActionFileUploadInterceptor.java
@@ -33,105 +33,62 @@ import java.util.Enumeration;
 import java.util.List;
 
 /**
- * <!-- START SNIPPET: description -->
  * <p>
  * Interceptor that is based off of {@link MultiPartRequestWrapper}, which is automatically applied for any request that
- * includes a file. It adds the following parameters, where [File Name] is the name given to the file uploaded by the
- * HTML form:
- * </p>
- * <ul>
- *
- * <li>[File Name] : File - the actual File</li>
- *
- * <li>[File Name]ContentType : String - the content type of the file</li>
- *
- * <li>[File Name]FileName : String - the actual name of the file uploaded (not the HTML name)</li>
- *
- * </ul>
- *
- * <p>You can get access to these files by merely providing setters in your action that correspond to any of the three
- * patterns above, such as setDocument(File document), setDocumentContentType(String contentType), etc.
- * <br>See the example code section.
+ * includes a file when the support for multi-part request is enabled,
+ * see <a href="https://struts.apache.org/core-developers/file-upload.html#disabling-file-upload-support">Disabling file upload</a>.
  * </p>
  *
- * <p> This interceptor will add several field errors, assuming that the action implements {@link ValidationAware}.
+ * <p>
+ * You can get access to these files by implementing {@link UploadedFilesAware} interface. The interceptor will then
+ * call {@link UploadedFilesAware#withUploadedFiles(List)} when there are files which were accepted during the upload process.
+ * </p>
+ *
+ * <p>
+ * This interceptor will add several field errors, assuming that the action implements {@link ValidationAware}.
  * These error messages are based on several i18n values stored in struts-messages.properties, a default i18n file
  * processed for all i18n requests. You can override the text of these messages by providing text for the following
  * keys:
  * </p>
  *
  * <ul>
- *
  * <li>struts.messages.error.uploading - a general error that occurs when the file could not be uploaded</li>
- *
  * <li>struts.messages.error.file.too.large - occurs when the uploaded file is too large</li>
- *
  * <li>struts.messages.error.content.type.not.allowed - occurs when the uploaded file does not match the expected
  * content types specified</li>
- *
  * <li>struts.messages.error.file.extension.not.allowed - occurs when the uploaded file does not match the expected
  * file extensions specified</li>
- *
  * </ul>
- * <p>
- * <!-- END SNIPPET: description -->
  *
- * <p><u>Interceptor parameters:</u></p>
- * <p>
- * <!-- START SNIPPET: parameters -->
- *
+ * <p>Interceptor parameters:</p>
  * <ul>
- *
  * <li>maximumSize (optional) - the maximum size (in bytes) that the interceptor will allow a file reference to be set
  * on the action. Note, this is <b>not</b> related to the various properties found in struts.properties.
  * Default to approximately 2MB.</li>
- *
  * <li>allowedTypes (optional) - a comma separated list of content types (ie: text/html) that the interceptor will allow
  * a file reference to be set on the action. If none is specified allow all types to be uploaded.</li>
- *
  * <li>allowedExtensions (optional) - a comma separated list of file extensions (ie: .html) that the interceptor will allow
  * a file reference to be set on the action. If none is specified allow all extensions to be uploaded.</li>
  * </ul>
- * <p>
- * <p>
- * <!-- END SNIPPET: parameters -->
  *
- * <p><u>Extending the interceptor:</u></p>
- * <p>
- * <p>
- * <p>
- * <!-- START SNIPPET: extending -->
- * <p>
- * You can extend this interceptor and override the acceptFile method to provide more control over which files
- * are supported and which are not.
- * </p>
- * <!-- END SNIPPET: extending -->
- *
- * <p><u>Example code:</u></p>
+ * <p>Example code:</p>
  *
  * <pre>
- * <!-- START SNIPPET: example-configuration -->
  * &lt;action name="doUpload" class="com.example.UploadAction"&gt;
- *     &lt;interceptor-ref name="fileUpload"/&gt;
+ *     &lt;interceptor-ref name="actionFileUpload"/&gt;
  *     &lt;interceptor-ref name="basicStack"/&gt;
  *     &lt;result name="success"&gt;good_result.jsp&lt;/result&gt;
  * &lt;/action&gt;
- * <!-- END SNIPPET: example-configuration -->
  * </pre>
  * <p>
- * <!-- START SNIPPET: multipart-note -->
  * <p>
  * You must set the encoding to <code>multipart/form-data</code> in the form where the user selects the file to upload.
  * </p>
- * <!-- END SNIPPET: multipart-note -->
- *
  * <pre>
- * <!-- START SNIPPET: example-form -->
  *   &lt;s:form action="doUpload" method="post" enctype="multipart/form-data"&gt;
  *       &lt;s:file name="upload" label="File"/&gt;
  *       &lt;s:submit/&gt;
  *   &lt;/s:form&gt;
- * <!-- END SNIPPET: example-form -->
  * </pre>
  * <p>
  * And then in your action code you'll have access to the File object if you provide setters according to the
@@ -139,35 +96,33 @@ import java.util.List;
  * </p>
  *
  * <pre>
- * <!-- START SNIPPET: example-action -->
- *    package com.example;
+ *  package com.example;
  *
- *    import java.io.File;
- *    import com.opensymphony.xwork2.ActionSupport;
+ *  import java.io.File;
+ *  import com.opensymphony.xwork2.ActionSupport;
+ *  import org.apache.struts2.action.UploadedFilesAware;
  *
- *    public UploadAction extends ActionSupport {
- *       private File file;
- *       private String contentType;
- *       private String filename;
+ *  public UploadAction extends ActionSupport implements UploadedFilesAware {
+ *    private UploadedFile uploadedFile;
+ *    private String contentType;
+ *    private String fileName;
+ *    private String originalName;
  *
- *       public void setUpload(File file) {
- *          this.file = file;
- *       }
+ *    &#064;Override
+ *    public void withUploadedFiles(List<UploadedFile> uploadedFiles) {
+ *        if (!uploadedFiles.isEmpty() > 0) {
+ *            this.uploadedFile = uploadedFiles.get(0);
+ *            this.fileName = uploadedFile.getName();
+ *            this.contentType = uploadedFile.getContentType();
+ *            this.originalName = uploadedFile.getOriginalName();
+ *        }
+ *    }
  *
- *       public void setUploadContentType(String contentType) {
- *          this.contentType = contentType;
- *       }
- *
- *       public void setUploadFileName(String filename) {
- *          this.filename = filename;
- *       }
- *
- *       public String execute() {
- *          //...
- *          return SUCCESS;
- *       }
+ *    public String execute() {
+ *       //...
+ *       return SUCCESS;
+ *    }
  *  }
- * <!-- END SNIPPET: example-action -->
  * </pre>
  */
 public class ActionFileUploadInterceptor extends AbstractFileUploadInterceptor {

--- a/core/src/main/java/org/apache/struts2/interceptor/FileUploadInterceptor.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/FileUploadInterceptor.java
@@ -191,7 +191,7 @@ public class FileUploadInterceptor extends AbstractFileUploadInterceptor {
         if (!(request instanceof MultiPartRequestWrapper)) {
             if (LOG.isDebugEnabled()) {
                 ActionProxy proxy = invocation.getProxy();
-                LOG.debug(getTextMessage("struts.messages.bypass.request", new String[]{proxy.getNamespace(), proxy.getActionName()}));
+                LOG.debug(getTextMessage(STRUTS_MESSAGES_BYPASS_REQUEST_KEY, new String[]{proxy.getNamespace(), proxy.getActionName()}));
             }
 
             return invocation.invoke();
@@ -243,12 +243,12 @@ public class FileUploadInterceptor extends AbstractFileUploadInterceptor {
                     }
                 } else {
                     if (LOG.isWarnEnabled()) {
-                        LOG.warn(getTextMessage(action, "struts.messages.invalid.file", new String[]{inputName}));
+                        LOG.warn(getTextMessage(action, STRUTS_MESSAGES_INVALID_FILE_KEY, new String[]{inputName}));
                     }
                 }
             } else {
                 if (LOG.isWarnEnabled()) {
-                    LOG.warn(getTextMessage(action, "struts.messages.invalid.content.type", new String[]{inputName}));
+                    LOG.warn(getTextMessage(action, STRUTS_MESSAGES_INVALID_CONTENT_TYPE_KEY, new String[]{inputName}));
                 }
             }
         }

--- a/core/src/main/java/org/apache/struts2/interceptor/FileUploadInterceptor.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/FileUploadInterceptor.java
@@ -172,7 +172,10 @@ import java.util.Map;
  *  }
  * <!-- END SNIPPET: example-action -->
  * </pre>
+ *
+ * @deprecated since Struts 6.4.0, use {@link ActionFileUploadInterceptor} instead
  */
+@Deprecated
 public class FileUploadInterceptor extends AbstractFileUploadInterceptor {
 
     private static final long serialVersionUID = -4764627478894962478L;

--- a/core/src/main/resources/org/apache/struts2/struts-messages_en.properties
+++ b/core/src/main/resources/org/apache/struts2/struts-messages_en.properties
@@ -25,15 +25,40 @@ struts.internal.invalid.token=Form token {0} does not match the session token {1
 
 struts.messages.bypass.request=Bypassing {0}/{1}
 struts.messages.current.file=File {0} {1} {2} {3}
+# 0 - input name
 struts.messages.invalid.file=Could not find a Filename for {0}. Verify that a valid file was submitted.
+# 0 - original filename
 struts.messages.invalid.content.type=Could not find a Content-Type for {0}. Verify that a valid file was submitted.
 struts.messages.removing.file=Removing file {0} {1}
 struts.messages.error.uploading=Error uploading: {0}
-struts.messages.error.file.too.large=The file is too large to be uploaded: {0} "{1}" "{2}" {3}
+# 0 - input name
+# 1 - original filename
+# 2 - file name after uploading the file
+# 3 - size of the uploaded files
+# 4 - maximum allowed size
+struts.messages.error.file.too.large=The file is too large to be uploaded: {0} "{1}" "{2}" has size {3} and allowed mx size is {4}
+# 0 - input name
+# 1 - original filename
+# 2 - file name after uploading the file
+# 3 - content type of the file
 struts.messages.error.content.type.not.allowed=Content-Type not allowed: {0} "{1}" "{2}" {3}
+# 0 - input name
+# 1 - original filename
+# 2 - file name after uploading the file
+# 3 - content type of the file
 struts.messages.error.file.extension.not.allowed=File extension not allowed: {0} "{1}" "{2}" {3}
 
 # dedicated messages used to handle various problems with file upload - check {@link JakartaMultiPartRequest#parse(HttpServletRequest, String)}
+# params depend on exception being handled
+# FileUploadBase.SizeLimitExceededException:
+# 0 - permitted size
+# 1 - actual size
+# FileUploadBase.FileSizeLimitExceededException
+# 0 - file name
+# 1 - permitted size
+# 2 - actual size
+# FileCountLimitExceededException
+# 0 - limit
 struts.messages.upload.error.SizeLimitExceededException=Request exceeded allowed size limit! Max size allowed is: {0} but request was: {1}!
 struts.messages.upload.error.IOException=Error uploading: {0}!
 

--- a/core/src/main/resources/struts-default.xml
+++ b/core/src/main/resources/struts-default.xml
@@ -58,6 +58,7 @@
             <interceptor name="execAndWait" class="org.apache.struts2.interceptor.ExecuteAndWaitInterceptor"/>
             <interceptor name="exception" class="com.opensymphony.xwork2.interceptor.ExceptionMappingInterceptor"/>
             <interceptor name="fileUpload" class="org.apache.struts2.interceptor.FileUploadInterceptor"/>
+            <interceptor name="actionFileUpload" class="org.apache.struts2.interceptor.ActionFileUploadInterceptor"/>
             <interceptor name="i18n" class="org.apache.struts2.interceptor.I18nInterceptor"/>
             <interceptor name="logger" class="com.opensymphony.xwork2.interceptor.LoggingInterceptor"/>
             <interceptor name="modelDriven" class="com.opensymphony.xwork2.interceptor.ModelDrivenInterceptor"/>
@@ -121,6 +122,12 @@
                 <interceptor-ref name="basicStack"/>
             </interceptor-stack>
 
+            <!-- Action based file upload stack -->
+            <interceptor-stack name="actionFileUploadStack">
+                <interceptor-ref name="actionFileUpload"/>
+                <interceptor-ref name="basicStack"/>
+            </interceptor-stack>
+
             <!-- Sample model-driven stack  -->
             <interceptor-stack name="modelDrivenStack">
                 <interceptor-ref name="modelDriven"/>
@@ -165,6 +172,7 @@
                 <interceptor-ref name="chain"/>
                 <interceptor-ref name="modelDriven"/>
                 <interceptor-ref name="fileUpload"/>
+                <interceptor-ref name="actionFileUpload"/>
                 <interceptor-ref name="staticParams"/>
                 <interceptor-ref name="actionMappingParams"/>
                 <interceptor-ref name="params"/>
@@ -203,6 +211,7 @@
                 <interceptor-ref name="scopedModelDriven"/>
                 <interceptor-ref name="modelDriven"/>
                 <interceptor-ref name="fileUpload"/>
+                <interceptor-ref name="actionFileUpload"/>
                 <interceptor-ref name="checkbox"/>
                 <interceptor-ref name="datetime"/>
                 <interceptor-ref name="multiselect"/>

--- a/core/src/test/java/org/apache/struts2/conversion/UploadedFileConverterTest.java
+++ b/core/src/test/java/org/apache/struts2/conversion/UploadedFileConverterTest.java
@@ -34,10 +34,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class UploadedFileConverterTest {
 
     private Map<String, Object> context;
-    private Class target;
+    private Class<?> target;
     private Member member;
     private String propertyName;
     private File tempFile;
+    private String contentType;
+    private String originalName;
 
     @Before
     public void setUp() throws Exception {
@@ -46,6 +48,8 @@ public class UploadedFileConverterTest {
         member = File.class.getMethod("length");
         propertyName = "ignore";
         tempFile = File.createTempFile("struts", "test");
+        contentType = "text/plain";
+        originalName = tempFile.getName();
     }
 
     @After
@@ -54,10 +58,10 @@ public class UploadedFileConverterTest {
     }
 
     @Test
-    public void convertUploadedFileToFile() throws Exception {
+    public void convertUploadedFileToFile() {
         // given
         UploadedFileConverter ufc = new UploadedFileConverter();
-        UploadedFile uploadedFile = new StrutsUploadedFile(tempFile);
+        UploadedFile uploadedFile = StrutsUploadedFile.Builder.create(tempFile).withContentType(this.contentType).withOriginalName(this.originalName).build();
 
         // when
         Object result = ufc.convertValue(context, target, member, propertyName, uploadedFile, File.class);
@@ -70,10 +74,15 @@ public class UploadedFileConverterTest {
     }
 
     @Test
-    public void convertUploadedFileArrayToFile() throws Exception {
+    public void convertUploadedFileArrayToFile() {
         // given
         UploadedFileConverter ufc = new UploadedFileConverter();
-        UploadedFile[] uploadedFile = new UploadedFile[] { new StrutsUploadedFile(tempFile) };
+        UploadedFile[] uploadedFile = new UploadedFile[]{
+            StrutsUploadedFile.Builder.create(tempFile)
+                .withContentType(this.contentType)
+                .withOriginalName(this.originalName)
+                .build()
+        };
 
         // when
         Object result = ufc.convertValue(context, target, member, propertyName, uploadedFile, File.class);

--- a/core/src/test/java/org/apache/struts2/interceptor/ActionFileUploadInterceptorTest.java
+++ b/core/src/test/java/org/apache/struts2/interceptor/ActionFileUploadInterceptorTest.java
@@ -44,6 +44,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 /**
  * Test case for {@link ActionFileUploadInterceptor}.
  */
@@ -199,7 +201,6 @@ public class ActionFileUploadInterceptorTest extends StrutsInternalTestCase {
     }
 
     public void testAcceptFileWithMaxSize() throws Exception {
-        interceptor.setAllowedTypes("text/plain");
         interceptor.setMaximumSize(10L);
 
         // when file is not of allowed types
@@ -218,9 +219,12 @@ public class ActionFileUploadInterceptorTest extends StrutsInternalTestCase {
         assertEquals(1, errors.size());
         String msg = errors.get(0);
         // the error message should contain at least this test
-        assertTrue(msg.startsWith("The file is too large to be uploaded"));
-        assertTrue(msg.indexOf("inputName") > 0);
-        assertTrue(msg.indexOf("log4j2.xml") > 0);
+        assertThat(msg).contains(
+            "The file is too large to be uploaded",
+            "inputName",
+            "log4j2.xml",
+            "allowed mx size is 10"
+        );
     }
 
     public void testNoMultipartRequest() throws Exception {

--- a/core/src/test/java/org/apache/struts2/interceptor/ActionFileUploadInterceptorTest.java
+++ b/core/src/test/java/org/apache/struts2/interceptor/ActionFileUploadInterceptorTest.java
@@ -23,12 +23,12 @@ import com.opensymphony.xwork2.ActionSupport;
 import com.opensymphony.xwork2.DefaultLocaleProvider;
 import com.opensymphony.xwork2.ValidationAwareSupport;
 import com.opensymphony.xwork2.mock.MockActionInvocation;
+import com.opensymphony.xwork2.mock.MockActionProxy;
 import com.opensymphony.xwork2.util.ClassLoaderUtil;
 import org.apache.commons.fileupload.servlet.ServletFileUpload;
 import org.apache.struts2.ServletActionContext;
 import org.apache.struts2.StrutsInternalTestCase;
-import org.apache.struts2.TestAction;
-import org.apache.struts2.dispatcher.HttpParameters;
+import org.apache.struts2.action.UploadedFilesAware;
 import org.apache.struts2.dispatcher.multipart.JakartaMultiPartRequest;
 import org.apache.struts2.dispatcher.multipart.MultiPartRequestWrapper;
 import org.apache.struts2.dispatcher.multipart.StrutsUploadedFile;
@@ -37,21 +37,17 @@ import org.springframework.mock.web.MockHttpServletRequest;
 
 import javax.servlet.http.HttpServletRequest;
 import java.io.File;
-import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
-
 
 /**
- * Test case for FileUploadInterceptor.
+ * Test case for {@link ActionFileUploadInterceptor}.
  */
-public class FileUploadInterceptorTest extends StrutsInternalTestCase {
+public class ActionFileUploadInterceptorTest extends StrutsInternalTestCase {
 
     public static final UploadedFile EMPTY_FILE = new UploadedFile() {
         @Override
@@ -95,8 +91,13 @@ public class FileUploadInterceptorTest extends StrutsInternalTestCase {
         }
     };
 
-    private FileUploadInterceptor interceptor;
+    private ActionFileUploadInterceptor interceptor;
     private File tempDir;
+
+    private final String htmlContent = "<html><head></head><body>html content</body></html>";
+    private final String plainContent = "plain content";
+    private final String boundary = "simple boundary";
+    private final String endline = "\r\n";
 
     public void testAcceptFileWithEmptyAllowedTypesAndExtensions() {
         // when allowed type is empty
@@ -178,7 +179,7 @@ public class FileUploadInterceptorTest extends StrutsInternalTestCase {
     }
 
     public void testAcceptFileWithNoFile() {
-        FileUploadInterceptor interceptor = new FileUploadInterceptor();
+        ActionFileUploadInterceptor interceptor = new ActionFileUploadInterceptor();
         interceptor.setContainer(container);
 
         interceptor.setAllowedTypes("text/plain");
@@ -204,7 +205,7 @@ public class FileUploadInterceptorTest extends StrutsInternalTestCase {
         // when file is not of allowed types
         ValidationAwareSupport validation = new ValidationAwareSupport();
 
-        URL url = ClassLoaderUtil.getResource("log4j2.xml", FileUploadInterceptorTest.class);
+        URL url = ClassLoaderUtil.getResource("log4j2.xml", ActionFileUploadInterceptorTest.class);
         File file = new File(new URI(url.toString()));
         assertTrue("log4j2.xml should be in src/test folder", file.exists());
         UploadedFile uploadedFile = StrutsUploadedFile.Builder.create(file).withContentType("text/html").withOriginalName("filename").build();
@@ -223,11 +224,15 @@ public class FileUploadInterceptorTest extends StrutsInternalTestCase {
     }
 
     public void testNoMultipartRequest() throws Exception {
-        MyFileupAction action = new MyFileupAction();
+        MyFileUploadAction action = new MyFileUploadAction();
 
         MockActionInvocation mai = new MockActionInvocation();
         mai.setAction(action);
         mai.setResultCode("NoMultipart");
+        MockActionProxy proxy = new MockActionProxy();
+        proxy.setNamespace("/test");
+        proxy.setActionName("myFileUpload");
+        mai.setProxy(proxy);
         mai.setInvocationContext(ActionContext.getContext());
 
         // if no multipart request it will bypass and execute it
@@ -240,13 +245,12 @@ public class FileUploadInterceptorTest extends StrutsInternalTestCase {
         req.setContentType("multipart/form-data"); // not a multipart contentype
         req.setMethod("post");
 
-        MyFileupAction action = container.inject(MyFileupAction.class);
+        MyFileUploadAction action = container.inject(MyFileUploadAction.class);
         MockActionInvocation mai = new MockActionInvocation();
         mai.setAction(action);
         mai.setResultCode("success");
         mai.setInvocationContext(ActionContext.getContext());
 
-        ActionContext.getContext().withParameters(HttpParameters.create().build());
         ActionContext.getContext().put(ServletActionContext.HTTP_REQUEST, createMultipartRequestMaxSize(req, 2000));
 
         interceptor.intercept(mai);
@@ -262,13 +266,12 @@ public class FileUploadInterceptorTest extends StrutsInternalTestCase {
         req.addHeader("Content-type", "multipart/form-data");
         req.setContent(null); // there is no content
 
-        MyFileupAction action = container.inject(MyFileupAction.class);
+        MyFileUploadAction action = container.inject(MyFileUploadAction.class);
         MockActionInvocation mai = new MockActionInvocation();
         mai.setAction(action);
         mai.setResultCode("success");
         mai.setInvocationContext(ActionContext.getContext());
 
-        ActionContext.getContext().withParameters(HttpParameters.create().build());
         ActionContext.getContext().put(ServletActionContext.HTTP_REQUEST, createMultipartRequestMaxSize(req, 2000));
 
         interceptor.intercept(mai);
@@ -284,58 +287,43 @@ public class FileUploadInterceptorTest extends StrutsInternalTestCase {
 
         // inspired by the unit tests for jakarta commons fileupload
         String content = ("-----1234\r\n" +
-                "Content-Disposition: form-data; name=\"file\"; filename=\"deleteme.txt\"\r\n" +
-                "Content-Type: text/html\r\n" +
-                "\r\n" +
-                "Unit test of FileUploadInterceptor" +
-                "\r\n" +
-                "-----1234--\r\n");
+            "Content-Disposition: form-data; name=\"file\"; filename=\"deleteme.txt\"\r\n" +
+            "Content-Type: text/html\r\n" +
+            "\r\n" +
+            "Unit test of ActionFileUploadInterceptor" +
+            "\r\n" +
+            "-----1234--\r\n");
         req.setContent(content.getBytes(StandardCharsets.US_ASCII));
 
-        MyFileupAction action = new MyFileupAction();
+        MyFileUploadAction action = new MyFileUploadAction();
 
         MockActionInvocation mai = new MockActionInvocation();
         mai.setAction(action);
         mai.setResultCode("success");
         mai.setInvocationContext(ActionContext.getContext());
-        Map<String, Object> param = new HashMap<>();
-        ActionContext.getContext().withParameters(HttpParameters.create(param).build());
         ActionContext.getContext().put(ServletActionContext.HTTP_REQUEST, createMultipartRequestMaxSize(req, 2000));
 
         interceptor.intercept(mai);
 
         assertFalse(action.hasErrors());
 
-        HttpParameters parameters = mai.getInvocationContext().getParameters();
-        assertEquals(3, parameters.keySet().size());
-        UploadedFile[] files = (UploadedFile[]) parameters.get("file").getObject();
-        String[] fileContentTypes = parameters.get("fileContentType").getMultipleValues();
-        String[] fileRealFilenames = parameters.get("fileFileName").getMultipleValues();
+        List<UploadedFile> files = action.getUploadFiles();
 
         assertNotNull(files);
-        assertNotNull(fileContentTypes);
-        assertNotNull(fileRealFilenames);
-        assertEquals(1, files.length);
-        assertEquals(1, fileContentTypes.length);
-        assertEquals(1, fileRealFilenames.length);
-        assertEquals("text/html", fileContentTypes[0]);
-        assertNotNull("deleteme.txt", fileRealFilenames[0]);
+        assertEquals(1, files.size());
+        assertEquals("text/html", files.get(0).getContentType());
+        assertNotNull("deleteme.txt", files.get(0).getOriginalName());
     }
 
     /**
      * tests whether with multiple files sent with the same name, the ones with forbiddenTypes (see
-     * FileUploadInterceptor.setAllowedTypes(...) ) are sorted out.
+     * ActionFileUploadInterceptor.setAllowedTypes(...) ) are sorted out.
      */
     public void testMultipleAccept() throws Exception {
-        final String htmlContent = "<html><head></head><body>html content</body></html>";
-        final String plainContent = "plain content";
-        final String bondary = "simple boundary";
-        final String endline = "\r\n";
-
         MockHttpServletRequest req = new MockHttpServletRequest();
         req.setCharacterEncoding(StandardCharsets.UTF_8.name());
         req.setMethod("POST");
-        req.addHeader("Content-type", "multipart/form-data; boundary=" + bondary);
+        req.addHeader("Content-type", "multipart/form-data; boundary=" + boundary);
         String content = encodeTextFile("test.html", "text/plain", plainContent) +
             encodeTextFile("test1.html", "text/html", htmlContent) +
             encodeTextFile("test2.html", "text/html", htmlContent) +
@@ -343,48 +331,33 @@ public class FileUploadInterceptorTest extends StrutsInternalTestCase {
             endline +
             endline +
             "--" +
-            bondary +
+            boundary +
             "--" +
             endline;
         req.setContent(content.getBytes());
 
         assertTrue(ServletFileUpload.isMultipartContent(req));
 
-        MyFileupAction action = new MyFileupAction();
+        MyFileUploadAction action = new MyFileUploadAction();
         container.inject(action);
         MockActionInvocation mai = new MockActionInvocation();
         mai.setAction(action);
         mai.setResultCode("success");
         mai.setInvocationContext(ActionContext.getContext());
-        Map<String, Object> param = new HashMap<>();
-        ActionContext.getContext().withParameters(HttpParameters.create(param).build());
         ActionContext.getContext().put(ServletActionContext.HTTP_REQUEST, createMultipartRequestMaxSize(req, 2000));
 
         interceptor.setAllowedTypes("text/html");
         interceptor.intercept(mai);
 
-        HttpParameters parameters = mai.getInvocationContext().getParameters();
-        assertEquals(3, parameters.keySet().size());
-        UploadedFile[] files = (UploadedFile[]) parameters.get("file").getObject();
-        String[] fileContentTypes = parameters.get("fileContentType").getMultipleValues();
-        String[] fileRealFilenames = parameters.get("fileFileName").getMultipleValues();
+        List<UploadedFile> files = action.getUploadFiles();
 
         assertNotNull(files);
-        assertNotNull(fileContentTypes);
-        assertNotNull(fileRealFilenames);
-        assertEquals("files accepted ", 2, files.length);
-        assertEquals(2, fileContentTypes.length);
-        assertEquals(2, fileRealFilenames.length);
-        assertEquals("text/html", fileContentTypes[0]);
-        assertNotNull("test1.html", fileRealFilenames[0]);
+        assertEquals("files accepted ", 2, files.size());
+        assertEquals("text/html", files.get(0).getContentType());
+        assertNotNull("test1.html", files.get(0).getOriginalName());
     }
 
     public void testUnacceptedNumberOfFiles() throws Exception {
-        final String htmlContent = "<html><head></head><body>html content</body></html>";
-        final String plainContent = "plain content";
-        final String boundary = "simple boundary";
-        final String endline = "\r\n";
-
         MockHttpServletRequest req = new MockHttpServletRequest();
         req.setCharacterEncoding(StandardCharsets.UTF_8.name());
         req.setMethod("POST");
@@ -402,21 +375,18 @@ public class FileUploadInterceptorTest extends StrutsInternalTestCase {
 
         assertTrue(ServletFileUpload.isMultipartContent(req));
 
-        MyFileupAction action = new MyFileupAction();
+        MyFileUploadAction action = new MyFileUploadAction();
         container.inject(action);
         MockActionInvocation mai = new MockActionInvocation();
         mai.setAction(action);
         mai.setResultCode("success");
         mai.setInvocationContext(ActionContext.getContext());
-        Map<String, Object> param = new HashMap<>();
-        ActionContext.getContext().withParameters(HttpParameters.create(param).build());
-        ActionContext.getContext().put(ServletActionContext.HTTP_REQUEST, createMultipartRequestMaxFiles(req));
+        ActionContext.getContext().withServletRequest(createMultipartRequestMaxFiles(req));
 
         interceptor.setAllowedTypes("text/html");
         interceptor.intercept(mai);
 
-        HttpParameters parameters = mai.getInvocationContext().getParameters();
-        assertEquals(0, parameters.keySet().size());
+        assertNull(action.getUploadFiles());
         assertEquals(1, action.getActionErrors().size());
         assertEquals("Request exceeded allowed number of files! Max allowed files number is: 3!", action.getActionErrors().iterator().next());
     }
@@ -429,24 +399,22 @@ public class FileUploadInterceptorTest extends StrutsInternalTestCase {
 
         // inspired by the unit tests for jakarta commons fileupload
         String content = ("-----1234\r\n" +
-                "Content-Disposition: form-data; name=\"file\"; filename=\"deleteme.txt\"\r\n" +
-                "Content-Type: text/html\r\n" +
-                "\r\n" +
-                "Unit test of FileUploadInterceptor" +
-                "\r\n" +
-                "-----1234--\r\n");
+            "Content-Disposition: form-data; name=\"file\"; filename=\"deleteme.txt\"\r\n" +
+            "Content-Type: text/html\r\n" +
+            "\r\n" +
+            "Unit test of ActionFileUploadInterceptor" +
+            "\r\n" +
+            "-----1234--\r\n");
         req.setContent(content.getBytes(StandardCharsets.US_ASCII));
 
-        MyFileupAction action = container.inject(MyFileupAction.class);
+        MyFileUploadAction action = container.inject(MyFileUploadAction.class);
 
         MockActionInvocation mai = new MockActionInvocation();
         mai.setAction(action);
         mai.setResultCode("success");
         mai.setInvocationContext(ActionContext.getContext());
-        Map<String, Object> param = new HashMap<>();
         ActionContext.getContext()
-                .withParameters(HttpParameters.create(param).build())
-                .withServletRequest(createMultipartRequestMaxFileSize(req));
+            .withServletRequest(createMultipartRequestMaxFileSize(req));
 
         interceptor.intercept(mai);
 
@@ -456,8 +424,8 @@ public class FileUploadInterceptorTest extends StrutsInternalTestCase {
         assertEquals(1, errors.size());
         String msg = errors.iterator().next();
         assertEquals(
-                "File in request exceeded allowed file size limit! Max file size allowed is: 10 but file deleteme.txt was: 34!",
-                msg);
+            "File in request exceeded allowed file size limit! Max file size allowed is: 10 but file deleteme.txt was: 40!",
+            msg);
     }
 
     public void testMultipartRequestMaxStringLength() throws Exception {
@@ -468,34 +436,32 @@ public class FileUploadInterceptorTest extends StrutsInternalTestCase {
 
         // inspired by the unit tests for jakarta commons fileupload
         String content = ("-----1234\r\n" +
-                "Content-Disposition: form-data; name=\"file\"; filename=\"deleteme.txt\"\r\n" +
-                "Content-Type: text/html\r\n" +
-                "\r\n" +
-                "Unit test of FileUploadInterceptor" +
-                "\r\n" +
-                "-----1234\r\n" +
-                "Content-Disposition: form-data; name=\"normalFormField1\"\r\n" +
-                "\r\n" +
-                "it works" +
-                "\r\n" +
-                "-----1234\r\n" +
-                "Content-Disposition: form-data; name=\"normalFormField2\"\r\n" +
-                "\r\n" +
-                "long string should not work" +
-                "\r\n" +
-                "-----1234--\r\n");
+            "Content-Disposition: form-data; name=\"file\"; filename=\"deleteme.txt\"\r\n" +
+            "Content-Type: text/html\r\n" +
+            "\r\n" +
+            "Unit test of ActionFileUploadInterceptor" +
+            "\r\n" +
+            "-----1234\r\n" +
+            "Content-Disposition: form-data; name=\"normalFormField1\"\r\n" +
+            "\r\n" +
+            "it works" +
+            "\r\n" +
+            "-----1234\r\n" +
+            "Content-Disposition: form-data; name=\"normalFormField2\"\r\n" +
+            "\r\n" +
+            "long string should not work" +
+            "\r\n" +
+            "-----1234--\r\n");
         req.setContent(content.getBytes(StandardCharsets.US_ASCII));
 
-        MyFileupAction action = container.inject(MyFileupAction.class);
+        MyFileUploadAction action = container.inject(MyFileUploadAction.class);
 
         MockActionInvocation mai = new MockActionInvocation();
         mai.setAction(action);
         mai.setResultCode("success");
         mai.setInvocationContext(ActionContext.getContext());
-        Map<String, Object> param = new HashMap<>();
         ActionContext.getContext()
-                .withParameters(HttpParameters.create(param).build())
-                .withServletRequest(createMultipartRequestMaxStringLength(req));
+            .withServletRequest(createMultipartRequestMaxStringLength(req));
 
         interceptor.intercept(mai);
 
@@ -505,8 +471,8 @@ public class FileUploadInterceptorTest extends StrutsInternalTestCase {
         assertEquals(1, errors.size());
         String msg = errors.iterator().next();
         assertEquals(
-                "The request parameter \"normalFormField2\" was too long.  Max length allowed is 20, but found 27!",
-                msg);
+            "The request parameter \"normalFormField2\" was too long.  Max length allowed is 20, but found 27!",
+            msg);
     }
 
     public void testMultipartRequestLocalizedError() throws Exception {
@@ -517,23 +483,21 @@ public class FileUploadInterceptorTest extends StrutsInternalTestCase {
 
         // inspired by the unit tests for jakarta commons fileupload
         String content = ("-----1234\r\n" +
-                "Content-Disposition: form-data; name=\"file\"; filename=\"deleteme.txt\"\r\n" +
-                "Content-Type: text/html\r\n" +
-                "\r\n" +
-                "Unit test of FileUploadInterceptor" +
-                "\r\n" +
-                "-----1234--\r\n");
+            "Content-Disposition: form-data; name=\"file\"; filename=\"deleteme.txt\"\r\n" +
+            "Content-Type: text/html\r\n" +
+            "\r\n" +
+            "Unit test of ActionFileUploadInterceptor" +
+            "\r\n" +
+            "-----1234--\r\n");
         req.setContent(content.getBytes(StandardCharsets.US_ASCII));
 
-        MyFileupAction action = container.inject(MyFileupAction.class);
+        MyFileUploadAction action = container.inject(MyFileUploadAction.class);
 
         MockActionInvocation mai = new MockActionInvocation();
         mai.setAction(action);
         mai.setResultCode("success");
         mai.setInvocationContext(ActionContext.getContext());
-        Map<String, Object> param = new HashMap<>();
         ActionContext.getContext()
-            .withParameters(HttpParameters.create(param).build())
             .withLocale(Locale.GERMAN)
             .withServletRequest(createMultipartRequestMaxSize(req, 10));
 
@@ -594,7 +558,7 @@ public class FileUploadInterceptorTest extends StrutsInternalTestCase {
     protected void setUp() throws Exception {
         super.setUp();
 
-        interceptor = new FileUploadInterceptor();
+        interceptor = new ActionFileUploadInterceptor();
         container.inject(interceptor);
         tempDir = File.createTempFile("struts", "fileupload");
         tempDir.delete();
@@ -607,12 +571,17 @@ public class FileUploadInterceptorTest extends StrutsInternalTestCase {
         super.tearDown();
     }
 
-    public static class MyFileupAction extends ActionSupport {
+    public static class MyFileUploadAction extends ActionSupport implements UploadedFilesAware {
+        private List<UploadedFile> uploadedFiles;
 
-        private static final long serialVersionUID = 6255238895447968889L;
+        @Override
+        public void withUploadedFiles(List<UploadedFile> uploadedFiles) {
+            this.uploadedFiles = uploadedFiles;
+        }
 
-        // no methods
+        public List<UploadedFile> getUploadFiles() {
+            return this.uploadedFiles;
+        }
     }
-
 
 }

--- a/core/src/test/java/org/apache/struts2/interceptor/FileUploadInterceptorTest.java
+++ b/core/src/test/java/org/apache/struts2/interceptor/FileUploadInterceptorTest.java
@@ -47,6 +47,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 
 /**
  * Test case for FileUploadInterceptor.
@@ -198,7 +200,6 @@ public class FileUploadInterceptorTest extends StrutsInternalTestCase {
     }
 
     public void testAcceptFileWithMaxSize() throws Exception {
-        interceptor.setAllowedTypes("text/plain");
         interceptor.setMaximumSize(10L);
 
         // when file is not of allowed types
@@ -217,9 +218,12 @@ public class FileUploadInterceptorTest extends StrutsInternalTestCase {
         assertEquals(1, errors.size());
         String msg = errors.get(0);
         // the error message should contain at least this test
-        assertTrue(msg.startsWith("The file is too large to be uploaded"));
-        assertTrue(msg.indexOf("inputName") > 0);
-        assertTrue(msg.indexOf("log4j2.xml") > 0);
+        assertThat(msg).contains(
+            "The file is too large to be uploaded",
+            "inputName",
+            "log4j2.xml",
+            "allowed mx size is 10"
+        );
     }
 
     public void testNoMultipartRequest() throws Exception {

--- a/plugins/pell-multipart/src/main/java/org/apache/struts2/dispatcher/multipart/PellMultiPartRequest.java
+++ b/plugins/pell-multipart/src/main/java/org/apache/struts2/dispatcher/multipart/PellMultiPartRequest.java
@@ -31,7 +31,6 @@ import java.util.List;
 
 /**
  * Multipart form data request adapter for Jason Pell's multipart utils package.
- *
  */
 public class PellMultiPartRequest extends AbstractMultiPartRequest {
 
@@ -69,7 +68,11 @@ public class PellMultiPartRequest extends AbstractMultiPartRequest {
     }
 
     public UploadedFile[] getFile(String fieldName) {
-        return new UploadedFile[]{ new StrutsUploadedFile(multi.getFile(fieldName)) };
+        return new UploadedFile[]{StrutsUploadedFile.Builder.create(multi.getFile(fieldName))
+            .withContentType(multi.getContentType(fieldName))
+            .withOriginalName(multi.getFileSystemName(fieldName))
+            .build()
+        };
     }
 
     public String[] getFileNames(String fieldName) {
@@ -132,7 +135,7 @@ public class PellMultiPartRequest extends AbstractMultiPartRequest {
             }
         } catch (IllegalArgumentException e) {
             if (LOG.isInfoEnabled()) {
-        	    LOG.info("Could not get encoding property 'struts.i18n.encoding' for file upload.  Using system default");
+                LOG.info("Could not get encoding property 'struts.i18n.encoding' for file upload.  Using system default");
             }
         } catch (UnsupportedEncodingException e) {
             LOG.error("Encoding " + encoding + " is not a valid encoding.  Please check your struts.properties file.");
@@ -140,8 +143,8 @@ public class PellMultiPartRequest extends AbstractMultiPartRequest {
     }
 
     /* (non-Javadoc)
-    * @see org.apache.struts2.dispatcher.multipart.MultiPartRequest#cleanUp()
-    */
+     * @see org.apache.struts2.dispatcher.multipart.MultiPartRequest#cleanUp()
+     */
     public void cleanUp() {
         Enumeration fileParameterNames = multi.getFileParameterNames();
         while (fileParameterNames != null && fileParameterNames.hasMoreElements()) {


### PR DESCRIPTION
This PR implements a new upload mechanism which uses a dedicated callback interface to pass info about uploaded files.

Closes [WW-5371](https://issues.apache.org/jira/browse/WW-5371)