### PR TITLE
WW-5364 Add missing system allowlist classes

### DIFF
--- a/core/src/main/java/com/opensymphony/xwork2/ognl/SecurityMemberAccess.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/SecurityMemberAccess.java
@@ -68,6 +68,8 @@ public class SecurityMemberAccess implements MemberAccess {
     private static final Set<Class<?>> ALLOWLIST_REQUIRED_CLASSES = unmodifiableSet(new HashSet<>(Arrays.asList(
             java.lang.Enum.class,
             java.util.Date.class,
+            java.util.Map.class,
+            java.util.Map.Entry.class,
             java.util.HashMap.class
     )));
 


### PR DESCRIPTION
WW-5364
--
Fix for the following in the showcase app - thanks @lukaszlenart for noticing
```
[WARN ] ognl.SecurityMemberAccess (SecurityMemberAccess.java:205) - Declaring class [interface java.util.Map$Entry] of member type [public abstract java.lang.Object java.util.Map$Entry.getKey()] is not allowlisted!
```