### PR TITLE
WW-5379 Implement alternative mechanism for Velocity directives to obtain ValueStack

### DIFF
--- a/core/src/main/java/org/apache/struts2/util/ValueStackProvider.java
+++ b/core/src/main/java/org/apache/struts2/util/ValueStackProvider.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.struts2.util;
+
+import com.opensymphony.xwork2.util.ValueStack;
+
+/**
+ * @since 6.4.0
+ */
+public interface ValueStackProvider {
+
+    ValueStack getValueStack();
+
+}

--- a/plugins/velocity/src/main/java/org/apache/struts2/views/velocity/StrutsVelocityContext.java
+++ b/plugins/velocity/src/main/java/org/apache/struts2/views/velocity/StrutsVelocityContext.java
@@ -77,10 +77,10 @@ public class StrutsVelocityContext extends VelocityContext {
     }
 
     protected List<Function<String, Object>> contextGetterList() {
-        return Arrays.asList(this::superGet, this::chainedContextGet, this::stackGet);
+        return Arrays.asList(this::superInternalGet, this::chainedContextGet, this::stackGet);
     }
 
-    protected Object superGet(String key) {
+    protected Object superInternalGet(String key) {
         return super.internalGet(key);
     }
 
@@ -96,7 +96,7 @@ public class StrutsVelocityContext extends VelocityContext {
             return null;
         }
         for (VelocityContext chainedContext : chainedContexts) {
-            Object val = chainedContext.internalGet(key);
+            Object val = chainedContext.get(key);
             if (val != null) {
                 return val;
             }

--- a/plugins/velocity/src/main/java/org/apache/struts2/views/velocity/StrutsVelocityContext.java
+++ b/plugins/velocity/src/main/java/org/apache/struts2/views/velocity/StrutsVelocityContext.java
@@ -103,4 +103,8 @@ public class StrutsVelocityContext extends VelocityContext {
         }
         return null;
     }
+
+    public ValueStack getValueStack() {
+        return stack;
+    }
 }

--- a/plugins/velocity/src/main/java/org/apache/struts2/views/velocity/StrutsVelocityContext.java
+++ b/plugins/velocity/src/main/java/org/apache/struts2/views/velocity/StrutsVelocityContext.java
@@ -19,6 +19,7 @@
 package org.apache.struts2.views.velocity;
 
 import com.opensymphony.xwork2.util.ValueStack;
+import org.apache.struts2.util.ValueStackProvider;
 import org.apache.velocity.VelocityContext;
 
 import java.util.ArrayList;
@@ -26,7 +27,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
 
-public class StrutsVelocityContext extends VelocityContext {
+public class StrutsVelocityContext extends VelocityContext implements ValueStackProvider {
 
     private final ValueStack stack;
     private final List<VelocityContext> chainedContexts;
@@ -104,6 +105,7 @@ public class StrutsVelocityContext extends VelocityContext {
         return null;
     }
 
+    @Override
     public ValueStack getValueStack() {
         return stack;
     }

--- a/plugins/velocity/src/main/java/org/apache/struts2/views/velocity/components/AbstractDirective.java
+++ b/plugins/velocity/src/main/java/org/apache/struts2/views/velocity/components/AbstractDirective.java
@@ -22,8 +22,8 @@ import com.opensymphony.xwork2.inject.Container;
 import com.opensymphony.xwork2.util.ValueStack;
 import org.apache.struts2.ServletActionContext;
 import org.apache.struts2.components.Component;
+import org.apache.struts2.util.ValueStackProvider;
 import org.apache.struts2.views.util.ContextUtil;
-import org.apache.struts2.views.velocity.StrutsVelocityContext;
 import org.apache.velocity.context.AbstractContext;
 import org.apache.velocity.context.Context;
 import org.apache.velocity.context.InternalContextAdapter;
@@ -86,8 +86,8 @@ public abstract class AbstractDirective extends Directive {
 
     private ValueStack extractValueStack(Context context) {
         do {
-            if (context instanceof StrutsVelocityContext) {
-                return ((StrutsVelocityContext) context).getValueStack();
+            if (context instanceof ValueStackProvider) {
+                return ((ValueStackProvider) context).getValueStack();
             }
             context = extractContext(context);
         } while (context != null);

--- a/plugins/velocity/src/test/java/org/apache/struts2/views/velocity/StrutsVelocityContextTest.java
+++ b/plugins/velocity/src/test/java/org/apache/struts2/views/velocity/StrutsVelocityContextTest.java
@@ -54,7 +54,7 @@ public class StrutsVelocityContextTest {
 
     @Test
     public void getChainedValue() {
-        when(chainedContext.internalGet("foo")).thenReturn("bar");
+        when(chainedContext.get("foo")).thenReturn("bar");
         assertEquals("bar", strutsVelocityContext.internalGet("foo"));
     }
 
@@ -75,7 +75,7 @@ public class StrutsVelocityContextTest {
         when(stack.findValue("foo")).thenReturn("qux");
         assertEquals("qux", strutsVelocityContext.internalGet("foo"));
 
-        when(chainedContext.internalGet("foo")).thenReturn("baz");
+        when(chainedContext.get("foo")).thenReturn("baz");
         assertEquals("baz", strutsVelocityContext.internalGet("foo"));
 
         strutsVelocityContext.put("foo", "bar");


### PR DESCRIPTION
WW-5379
--
This affords applications the ability to not include the ValueStack as `$stack` in the Velocity context and reduce risk of SSTI escalation.