### PR TITLE
WW-5378 Add option to NOT fallback to context lookup when finding value on OgnlValueStack

### DIFF
--- a/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlValueStack.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlValueStack.java
@@ -76,6 +76,7 @@ public class OgnlValueStack implements Serializable, ValueStack, ClearableValueS
     private transient XWorkConverter converter;
     private boolean devMode;
     private boolean logMissingProperties;
+    private boolean shouldFallbackToContext = true;
 
     /**
      * @since 6.4.0
@@ -170,6 +171,11 @@ public class OgnlValueStack implements Serializable, ValueStack, ClearableValueS
     @Inject(value = StrutsConstants.STRUTS_OGNL_LOG_MISSING_PROPERTIES, required = false)
     protected void setLogMissingProperties(String logMissingProperties) {
         this.logMissingProperties = BooleanUtils.toBoolean(logMissingProperties);
+    }
+
+    @Inject(value = StrutsConstants.STRUTS_OGNL_VALUE_STACK_FALLBACK_TO_CONTEXT, required = false)
+    protected void setShouldFallbackToContext(String shouldFallbackToContext) {
+        this.shouldFallbackToContext = BooleanUtils.toBoolean(shouldFallbackToContext);
     }
 
     /**
@@ -417,6 +423,9 @@ public class OgnlValueStack implements Serializable, ValueStack, ClearableValueS
     }
 
     protected Object findInContext(String name) {
+        if (!shouldFallbackToContext) {
+            return null;
+        }
         return getContext().get(name);
     }
 

--- a/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlValueStackFactory.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlValueStackFactory.java
@@ -60,18 +60,21 @@ public class OgnlValueStackFactory implements ValueStackFactory {
         this.textProvider = textProvider;
     }
 
+    @Override
     public ValueStack createValueStack() {
-        ValueStack stack = new OgnlValueStack(
-                xworkConverter, compoundRootAccessor, textProvider, container.getInstance(SecurityMemberAccess.class));
-        container.inject(stack);
-        return stack.getActionContext().withContainer(container).withValueStack(stack).getValueStack();
+        return createValueStack(null, true);
     }
 
+    @Override
     public ValueStack createValueStack(ValueStack stack) {
-        ValueStack result = new OgnlValueStack(
-                stack, xworkConverter, compoundRootAccessor, container.getInstance(SecurityMemberAccess.class));
-        container.inject(result);
-        return result.getActionContext().withContainer(container).withValueStack(result).getValueStack();
+        return createValueStack(stack, false);
+    }
+
+    protected ValueStack createValueStack(ValueStack stack, boolean useTextProvider) {
+        ValueStack newStack = new OgnlValueStack(
+                stack, xworkConverter, compoundRootAccessor, useTextProvider ? textProvider : null, container.getInstance(SecurityMemberAccess.class));
+        container.inject(newStack);
+        return newStack.getActionContext().withContainer(container).withValueStack(newStack).getValueStack();
     }
 
     @Inject

--- a/core/src/main/java/org/apache/struts2/StrutsConstants.java
+++ b/core/src/main/java/org/apache/struts2/StrutsConstants.java
@@ -309,6 +309,14 @@ public final class StrutsConstants {
     public static final String STRUTS_OGNL_LOG_MISSING_PROPERTIES = "struts.ognl.logMissingProperties";
 
     /**
+     * Determines whether lookups on the ValueStack should fallback to looking in the context if the OGNL expression
+     * fails or returns null.
+     *
+     * @since 6.4.0
+     */
+    public static final String STRUTS_OGNL_VALUE_STACK_FALLBACK_TO_CONTEXT = "struts.ognl.valueStackFallbackToContext";
+
+    /**
      * Logs properties that are not found (very verbose)
      * @deprecated as of 6.0.0.  Use {@link #STRUTS_OGNL_LOG_MISSING_PROPERTIES} instead.
      */

--- a/core/src/test/java/com/opensymphony/xwork2/ognl/OgnlValueStackTest.java
+++ b/core/src/test/java/com/opensymphony/xwork2/ognl/OgnlValueStackTest.java
@@ -1122,9 +1122,18 @@ public class OgnlValueStackTest extends XWorkTestCase {
         assertEquals("Hello World", vs.findValue("claus", String.class));
         assertEquals("Hello World", vs.findValue("top", String.class));
 
+        assertNull(vs.findValue("unknown", String.class));
+    }
+
+    public void testExprFallbackToContext() {
         vs.getContext().put("santa", "Hello Santa");
         assertEquals("Hello Santa", vs.findValue("santa", String.class));
-        assertNull(vs.findValue("unknown", String.class));
+    }
+
+    public void testExprFallbackToContext_disabled() {
+        vs.setShouldFallbackToContext("false");
+        vs.getContext().put("santa", "Hello Santa");
+        assertNull(vs.findValue("santa", String.class));
     }
 
     public void testWarnAboutInvalidProperties() {


### PR DESCRIPTION
WW-5378
--
The Struts OGNL context is powerful but also a security nightmare - this option allows applications to disable its access completely when used alongside OGNLGuard with `ognl.ASTVarRef,ognl.ASTThisVarRef` configured.