### PR TITLE
WW-5352 Introducing the StrutsParameter annotation

### DIFF
--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/UITagExample.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/UITagExample.java
@@ -24,9 +24,15 @@ import com.opensymphony.xwork2.ActionSupport;
 import com.opensymphony.xwork2.Validateable;
 import com.opensymphony.xwork2.util.ValueStack;
 import org.apache.struts2.ServletActionContext;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
 import java.io.File;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  */
@@ -89,6 +95,7 @@ public class UITagExample extends ActionSupport implements Validateable {
 		return leftSideCartoonCharacters;
 	}
 
+	@StrutsParameter
 	public void setLeftSideCartoonCharacters(List leftSideCartoonCharacters) {
 		this.leftSideCartoonCharacters = leftSideCartoonCharacters;
 	}
@@ -98,6 +105,7 @@ public class UITagExample extends ActionSupport implements Validateable {
 		return rightSideCartoonCharacters;
 	}
 
+	@StrutsParameter
 	public void setRightSideCartoonCharacters(List rightSideCartoonCharacters) {
 		this.rightSideCartoonCharacters = rightSideCartoonCharacters;
 	}
@@ -107,6 +115,7 @@ public class UITagExample extends ActionSupport implements Validateable {
 		return favouriteVehicalType;
 	}
 
+	@StrutsParameter
 	public void setFavouriteVehicalType(String favouriteVehicalType) {
 		this.favouriteVehicalType = favouriteVehicalType;
 	}
@@ -115,6 +124,7 @@ public class UITagExample extends ActionSupport implements Validateable {
 		return favouriteVehicalSpecific;
 	}
 
+	@StrutsParameter
 	public void setFavouriteVehicalSpecific(String favouriteVehicalSpecific) {
 		this.favouriteVehicalSpecific = favouriteVehicalSpecific;
 	}
@@ -145,6 +155,7 @@ public class UITagExample extends ActionSupport implements Validateable {
 		return name;
 	}
 
+	@StrutsParameter
 	public void setName(String name) {
 		this.name = name;
 	}
@@ -153,6 +164,7 @@ public class UITagExample extends ActionSupport implements Validateable {
 		return birthday;
 	}
 
+	@StrutsParameter
 	public void setBirthday(Date birthday) {
 		this.birthday = birthday;
 	}
@@ -161,6 +173,7 @@ public class UITagExample extends ActionSupport implements Validateable {
 		return bio;
 	}
 
+	@StrutsParameter
 	public void setBio(String bio) {
 		this.bio = bio;
 	}
@@ -169,6 +182,7 @@ public class UITagExample extends ActionSupport implements Validateable {
 		return favouriteColor;
 	}
 
+	@StrutsParameter
 	public void setFavouriteColor(String favoriteColor) {
 		this.favouriteColor = favoriteColor;
 	}
@@ -177,6 +191,7 @@ public class UITagExample extends ActionSupport implements Validateable {
 		return friends;
 	}
 
+	@StrutsParameter
 	public void setFriends(List friends) {
 		this.friends = friends;
 	}
@@ -193,6 +208,7 @@ public class UITagExample extends ActionSupport implements Validateable {
 		return legalAge;
 	}
 
+	@StrutsParameter
 	public void setLegalAge(boolean legalAge) {
 		this.legalAge = legalAge;
 	}
@@ -201,6 +217,7 @@ public class UITagExample extends ActionSupport implements Validateable {
 		return state;
 	}
 
+	@StrutsParameter
 	public void setState(String state) {
 		this.state = state;
 	}
@@ -209,6 +226,7 @@ public class UITagExample extends ActionSupport implements Validateable {
 		return region;
 	}
 
+	@StrutsParameter
 	public void setRegion(String region) {
 		this.region = region;
 	}
@@ -229,6 +247,7 @@ public class UITagExample extends ActionSupport implements Validateable {
 		this.pictureFileName = pictureFileName;
 	}
 
+	@StrutsParameter
 	public void setFavouriteLanguage(String favouriteLanguage) {
 		this.favouriteLanguage = favouriteLanguage;
 	}
@@ -237,7 +256,7 @@ public class UITagExample extends ActionSupport implements Validateable {
 		return favouriteLanguage;
 	}
 
-
+	@StrutsParameter
 	public void setThoughts(String thoughts) {
 		this.thoughts = thoughts;
 	}
@@ -250,6 +269,7 @@ public class UITagExample extends ActionSupport implements Validateable {
 		return wakeup;
 	}
 
+	@StrutsParameter
 	public void setWakeup(Date wakeup) {
 		this.wakeup = wakeup;
 	}

--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/action/ParamsAnnotationAction.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/action/ParamsAnnotationAction.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.struts2.showcase.action;
+
+import com.opensymphony.xwork2.ActionSupport;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
+import org.apache.struts2.showcase.model.MyDto;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
+
+/**
+ * This class supports {@link com.atlassian.confluence.stateless.webdriver.selenium3.security.StrutsParametersTest}
+ * which prevents critical security regressions. Do NOT modify without understanding the motivation behind the tests and
+ * the implications of any changes.
+ */
+public class ParamsAnnotationAction extends ActionSupport {
+
+    @StrutsParameter
+    public String varToPrint;
+
+    public String publicField = "no";
+
+    @StrutsParameter
+    public String publicFieldAnnotated = "no";
+
+    private String privateField = "no";
+
+    public int[] publicArray = new int[]{0};
+
+    @StrutsParameter(depth = 1)
+    public int[] publicArrayAnnotated = new int[]{0};
+
+    public List<String> publicList = new ArrayList<>(singletonList("no"));
+
+    @StrutsParameter(depth = 1)
+    public List<String> publicListAnnotated = new ArrayList<>(singletonList("no"));
+
+    private List<String> privateList = new ArrayList<>(singletonList("no"));
+
+    public Map<String, String> publicMap = new HashMap<>(singletonMap("key", "no"));
+
+    @StrutsParameter(depth = 1)
+    public Map<String, String> publicMapAnnotated = new HashMap<>(singletonMap("key", "no"));
+
+    public MyDto publicMyDto = new MyDto();
+
+    @StrutsParameter(depth = 2)
+    public MyDto publicMyDtoAnnotated = new MyDto();
+
+    @StrutsParameter(depth = 1)
+    public MyDto publicMyDtoAnnotatedDepthOne = new MyDto();
+
+    private MyDto privateMyDto = new MyDto();
+
+    public void setPrivateFieldMethod(String privateField) {
+        this.privateField = privateField;
+    }
+
+    @StrutsParameter
+    public void setPrivateFieldMethodAnnotated(String privateField) {
+        this.privateField = privateField;
+    }
+
+    public List<String> getPrivateListMethod() {
+        return privateList;
+    }
+
+    @StrutsParameter(depth = 1)
+    public List<String> getPrivateListMethodAnnotated() {
+        return privateList;
+    }
+
+    public MyDto getUnsafeMethodMyDto() {
+        return privateMyDto;
+    }
+
+    @StrutsParameter(depth = 2)
+    public MyDto getSafeMethodMyDto() {
+        return privateMyDto;
+    }
+
+    @StrutsParameter(depth = 1)
+    public MyDto getSafeMethodMyDtoDepthOne() {
+        return privateMyDto;
+    }
+
+    public String renderVarToPrint() throws ReflectiveOperationException {
+        if (varToPrint == null) {
+            return "null";
+        }
+        Field field = this.getClass().getDeclaredField(varToPrint);
+        field.setAccessible(true);
+        try {
+            return String.format("%s{%s}", varToPrint,
+                    field.getType().isArray() ? stringifyArray(field.get(this)) : field.get(this));
+        } finally {
+            field.setAccessible(false);
+        }
+    }
+
+    private String stringifyArray(Object array) {
+        switch (array.getClass().getComponentType().getName()) {
+            case "int":
+                return Arrays.toString((int[]) array);
+            default:
+                return "TODO";
+        }
+    }
+}

--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/action/SkillAction.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/action/SkillAction.java
@@ -21,6 +21,7 @@ package org.apache.struts2.showcase.action;
 import com.opensymphony.xwork2.Preparable;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 import org.apache.struts2.showcase.dao.Dao;
 import org.apache.struts2.showcase.dao.SkillDao;
 import org.apache.struts2.showcase.model.Skill;
@@ -71,6 +72,7 @@ public class SkillAction extends AbstractCRUDAction implements Preparable {
 		return skillDao;
 	}
 
+	@StrutsParameter(depth = 1)
 	public Skill getCurrentSkill() {
 		return currentSkill;
 	}

--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/async/ChatRoomAction.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/async/ChatRoomAction.java
@@ -19,6 +19,7 @@
 package org.apache.struts2.showcase.async;
 
 import com.opensymphony.xwork2.ActionSupport;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -34,10 +35,12 @@ public class ChatRoomAction extends ActionSupport {
 
     private static final List<String> messages = new ArrayList<>();
 
+    @StrutsParameter
     public void setMessage(String message) {
         this.message = message;
     }
 
+    @StrutsParameter
     public void setLastIndex(Integer lastIndex) {
         this.lastIndex = lastIndex;
     }

--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/conversion/AddressAction.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/conversion/AddressAction.java
@@ -21,6 +21,7 @@
 package org.apache.struts2.showcase.conversion;
 
 import com.opensymphony.xwork2.ActionSupport;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
 import java.util.LinkedHashSet;
 import java.util.Set;
@@ -30,7 +31,7 @@ import java.util.Set;
  */
 public class AddressAction extends ActionSupport {
 
-	private Set<Address> addresses = new LinkedHashSet<Address>();
+	private Set<Address> addresses = new LinkedHashSet<>();
 
 	public String input() throws Exception {
 		return SUCCESS;
@@ -41,6 +42,7 @@ public class AddressAction extends ActionSupport {
 		return SUCCESS;
 	}
 
+	@StrutsParameter(depth = 2)
 	public Set<Address> getAddresses() {
 		return addresses;
 	}

--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/conversion/OperationsEnumAction.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/conversion/OperationsEnumAction.java
@@ -21,6 +21,7 @@
 package org.apache.struts2.showcase.conversion;
 
 import com.opensymphony.xwork2.ActionSupport;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
 import java.util.Arrays;
 import java.util.LinkedList;
@@ -47,6 +48,7 @@ public class OperationsEnumAction extends ActionSupport {
 		return this.selectedOperations;
 	}
 
+	@StrutsParameter
 	public void setSelectedOperations(List<OperationsEnum> selectedOperations) {
 		this.selectedOperations = selectedOperations;
 	}

--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/conversion/PersonAction.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/conversion/PersonAction.java
@@ -21,6 +21,7 @@
 package org.apache.struts2.showcase.conversion;
 
 import com.opensymphony.xwork2.ActionSupport;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
 import java.util.List;
 
@@ -36,6 +37,7 @@ public class PersonAction extends ActionSupport {
 		return SUCCESS;
 	}
 
+	@StrutsParameter(depth = 2)
 	public List<Person> getPersons() {
 		return persons;
 	}

--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/filedownload/FileDownloadAction.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/filedownload/FileDownloadAction.java
@@ -22,6 +22,7 @@ package org.apache.struts2.showcase.filedownload;
 
 import com.opensymphony.xwork2.Action;
 import org.apache.struts2.ServletActionContext;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
 import java.io.InputStream;
 
@@ -38,6 +39,7 @@ public class FileDownloadAction implements Action {
 		return SUCCESS;
 	}
 
+	@StrutsParameter
 	public void setInputPath(String value) {
 		inputPath = sanitizeInputPath(value);
 	}

--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/fileupload/FileUploadAction.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/fileupload/FileUploadAction.java
@@ -23,6 +23,7 @@ package org.apache.struts2.showcase.fileupload;
 import com.opensymphony.xwork2.ActionSupport;
 import org.apache.struts2.action.UploadedFilesAware;
 import org.apache.struts2.dispatcher.multipart.UploadedFile;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
 import java.util.List;
 
@@ -65,6 +66,7 @@ public class FileUploadAction extends ActionSupport implements UploadedFilesAwar
         return caption;
     }
 
+    @StrutsParameter
     public void setCaption(String caption) {
         this.caption = caption;
     }

--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/model/MyDto.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/model/MyDto.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.struts2.showcase.model;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.util.Collections.singletonMap;
+
+public class MyDto {
+
+    public String str = "no";
+
+    public Map<String, String> map = new HashMap<>(singletonMap("key", "no"));
+    public int[] array = new int[]{0};
+
+    @Override
+    public String toString() {
+        return "str=" + str + ", map=" + map + ", array=" + Arrays.toString(array);
+    }
+}

--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/validation/FieldValidatorsExampleAction.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/validation/FieldValidatorsExampleAction.java
@@ -20,6 +20,8 @@
  */
 package org.apache.struts2.showcase.validation;
 
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
+
 import java.sql.Date;
 
 /**
@@ -44,6 +46,7 @@ public class FieldValidatorsExampleAction extends AbstractValidationActionSuppor
         return dateValidatorField;
     }
 
+    @StrutsParameter
     public void setDateValidatorField(Date dateValidatorField) {
         this.dateValidatorField = dateValidatorField;
     }
@@ -52,6 +55,7 @@ public class FieldValidatorsExampleAction extends AbstractValidationActionSuppor
         return emailValidatorField;
     }
 
+    @StrutsParameter
     public void setEmailValidatorField(String emailValidatorField) {
         this.emailValidatorField = emailValidatorField;
     }
@@ -60,6 +64,7 @@ public class FieldValidatorsExampleAction extends AbstractValidationActionSuppor
         return integerValidatorField;
     }
 
+    @StrutsParameter
     public void setIntegerValidatorField(Integer integerValidatorField) {
         this.integerValidatorField = integerValidatorField;
     }
@@ -68,6 +73,7 @@ public class FieldValidatorsExampleAction extends AbstractValidationActionSuppor
         return regexValidatorField;
     }
 
+    @StrutsParameter
     public void setRegexValidatorField(String regexValidatorField) {
         this.regexValidatorField = regexValidatorField;
     }
@@ -76,6 +82,7 @@ public class FieldValidatorsExampleAction extends AbstractValidationActionSuppor
         return requiredStringValidatorField;
     }
 
+    @StrutsParameter
     public void setRequiredStringValidatorField(String requiredStringValidatorField) {
         this.requiredStringValidatorField = requiredStringValidatorField;
     }
@@ -84,6 +91,7 @@ public class FieldValidatorsExampleAction extends AbstractValidationActionSuppor
         return requiredValidatorField;
     }
 
+    @StrutsParameter
     public void setRequiredValidatorField(String requiredValidatorField) {
         this.requiredValidatorField = requiredValidatorField;
     }
@@ -92,6 +100,7 @@ public class FieldValidatorsExampleAction extends AbstractValidationActionSuppor
         return stringLengthValidatorField;
     }
 
+    @StrutsParameter
     public void setStringLengthValidatorField(String stringLengthValidatorField) {
         this.stringLengthValidatorField = stringLengthValidatorField;
     }
@@ -100,6 +109,7 @@ public class FieldValidatorsExampleAction extends AbstractValidationActionSuppor
         return fieldExpressionValidatorField;
     }
 
+    @StrutsParameter
     public void setFieldExpressionValidatorField(
             String fieldExpressionValidatorField) {
         this.fieldExpressionValidatorField = fieldExpressionValidatorField;
@@ -109,6 +119,7 @@ public class FieldValidatorsExampleAction extends AbstractValidationActionSuppor
         return urlValidatorField;
     }
 
+    @StrutsParameter
     public void setUrlValidatorField(String urlValidatorField) {
         this.urlValidatorField = urlValidatorField;
     }

--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/wait/LongProcessAction.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/wait/LongProcessAction.java
@@ -21,6 +21,7 @@
 package org.apache.struts2.showcase.wait;
 
 import com.opensymphony.xwork2.ActionSupport;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
 /**
  * Example to illustrate the <code>execAndWait</code> interceptor.
@@ -41,6 +42,7 @@ public class LongProcessAction extends ActionSupport {
 		return time;
 	}
 
+	@StrutsParameter
 	public void setTime(int time) {
 		this.time = time;
 	}

--- a/apps/showcase/src/main/resources/struts-params-annotation.xml
+++ b/apps/showcase/src/main/resources/struts-params-annotation.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+-->
+<!DOCTYPE struts PUBLIC
+        "-//Apache Software Foundation//DTD Struts Configuration 6.0//EN"
+        "https://struts.apache.org/dtds/struts-6.0.dtd">
+
+<struts>
+    <package name="params-annotation" extends="velocity-default" namespace="/paramsannotation">
+        <action name="test" class="org.apache.struts2.showcase.action.ParamsAnnotationAction">
+            <result type="velocity">/WEB-INF/paramsannotation.vm</result>
+        </action>
+    </package>
+</struts>

--- a/apps/showcase/src/main/resources/struts.xml
+++ b/apps/showcase/src/main/resources/struts.xml
@@ -83,6 +83,8 @@
 
     <include file="struts-dispatcher.xml" />
 
+    <include file="struts-params-annotation.xml" />
+
     <package name="default" extends="struts-default">
         <interceptors>
             <interceptor-stack name="crudStack">

--- a/apps/showcase/src/main/resources/struts.xml
+++ b/apps/showcase/src/main/resources/struts.xml
@@ -36,11 +36,6 @@
 
     <constant name="struts.allowlist.enable" value="true" />
     <constant name="struts.parameters.requireAnnotations" value="true" />
-    <constant name="struts.allowlist.classes"
-              value="
-                org.apache.struts2.showcase.conversion.Person,
-                org.apache.struts2.showcase.conversion.Address
-    "/>
 
     <constant name="struts.convention.package.locators.basePackage" value="org.apache.struts2.showcase" />
     <constant name="struts.convention.result.path" value="/WEB-INF" />

--- a/apps/showcase/src/main/resources/struts.xml
+++ b/apps/showcase/src/main/resources/struts.xml
@@ -35,17 +35,7 @@
     <constant name="struts.action.extension" value="action,," />
 
     <constant name="struts.allowlist.enable" value="true" />
-    <constant name="struts.allowlist.packageNames"
-              value="
-                org.apache.struts2.showcase.model,
-                org.apache.struts2.showcase.conversion
-    "/>
-    <constant name="struts.allowlist.classes"
-              value="
-                org.apache.struts2.showcase.UITagExample$Language,
-                org.apache.struts2.showcase.UITagExample$VehicalType,
-                org.apache.struts2.showcase.UITagExample$VehicalSpecific
-    "/>
+    <constant name="struts.parameters.requireAnnotations" value="true" />
 
     <constant name="struts.convention.package.locators.basePackage" value="org.apache.struts2.showcase" />
     <constant name="struts.convention.result.path" value="/WEB-INF" />

--- a/apps/showcase/src/main/resources/struts.xml
+++ b/apps/showcase/src/main/resources/struts.xml
@@ -36,6 +36,12 @@
 
     <constant name="struts.allowlist.enable" value="true" />
     <constant name="struts.parameters.requireAnnotations" value="true" />
+    <constant name="struts.allowlist.classes"
+              value="
+                org.apache.struts2.showcase.conversion.OperationsEnum,
+                org.apache.struts2.showcase.conversion.Person,
+                org.apache.struts2.showcase.conversion.Address
+    "/>
 
     <constant name="struts.convention.package.locators.basePackage" value="org.apache.struts2.showcase" />
     <constant name="struts.convention.result.path" value="/WEB-INF" />

--- a/apps/showcase/src/main/resources/struts.xml
+++ b/apps/showcase/src/main/resources/struts.xml
@@ -38,7 +38,6 @@
     <constant name="struts.parameters.requireAnnotations" value="true" />
     <constant name="struts.allowlist.classes"
               value="
-                org.apache.struts2.showcase.conversion.OperationsEnum,
                 org.apache.struts2.showcase.conversion.Person,
                 org.apache.struts2.showcase.conversion.Address
     "/>

--- a/apps/showcase/src/main/webapp/WEB-INF/paramsannotation.vm
+++ b/apps/showcase/src/main/webapp/WEB-INF/paramsannotation.vm
@@ -1,0 +1,19 @@
+#*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*  http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*#
+<div id="output">$action.renderVarToPrint()</div>

--- a/apps/showcase/src/test/java/it/org/apache/struts2/showcase/StrutsParametersTest.java
+++ b/apps/showcase/src/test/java/it/org/apache/struts2/showcase/StrutsParametersTest.java
@@ -1,0 +1,239 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package it.org.apache.struts2.showcase;
+
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class StrutsParametersTest {
+
+    private WebClient webClient;
+
+    @Before
+    public void setUp() throws Exception {
+        webClient = new WebClient();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        webClient.close();
+    }
+
+    @Test
+    public void public_StringField_WithoutGetterSetter_FieldNotAnnotated() throws Exception {
+        Map<String, String> params = new HashMap<>();
+        params.put("publicField", "yes");
+        params.put("varToPrint", "publicField");
+        assertText(params, "publicField{no}");
+    }
+
+    @Test
+    public void public_StringField_WithoutGetterSetter_FieldAnnotated() throws Exception {
+        Map<String, String> params = new HashMap<>();
+        params.put("publicFieldAnnotated", "yes");
+        params.put("varToPrint", "publicFieldAnnotated");
+        assertText(params, "publicFieldAnnotated{yes}");
+    }
+
+    @Test
+    public void private_StringField_WithSetter_MethodNotAnnotated() throws Exception {
+        Map<String, String> params = new HashMap<>();
+        params.put("privateFieldMethod", "yes");
+        params.put("varToPrint", "privateField");
+        assertText(params, "privateField{no}");
+    }
+
+    @Test
+    public void private_StringField_WithSetter_MethodAnnotated() throws Exception {
+        Map<String, String> params = new HashMap<>();
+        params.put("privateFieldMethodAnnotated", "yes");
+        params.put("varToPrint", "privateField");
+        assertText(params, "privateField{yes}");
+    }
+
+    @Test
+    public void public_ArrayField_WithoutGetterSetter_FieldNotAnnotated() throws Exception {
+        Map<String, String> params = new HashMap<>();
+        params.put("publicArray[0]", "1");
+        params.put("varToPrint", "publicArray");
+        assertText(params, "publicArray{[0]}");
+    }
+
+    @Test
+    public void public_ArrayField_WithoutGetterSetter_FieldAnnotated() throws Exception {
+        Map<String, String> params = new HashMap<>();
+        params.put("publicArrayAnnotated[0]", "1");
+        params.put("varToPrint", "publicArrayAnnotated");
+        assertText(params, "publicArrayAnnotated{[1]}");
+    }
+
+    @Test
+    public void public_ListField_WithoutGetterSetter_FieldNotAnnotated() throws Exception {
+        Map<String, String> params = new HashMap<>();
+        params.put("publicList[0]", "yes");
+        params.put("varToPrint", "publicList");
+        assertText(params, "publicList{[no]}");
+    }
+
+    @Test
+    public void public_ListField_WithoutGetterSetter_FieldAnnotated() throws Exception {
+        Map<String, String> params = new HashMap<>();
+        params.put("publicListAnnotated[0]", "yes");
+        params.put("varToPrint", "publicListAnnotated");
+        assertText(params, "publicListAnnotated{[yes]}");
+    }
+
+    @Test
+    public void private_ListField_WithGetterNoSetter_MethodNotAnnotated() throws Exception {
+        Map<String, String> params = new HashMap<>();
+        params.put("privateListMethod[0]", "yes");
+        params.put("varToPrint", "privateList");
+        assertText(params, "privateList{[no]}");
+    }
+
+    @Test
+    public void private_ListField_WithGetterNoSetter_MethodAnnotated() throws Exception {
+        Map<String, String> params = new HashMap<>();
+        params.put("privateListMethodAnnotated[0]", "yes");
+        params.put("varToPrint", "privateList");
+        assertText(params, "privateList{[yes]}");
+    }
+
+    @Test
+    public void public_MapField_WithoutGetterSetter_FieldNotAnnotated() throws Exception {
+        Map<String, String> params = new HashMap<>();
+        params.put("publicMap['key']", "yes");
+        params.put("varToPrint", "publicMap");
+        assertText(params, "publicMap{{key=no}}");
+    }
+
+    @Test
+    public void public_MapField_WithoutGetterSetter_FieldAnnotated() throws Exception {
+        Map<String, String> params = new HashMap<>();
+        params.put("publicMapAnnotated['key']", "yes");
+        params.put("varToPrint", "publicMapAnnotated");
+        assertText(params, "publicMapAnnotated{{key=yes}}");
+    }
+
+    @Test
+    public void public_MapField_Insert_WithoutGetterSetter_FieldNotAnnotated() throws Exception {
+        Map<String, String> params = new HashMap<>();
+        params.put("publicMap[999]", "yes");
+        params.put("varToPrint", "publicMap");
+        assertText(params, "publicMap{{key=no}}");
+    }
+
+    @Test
+    public void public_MapField_Insert_WithoutGetterSetter_FieldAnnotated() throws Exception {
+        Map<String, String> params = new HashMap<>();
+        params.put("publicMapAnnotated[999]", "yes");
+        params.put("varToPrint", "publicMapAnnotated");
+        assertText(params, "publicMapAnnotated{{999=yes, key=no}}");
+    }
+
+    @Test
+    public void public_MyDtoField_WithoutGetter_FieldNotAnnotated() throws Exception {
+        Map<String, String> params = new HashMap<>();
+        params.put("publicMyDto.str", "yes");
+        params.put("publicMyDto.map['key']", "yes");
+        params.put("publicMyDto.array[0]", "1");
+        params.put("varToPrint", "publicMyDto");
+        assertText(params, "publicMyDto{str=no, map={key=no}, array=[0]}");
+    }
+
+    @Test
+    public void public_MyDtoField_WithoutGetter_FieldAnnotated() throws Exception {
+        Map<String, String> params = new HashMap<>();
+        params.put("publicMyDtoAnnotated.str", "yes");
+        params.put("publicMyDtoAnnotated.map['key']", "yes");
+        params.put("publicMyDtoAnnotated.array[0]", "1");
+        params.put("varToPrint", "publicMyDtoAnnotated");
+        assertText(params, "publicMyDtoAnnotated{str=yes, map={key=yes}, array=[1]}");
+    }
+
+    @Test
+    public void public_MyDtoField_WithoutGetter_FieldAnnotatedDepthOne() throws Exception {
+        Map<String, String> params = new HashMap<>();
+        params.put("publicMyDtoAnnotatedDepthOne.str", "yes");
+        params.put("publicMyDtoAnnotatedDepthOne.map['key']", "yes");
+        params.put("publicMyDtoAnnotatedDepthOne.array[0]", "1");
+        params.put("varToPrint", "publicMyDtoAnnotatedDepthOne");
+        assertText(params, "publicMyDtoAnnotatedDepthOne{str=yes, map={key=no}, array=[0]}");
+    }
+
+    @Test
+    public void private_MyDtoField_WithGetter_MethodNotAnnotated() throws Exception {
+        Map<String, String> params = new HashMap<>();
+        params.put("unsafeMethodMyDto.str", "yes");
+        params.put("unsafeMethodMyDto.map['key']", "yes");
+        params.put("unsafeMethodMyDto.array[0]", "1");
+        params.put("varToPrint", "privateMyDto");
+        assertText(params, "privateMyDto{str=no, map={key=no}, array=[0]}");
+    }
+
+    @Test
+    public void private_MyDtoField_WithGetter_MethodNotAnnotated_Alternate() throws Exception {
+        Map<String, String> params = new HashMap<>();
+        params.put("unsafeMethodMyDto['str']", "yes");
+        params.put("unsafeMethodMyDto['map']['key']", "yes");
+        params.put("unsafeMethodMyDto['map'][999]", "yes");
+        params.put("unsafeMethodMyDto['array'][0]", "1");
+        params.put("varToPrint", "privateMyDto");
+        assertText(params, "privateMyDto{str=no, map={key=no}, array=[0]}");
+    }
+
+    @Test
+    public void private_MyDtoField_WithGetter_MethodAnnotated() throws Exception {
+        Map<String, String> params = new HashMap<>();
+        params.put("safeMethodMyDto.str", "yes");
+        params.put("safeMethodMyDto.map['key']", "yes");
+        params.put("safeMethodMyDto.array[0]", "1");
+        params.put("varToPrint", "privateMyDto");
+        assertText(params, "privateMyDto{str=yes, map={key=yes}, array=[1]}");
+    }
+
+    @Test
+    public void private_MyDtoField_WithGetter_MethodAnnotatedDepthOne() throws Exception {
+        Map<String, String> params = new HashMap<>();
+        params.put("safeMethodMyDtoDepthOne.str", "yes");
+        params.put("safeMethodMyDtoDepthOne.map['key']", "yes");
+        params.put("safeMethodMyDtoDepthOne.array[0]", "1");
+        params.put("varToPrint", "privateMyDto");
+        assertText(params, "privateMyDto{str=yes, map={key=no}, array=[0]}");
+    }
+
+    private void assertText(Map<String, String> params, String text) throws IOException {
+        UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(ParameterUtils.getBaseUrl()).path("/paramsannotation/test.action");
+        params.forEach(builder::queryParam);
+        String url = builder.toUriString();
+        HtmlPage page = webClient.getPage(url);
+        String output = page.getElementById("output").asNormalizedText();
+        assertEquals(text, output);
+    }
+}

--- a/core/src/main/java/com/opensymphony/xwork2/config/impl/DefaultConfiguration.java
+++ b/core/src/main/java/com/opensymphony/xwork2/config/impl/DefaultConfiguration.java
@@ -112,6 +112,7 @@ import org.apache.struts2.conversion.StrutsTypeConverterHolder;
 import org.apache.struts2.ognl.OgnlGuard;
 import org.apache.struts2.ognl.ProviderAllowlist;
 import org.apache.struts2.ognl.StrutsOgnlGuard;
+import org.apache.struts2.ognl.ThreadAllowlist;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -395,6 +396,7 @@ public class DefaultConfiguration implements Configuration {
                 .factory(SecurityMemberAccess.class, Scope.PROTOTYPE)
                 .factory(OgnlGuard.class, StrutsOgnlGuard.class, Scope.SINGLETON)
                 .factory(ProviderAllowlist.class, Scope.SINGLETON)
+                .factory(ThreadAllowlist.class, Scope.SINGLETON)
 
                 .factory(ValueSubstitutor.class, EnvsValueSubstitutor.class, Scope.SINGLETON);
     }

--- a/core/src/main/java/com/opensymphony/xwork2/ognl/SecurityMemberAccess.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/SecurityMemberAccess.java
@@ -26,6 +26,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.struts2.StrutsConstants;
 import org.apache.struts2.ognl.ProviderAllowlist;
+import org.apache.struts2.ognl.ThreadAllowlist;
 
 import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Field;
@@ -75,6 +76,7 @@ public class SecurityMemberAccess implements MemberAccess {
     )));
 
     private final ProviderAllowlist providerAllowlist;
+    private final ThreadAllowlist threadAllowlist;
     private boolean allowStaticFieldAccess = true;
     private Set<Pattern> excludeProperties = emptySet();
     private Set<Pattern> acceptProperties = emptySet();
@@ -89,8 +91,9 @@ public class SecurityMemberAccess implements MemberAccess {
     private boolean disallowDefaultPackageAccess = false;
 
     @Inject
-    public SecurityMemberAccess(@Inject ProviderAllowlist providerAllowlist) {
+    public SecurityMemberAccess(@Inject ProviderAllowlist providerAllowlist, @Inject ThreadAllowlist threadAllowlist) {
         this.providerAllowlist = providerAllowlist;
+        this.threadAllowlist = threadAllowlist;
     }
 
     /**
@@ -99,11 +102,11 @@ public class SecurityMemberAccess implements MemberAccess {
      * - block or allow access to properties (configurable-after-construction)
      *
      * @param allowStaticFieldAccess if set to true static fields (constants) will be accessible
-     * @deprecated since 6.4.0, use {@link #SecurityMemberAccess(ProviderAllowlist)} instead.
+     * @deprecated since 6.4.0, use {@link #SecurityMemberAccess(ProviderAllowlist, ThreadAllowlist)} instead.
      */
     @Deprecated
     public SecurityMemberAccess(boolean allowStaticFieldAccess) {
-        this(null);
+        this(null, null);
         useAllowStaticFieldAccess(String.valueOf(allowStaticFieldAccess));
     }
 
@@ -223,6 +226,7 @@ public class SecurityMemberAccess implements MemberAccess {
         return allowlistClasses.contains(clazz)
                 || ALLOWLIST_REQUIRED_CLASSES.contains(clazz)
                 || (providerAllowlist != null && providerAllowlist.getProviderAllowlist().contains(clazz))
+                || (threadAllowlist != null && threadAllowlist.getAllowlist().contains(clazz))
                 || isClassBelongsToPackages(clazz, ALLOWLIST_REQUIRED_PACKAGES)
                 || isClassBelongsToPackages(clazz, allowlistPackageNames);
     }

--- a/core/src/main/java/com/opensymphony/xwork2/security/DefaultAcceptedPatternsChecker.java
+++ b/core/src/main/java/com/opensymphony/xwork2/security/DefaultAcceptedPatternsChecker.java
@@ -31,6 +31,7 @@ import java.util.regex.Pattern;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.unmodifiableSet;
+import static java.util.stream.Collectors.joining;
 
 public class DefaultAcceptedPatternsChecker implements AcceptedPatternsChecker {
 
@@ -44,6 +45,7 @@ public class DefaultAcceptedPatternsChecker implements AcceptedPatternsChecker {
      * Must match {@link #ACCEPTED_PATTERNS} RegEx. Signifies characters which result in a nested lookup via OGNL.
      */
     public static final Set<Character> NESTING_CHARS = unmodifiableSet(new HashSet<>(asList('.', '[', '(')));
+    public static final String NESTING_CHARS_STR = NESTING_CHARS.stream().map(String::valueOf).collect(joining());
 
     public static final String[] DMI_AWARE_ACCEPTED_PATTERNS = {
             "\\w+([:]?\\w+)?((\\.\\w+)|(\\[\\d+])|(\\(\\d+\\))|(\\['(\\w-?|[\\u4e00-\\u9fa5]-?)+'])|(\\('(\\w-?|[\\u4e00-\\u9fa5]-?)+'\\)))*([!]?\\w+)?"

--- a/core/src/main/java/com/opensymphony/xwork2/security/DefaultAcceptedPatternsChecker.java
+++ b/core/src/main/java/com/opensymphony/xwork2/security/DefaultAcceptedPatternsChecker.java
@@ -25,11 +25,12 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.struts2.StrutsConstants;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.regex.Pattern;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.unmodifiableSet;
 
 public class DefaultAcceptedPatternsChecker implements AcceptedPatternsChecker {
 
@@ -38,6 +39,11 @@ public class DefaultAcceptedPatternsChecker implements AcceptedPatternsChecker {
     public static final String[] ACCEPTED_PATTERNS = {
             "\\w+((\\.\\w+)|(\\[\\d+])|(\\(\\d+\\))|(\\['(\\w-?|[\\u4e00-\\u9fa5]-?)+'])|(\\('(\\w-?|[\\u4e00-\\u9fa5]-?)+'\\)))*"
     };
+
+    /**
+     * Must match {@link #ACCEPTED_PATTERNS} RegEx. Signifies characters which result in a nested lookup via OGNL.
+     */
+    public static final Set<Character> NESTING_CHARS = unmodifiableSet(new HashSet<>(asList('.', '[', '(')));
 
     public static final String[] DMI_AWARE_ACCEPTED_PATTERNS = {
             "\\w+([:]?\\w+)?((\\.\\w+)|(\\[\\d+])|(\\(\\d+\\))|(\\['(\\w-?|[\\u4e00-\\u9fa5]-?)+'])|(\\('(\\w-?|[\\u4e00-\\u9fa5]-?)+'\\)))*([!]?\\w+)?"
@@ -74,7 +80,7 @@ public class DefaultAcceptedPatternsChecker implements AcceptedPatternsChecker {
                 newAcceptedPatterns.add(Pattern.compile(pattern, Pattern.CASE_INSENSITIVE));
             }
         } finally {
-            acceptedPatterns = Collections.unmodifiableSet(newAcceptedPatterns);
+            acceptedPatterns = unmodifiableSet(newAcceptedPatterns);
         }
     }
 
@@ -85,7 +91,7 @@ public class DefaultAcceptedPatternsChecker implements AcceptedPatternsChecker {
 
     @Override
     public void setAcceptedPatterns(String[] additionalPatterns) {
-        setAcceptedPatterns(new HashSet<>(Arrays.asList(additionalPatterns)));
+        setAcceptedPatterns(new HashSet<>(asList(additionalPatterns)));
     }
 
     @Override
@@ -97,7 +103,7 @@ public class DefaultAcceptedPatternsChecker implements AcceptedPatternsChecker {
                 newAcceptedPatterns.add(Pattern.compile(pattern, Pattern.CASE_INSENSITIVE));
             }
         } finally {
-            acceptedPatterns = Collections.unmodifiableSet(newAcceptedPatterns);
+            acceptedPatterns = unmodifiableSet(newAcceptedPatterns);
         }
     }
 

--- a/core/src/main/java/org/apache/struts2/StrutsConstants.java
+++ b/core/src/main/java/org/apache/struts2/StrutsConstants.java
@@ -469,6 +469,8 @@ public final class StrutsConstants {
     public static final String STRUTS_ADDITIONAL_EXCLUDED_PATTERNS = "struts.additional.excludedPatterns";
     public static final String STRUTS_ADDITIONAL_ACCEPTED_PATTERNS = "struts.additional.acceptedPatterns";
 
+    public static final String STRUTS_PARAMETERS_REQUIRE_ANNOTATIONS = "struts.parameters.requireAnnotations";
+
     public static final String STRUTS_CONTENT_TYPE_MATCHER = "struts.contentTypeMatcher";
 
     public static final String STRUTS_SMI_METHOD_REGEX = "struts.strictMethodInvocation.methodRegex";

--- a/core/src/main/java/org/apache/struts2/StrutsConstants.java
+++ b/core/src/main/java/org/apache/struts2/StrutsConstants.java
@@ -470,6 +470,7 @@ public final class StrutsConstants {
     public static final String STRUTS_ADDITIONAL_ACCEPTED_PATTERNS = "struts.additional.acceptedPatterns";
 
     public static final String STRUTS_PARAMETERS_REQUIRE_ANNOTATIONS = "struts.parameters.requireAnnotations";
+    public static final String STRUTS_PARAMETERS_REQUIRE_ANNOTATIONS_TRANSITION = "struts.parameters.requireAnnotations.transitionMode";
 
     public static final String STRUTS_CONTENT_TYPE_MATCHER = "struts.contentTypeMatcher";
 

--- a/core/src/main/java/org/apache/struts2/components/IteratorComponent.java
+++ b/core/src/main/java/org/apache/struts2/components/IteratorComponent.java
@@ -18,9 +18,11 @@
  */
 package org.apache.struts2.components;
 
+import com.opensymphony.xwork2.inject.Inject;
 import com.opensymphony.xwork2.util.ValueStack;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.struts2.ognl.ThreadAllowlist;
 import org.apache.struts2.util.MakeIterator;
 import org.apache.struts2.views.annotations.StrutsTag;
 import org.apache.struts2.views.annotations.StrutsTagAttribute;
@@ -188,8 +190,8 @@ import java.util.List;
  * <!-- START SNIPPET: example6description -->
  *
  * <p>Another way to create a simple loop, similar to JSTL's
- * &lt;c:forEach begin="..." end="..." ...&gt; is to use some 
- * OGNL magic, which provides some under-the-covers magic to 
+ * &lt;c:forEach begin="..." end="..." ...&gt; is to use some
+ * OGNL magic, which provides some under-the-covers magic to
  * make 0-n loops trivial. This example also loops five times.</p>
  *
  * <!-- END SNIPPET: example6description -->
@@ -237,9 +239,15 @@ public class IteratorComponent extends ContextBean {
     protected Integer end;
     protected String stepStr;
     protected Integer step;
+    private ThreadAllowlist threadAllowlist;
 
     public IteratorComponent(ValueStack stack) {
         super(stack);
+    }
+
+    @Inject
+    public void setThreadAllowlist(ThreadAllowlist threadAllowlist) {
+        this.threadAllowlist = threadAllowlist;
     }
 
     public boolean start(Writer writer) {
@@ -298,6 +306,7 @@ public class IteratorComponent extends ContextBean {
         if ((iterator != null) && iterator.hasNext()) {
             Object currentValue = iterator.next();
             stack.push(currentValue);
+            threadAllowlist.allowClass(currentValue.getClass());
 
             String var = getVar();
 

--- a/core/src/main/java/org/apache/struts2/dispatcher/Dispatcher.java
+++ b/core/src/main/java/org/apache/struts2/dispatcher/Dispatcher.java
@@ -719,8 +719,6 @@ public class Dispatcher {
             } else {
                 throw new ServletException(e);
             }
-        } finally {
-            threadAllowlist.clearAllowlist();
         }
     }
 
@@ -1051,6 +1049,7 @@ public class Dispatcher {
      */
     public void cleanUpRequest(HttpServletRequest request) {
         ContainerHolder.clear();
+        threadAllowlist.clearAllowlist();
         if (!(request instanceof MultiPartRequestWrapper)) {
             return;
         }

--- a/core/src/main/java/org/apache/struts2/dispatcher/Dispatcher.java
+++ b/core/src/main/java/org/apache/struts2/dispatcher/Dispatcher.java
@@ -68,6 +68,7 @@ import org.apache.struts2.dispatcher.mapper.ActionMapper;
 import org.apache.struts2.dispatcher.mapper.ActionMapping;
 import org.apache.struts2.dispatcher.multipart.MultiPartRequest;
 import org.apache.struts2.dispatcher.multipart.MultiPartRequestWrapper;
+import org.apache.struts2.ognl.ThreadAllowlist;
 import org.apache.struts2.util.ObjectFactoryDestroyable;
 import org.apache.struts2.util.fs.JBossFileManager;
 
@@ -199,6 +200,7 @@ public class Dispatcher {
     private LocaleProviderFactory localeProviderFactory;
     private StaticContentLoader staticContentLoader;
     private ActionMapper actionMapper;
+    private ThreadAllowlist threadAllowlist;
 
     /**
      * Provide the dispatcher instance for the current thread.
@@ -402,6 +404,11 @@ public class Dispatcher {
 
     public ActionMapper getActionMapper() {
         return actionMapper;
+    }
+
+    @Inject
+    public void setThreadAllowlist(ThreadAllowlist threadAllowlist) {
+        this.threadAllowlist = threadAllowlist;
     }
 
     /**
@@ -712,6 +719,8 @@ public class Dispatcher {
             } else {
                 throw new ServletException(e);
             }
+        } finally {
+            threadAllowlist.clearAllowlist();
         }
     }
 

--- a/core/src/main/java/org/apache/struts2/interceptor/parameter/ParametersInterceptor.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/parameter/ParametersInterceptor.java
@@ -62,6 +62,7 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.regex.Pattern;
 
+import static com.opensymphony.xwork2.security.DefaultAcceptedPatternsChecker.NESTING_CHARS;
 import static java.util.Collections.unmodifiableSet;
 import static java.util.stream.Collectors.joining;
 import static org.apache.commons.lang3.StringUtils.indexOfAny;
@@ -341,7 +342,7 @@ public class ParametersInterceptor extends MethodFilterInterceptor {
      * Checks if the Action class member corresponding to a parameter is appropriately annotated with
      * {@link StrutsParameter} and OGNL allowlists any necessary classes.
      * <p>
-     * Note that this logic relies on the use of {@link DefaultAcceptedPatternsChecker#ACCEPTED_PATTERNS} and may also
+     * Note that this logic relies on the use of {@link DefaultAcceptedPatternsChecker#NESTING_CHARS} and may also
      * be adversely impacted by the use of custom OGNL property accessors.
      */
     protected boolean isParameterAnnotatedAndAllowlist(String name, Object action) {
@@ -349,9 +350,9 @@ public class ParametersInterceptor extends MethodFilterInterceptor {
             return true;
         }
 
-        int nestingIndex = indexOfAny(name, ".[");
+        int nestingIndex = indexOfAny(name, NESTING_CHARS.stream().map(String::valueOf).collect(joining()));
         String rootProperty = nestingIndex == -1 ? name : name.substring(0, nestingIndex);
-        long paramDepth = name.chars().filter(ch -> ch == '.' || ch == '[').count();
+        long paramDepth = name.codePoints().mapToObj(c -> (char) c).filter(NESTING_CHARS::contains).count();
 
         return hasValidAnnotatedMember(rootProperty, action, paramDepth);
     }

--- a/core/src/main/java/org/apache/struts2/interceptor/parameter/ParametersInterceptor.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/parameter/ParametersInterceptor.java
@@ -70,6 +70,7 @@ public class ParametersInterceptor extends MethodFilterInterceptor {
     private boolean dmiEnabled = false;
 
     protected boolean ordered = false;
+    protected boolean requireAnnotations = false;
 
     private ValueStackFactory valueStackFactory;
     private ExcludedPatternsChecker excludedPatterns;
@@ -85,6 +86,11 @@ public class ParametersInterceptor extends MethodFilterInterceptor {
     @Inject(StrutsConstants.STRUTS_DEVMODE)
     public void setDevMode(String mode) {
         this.devMode = BooleanUtils.toBoolean(mode);
+    }
+
+    @Inject(value = StrutsConstants.STRUTS_PARAMETERS_REQUIRE_ANNOTATIONS, required = false)
+    public void setRequireAnnotations(String requireAnnotations) {
+        this.requireAnnotations = BooleanUtils.toBoolean(requireAnnotations);
     }
 
     @Inject
@@ -295,11 +301,19 @@ public class ParametersInterceptor extends MethodFilterInterceptor {
      * @return true if parameter is accepted
      */
     protected boolean isAcceptableParameter(String name, Object action) {
-        return acceptableName(name) && isAcceptableParameterNameAware(name, action);
+        return acceptableName(name) && isAcceptableParameterNameAware(name, action) && isParameterAnnotated(name, action);
     }
 
     protected boolean isAcceptableParameterNameAware(String name, Object action) {
         return !(action instanceof ParameterNameAware) || ((ParameterNameAware) action).acceptableParameterName(name);
+    }
+
+    protected boolean isParameterAnnotated(String name, Object action) {
+        if (!requireAnnotations) {
+            return true;
+        }
+        // TODO: Implement
+        return true;
     }
 
     /**

--- a/core/src/main/java/org/apache/struts2/interceptor/parameter/ParametersInterceptor.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/parameter/ParametersInterceptor.java
@@ -400,7 +400,15 @@ public class ParametersInterceptor extends MethodFilterInterceptor {
         if (!(genericType instanceof ParameterizedType)) {
             return;
         }
-        Type paramType = ((ParameterizedType) genericType).getActualTypeArguments()[0];
+        Type[] paramTypes = ((ParameterizedType) genericType).getActualTypeArguments();
+        allowlistParamType(paramTypes[0]);
+        if (paramTypes.length > 1) {
+            // Probably useful for Map or Map-like classes
+            allowlistParamType(paramTypes[1]);
+        }
+    }
+
+    protected void allowlistParamType(Type paramType) {
         if (paramType instanceof Class) {
             threadAllowlist.allowClass((Class<?>) paramType);
         }

--- a/core/src/main/java/org/apache/struts2/interceptor/parameter/ParametersInterceptor.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/parameter/ParametersInterceptor.java
@@ -399,8 +399,11 @@ public class ParametersInterceptor extends MethodFilterInterceptor {
         if (relevantMethod == null) {
             return false;
         }
-        StrutsParameter annotation = getParameterAnnotation(relevantMethod);
-        if (annotation == null || annotation.depth() < paramDepth) {
+        if (getPermittedInjectionDepth(relevantMethod) < paramDepth) {
+            LOG.debug(
+                    "Parameter injection for method [{}] on action [{}] rejected. Ensure it is annotated with @StrutsParameter with an appropriate 'depth'.",
+                    relevantMethod.getName(),
+                    relevantMethod.getDeclaringClass().getName());
             return false;
         }
         if (paramDepth >= 1) {
@@ -450,8 +453,11 @@ public class ParametersInterceptor extends MethodFilterInterceptor {
         if (!Modifier.isPublic(field.getModifiers())) {
             return false;
         }
-        StrutsParameter annotation = getParameterAnnotation(field);
-        if (annotation == null || annotation.depth() < paramDepth) {
+        if (getPermittedInjectionDepth(field) < paramDepth) {
+            LOG.debug(
+                    "Parameter injection for field [{}] on action [{}] rejected. Ensure it is annotated with @StrutsParameter with an appropriate 'depth'.",
+                    fieldName,
+                    action.getClass().getName());
             return false;
         }
         if (paramDepth >= 1) {
@@ -465,6 +471,17 @@ public class ParametersInterceptor extends MethodFilterInterceptor {
 
     protected void allowlistFieldIfParameterized(Field field) {
         allowlistParameterizedTypeArg(field.getGenericType());
+    }
+
+    /**
+     * @return permitted injection depth where -1 indicates not permitted
+     */
+    protected int getPermittedInjectionDepth(AnnotatedElement element) {
+        StrutsParameter annotation = getParameterAnnotation(element);
+        if (annotation == null) {
+            return -1;
+        }
+        return annotation.depth();
     }
 
     /**

--- a/core/src/main/java/org/apache/struts2/interceptor/parameter/ParametersInterceptor.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/parameter/ParametersInterceptor.java
@@ -366,8 +366,9 @@ public class ParametersInterceptor extends MethodFilterInterceptor {
 
         int nestingIndex = indexOfAny(name, NESTING_CHARS_STR);
         String rootProperty = nestingIndex == -1 ? name : name.substring(0, nestingIndex);
+        String normalisedRootProperty = Character.toLowerCase(rootProperty.charAt(0)) + rootProperty.substring(1);
 
-        return hasValidAnnotatedMember(rootProperty, action, paramDepth);
+        return hasValidAnnotatedMember(normalisedRootProperty, action, paramDepth);
     }
 
     /**

--- a/core/src/main/java/org/apache/struts2/interceptor/parameter/ParametersInterceptor.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/parameter/ParametersInterceptor.java
@@ -34,6 +34,7 @@ import com.opensymphony.xwork2.util.ValueStack;
 import com.opensymphony.xwork2.util.ValueStackFactory;
 import com.opensymphony.xwork2.util.reflection.ReflectionContextState;
 import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.ClassUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.struts2.StrutsConstants;
@@ -403,7 +404,7 @@ public class ParametersInterceptor extends MethodFilterInterceptor {
             return false;
         }
         if (paramDepth >= 1) {
-            threadAllowlist.allowClass(relevantMethod.getReturnType());
+            allowlistClass(relevantMethod.getReturnType());
         }
         if (paramDepth >= 2) {
             allowlistReturnTypeIfParameterized(relevantMethod);
@@ -429,8 +430,14 @@ public class ParametersInterceptor extends MethodFilterInterceptor {
 
     protected void allowlistParamType(Type paramType) {
         if (paramType instanceof Class) {
-            threadAllowlist.allowClass((Class<?>) paramType);
+            allowlistClass((Class<?>) paramType);
         }
+    }
+
+    protected void allowlistClass(Class<?> clazz) {
+        threadAllowlist.allowClass(clazz);
+        ClassUtils.getAllSuperclasses(clazz).forEach(threadAllowlist::allowClass);
+        ClassUtils.getAllInterfaces(clazz).forEach(threadAllowlist::allowClass);
     }
 
     protected boolean hasValidAnnotatedField(Object action, String fieldName, long paramDepth) {
@@ -448,7 +455,7 @@ public class ParametersInterceptor extends MethodFilterInterceptor {
             return false;
         }
         if (paramDepth >= 1) {
-            threadAllowlist.allowClass(field.getType());
+            allowlistClass(field.getType());
         }
         if (paramDepth >= 2) {
             allowlistFieldIfParameterized(field);

--- a/core/src/main/java/org/apache/struts2/interceptor/parameter/ParametersInterceptor.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/parameter/ParametersInterceptor.java
@@ -41,6 +41,7 @@ import org.apache.struts2.action.ParameterNameAware;
 import org.apache.struts2.action.ParameterValueAware;
 import org.apache.struts2.dispatcher.HttpParameters;
 import org.apache.struts2.dispatcher.Parameter;
+import org.apache.struts2.ognl.ThreadAllowlist;
 
 import java.util.Collection;
 import java.util.Comparator;
@@ -73,6 +74,7 @@ public class ParametersInterceptor extends MethodFilterInterceptor {
     protected boolean requireAnnotations = false;
 
     private ValueStackFactory valueStackFactory;
+    protected ThreadAllowlist threadAllowlist;
     private ExcludedPatternsChecker excludedPatterns;
     private AcceptedPatternsChecker acceptedPatterns;
     private Set<Pattern> excludedValuePatterns = null;
@@ -81,6 +83,11 @@ public class ParametersInterceptor extends MethodFilterInterceptor {
     @Inject
     public void setValueStackFactory(ValueStackFactory valueStackFactory) {
         this.valueStackFactory = valueStackFactory;
+    }
+
+    @Inject
+    public void setThreadAllowlist(ThreadAllowlist threadAllowlist) {
+        this.threadAllowlist = threadAllowlist;
     }
 
     @Inject(StrutsConstants.STRUTS_DEVMODE)

--- a/core/src/main/java/org/apache/struts2/interceptor/parameter/ParametersInterceptor.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/parameter/ParametersInterceptor.java
@@ -63,6 +63,7 @@ import java.util.TreeMap;
 import java.util.regex.Pattern;
 
 import static com.opensymphony.xwork2.security.DefaultAcceptedPatternsChecker.NESTING_CHARS;
+import static com.opensymphony.xwork2.security.DefaultAcceptedPatternsChecker.NESTING_CHARS_STR;
 import static java.util.Collections.unmodifiableSet;
 import static java.util.stream.Collectors.joining;
 import static org.apache.commons.lang3.StringUtils.indexOfAny;
@@ -340,7 +341,7 @@ public class ParametersInterceptor extends MethodFilterInterceptor {
             return true;
         }
 
-        int nestingIndex = indexOfAny(name, NESTING_CHARS.stream().map(String::valueOf).collect(joining()));
+        int nestingIndex = indexOfAny(name, NESTING_CHARS_STR);
         String rootProperty = nestingIndex == -1 ? name : name.substring(0, nestingIndex);
         long paramDepth = name.codePoints().mapToObj(c -> (char) c).filter(NESTING_CHARS::contains).count();
 

--- a/core/src/main/java/org/apache/struts2/interceptor/parameter/ParametersInterceptor.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/parameter/ParametersInterceptor.java
@@ -219,6 +219,10 @@ public class ParametersInterceptor extends MethodFilterInterceptor {
         Map<String, Parameter> acceptableParameters;
         ValueStack newStack;
         try {
+            if (!threadAllowlist.getAllowlist().isEmpty()) {
+                LOG.error("Thread allowlist was utilised but not cleared", new IllegalStateException());
+                threadAllowlist.clearAllowlist();
+            }
             acceptableParameters = toAcceptableParameters(parameters, action); // Side-effect: Allowlist required types
 
             newStack = toNewStack(stack);

--- a/core/src/main/java/org/apache/struts2/interceptor/parameter/ParametersInterceptor.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/parameter/ParametersInterceptor.java
@@ -217,23 +217,13 @@ public class ParametersInterceptor extends MethodFilterInterceptor {
     }
 
     protected void applyParameters(final Object action, ValueStack stack, HttpParameters parameters) {
-        Map<String, Parameter> acceptableParameters;
-        ValueStack newStack;
-        try {
-            if (!threadAllowlist.getAllowlist().isEmpty()) {
-                LOG.error("Thread allowlist was utilised but not cleared", new IllegalStateException());
-                threadAllowlist.clearAllowlist();
-            }
-            acceptableParameters = toAcceptableParameters(parameters, action); // Side-effect: Allowlist required types
+        Map<String, Parameter> acceptableParameters = toAcceptableParameters(parameters, action);
 
-            newStack = toNewStack(stack);
-            batchApplyReflectionContextState(newStack.getContext(), true);
-            applyMemberAccessProperties(newStack);
+        ValueStack newStack = toNewStack(stack);
+        batchApplyReflectionContextState(newStack.getContext(), true);
+        applyMemberAccessProperties(newStack);
 
-            applyParametersOnStack(newStack, acceptableParameters, action);
-        } finally {
-            threadAllowlist.clearAllowlist();
-        }
+        applyParametersOnStack(newStack, acceptableParameters, action);
 
         if (newStack instanceof ClearableValueStack) {
             stack.getActionContext().withConversionErrors(newStack.getActionContext().getConversionErrors());

--- a/core/src/main/java/org/apache/struts2/interceptor/parameter/StrutsParameter.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/parameter/StrutsParameter.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.struts2.interceptor.parameter;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Used to annotate public getter/setter methods or fields on {@link com.opensymphony.xwork2.Action} classes that are
+ * intended for parameter injection by the {@link ParametersInterceptor}.
+ *
+ * @since 6.4.0
+ */
+@Target({ElementType.METHOD, ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface StrutsParameter {
+
+    /**
+     * The depth to which parameter injection is permitted, where a depth of 0 only allows setters/fields directly on
+     * the action class. Setting within a POJO on an action will require a depth of 1 or more depending on the level of
+     * nesting within the POJO.
+     * <p>
+     * In a practical sense, the depth dictates the number of periods or brackets that can appear in the parameter name.
+     */
+    int depth() default 0;
+}

--- a/core/src/main/java/org/apache/struts2/ognl/ThreadAllowlist.java
+++ b/core/src/main/java/org/apache/struts2/ognl/ThreadAllowlist.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.struts2.ognl;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static java.util.Collections.emptySet;
+import static java.util.Collections.unmodifiableSet;
+
+/**
+ * Allows any bean to allowlist a class for use in OGNL expressions, for the current thread only. The allowlist can be
+ * cleared once any desired OGNL expressions have been evaluated.
+ *
+ * @since 6.4.0
+ */
+public class ThreadAllowlist {
+
+    private final ThreadLocal<Set<Class<?>>> allowlist = new ThreadLocal<>();
+
+    public void allowClass(Class<?> clazz) {
+        if (allowlist.get() == null) {
+            allowlist.set(new HashSet<>());
+        }
+        allowlist.get().add(clazz);
+    }
+
+    public void clearAllowlist() {
+        allowlist.remove();
+    }
+
+    public Set<Class<?>> getAllowlist() {
+        return allowlist.get() != null ? unmodifiableSet(allowlist.get()) : emptySet();
+    }
+}

--- a/core/src/main/java/org/apache/struts2/views/jsp/ComponentTagSupport.java
+++ b/core/src/main/java/org/apache/struts2/views/jsp/ComponentTagSupport.java
@@ -18,15 +18,13 @@
  */
 package org.apache.struts2.views.jsp;
 
+import com.opensymphony.xwork2.inject.Container;
+import com.opensymphony.xwork2.util.ValueStack;
+import org.apache.struts2.components.Component;
+
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.jsp.JspException;
-
-import com.opensymphony.xwork2.ActionContext;
-import org.apache.struts2.components.Component;
-
-import com.opensymphony.xwork2.inject.Container;
-import com.opensymphony.xwork2.util.ValueStack;
 
 /**
  */
@@ -39,8 +37,7 @@ public abstract class ComponentTagSupport extends StrutsBodyTagSupport {
     public int doEndTag() throws JspException {
         component.end(pageContext.getOut(), getBody());
         component = null;  // Always clear component reference (since clearTagStateForTagPoolingServers() is conditional).
-        clearTagStateForTagPoolingServers();
-        return EVAL_PAGE;
+        return super.doEndTag();
     }
 
     @Override
@@ -49,7 +46,7 @@ public abstract class ComponentTagSupport extends StrutsBodyTagSupport {
         component = getBean(stack, (HttpServletRequest) pageContext.getRequest(), (HttpServletResponse) pageContext.getResponse());
         Container container = stack.getActionContext().getContainer();
         container.inject(component);
-        
+
         populateParams();
         boolean evalBody = component.start(pageContext.getOut());
 
@@ -62,7 +59,7 @@ public abstract class ComponentTagSupport extends StrutsBodyTagSupport {
 
     /**
      * Define method to populate component state based on the Tag parameters.
-     * 
+     * <p>
      * Descendants should override this method for custom behaviour, but should <em>always</em> call the ancestor method when doing so.
      */
     protected void populateParams() {
@@ -71,7 +68,7 @@ public abstract class ComponentTagSupport extends StrutsBodyTagSupport {
 
     /**
      * Specialized method to populate the performClearTagStateForTagPoolingServers state of the Component to match the value set in the Tag.
-     * 
+     * <p>
      * Generally only unit tests would call this method directly, to avoid calling the whole populateParams() chain again after doStartTag()
      * has been called.  Doing that can break tag / component state behaviour, but unit tests still need a way to set the
      * performClearTagStateForTagPoolingServers state for the component (which only comes into being after doStartTag() is called).

--- a/core/src/main/resources/struts-beans.xml
+++ b/core/src/main/resources/struts-beans.xml
@@ -170,6 +170,7 @@
     <bean type="org.apache.struts2.ognl.OgnlGuard" name="struts"
           class="org.apache.struts2.ognl.StrutsOgnlGuard"/>
     <bean class="org.apache.struts2.ognl.ProviderAllowlist"/>
+    <bean class="org.apache.struts2.ognl.ThreadAllowlist"/>
 
     <bean type="com.opensymphony.xwork2.util.TextParser" name="struts"
           class="com.opensymphony.xwork2.util.OgnlTextParser" scope="singleton"/>

--- a/core/src/test/java/com/opensymphony/xwork2/ognl/SecurityMemberAccessTest.java
+++ b/core/src/test/java/com/opensymphony/xwork2/ognl/SecurityMemberAccessTest.java
@@ -25,6 +25,7 @@ import com.opensymphony.xwork2.util.Foo;
 import ognl.MemberAccess;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.struts2.ognl.ProviderAllowlist;
+import org.apache.struts2.ognl.ThreadAllowlist;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -54,18 +55,21 @@ public class SecurityMemberAccessTest {
     private FooBar target;
     protected SecurityMemberAccess sma;
     private ProviderAllowlist mockedProviderAllowlist;
+    private ThreadAllowlist mockedThreadAllowlist;
 
     @Before
     public void setUp() throws Exception {
         context = new HashMap<>();
         target = new FooBar();
         mockedProviderAllowlist = mock(ProviderAllowlist.class);
+        mockedThreadAllowlist = mock(ThreadAllowlist.class);
         assignNewSma(true);
     }
 
     protected void assignNewSma(boolean allowStaticFieldAccess) {
         when(mockedProviderAllowlist.getProviderAllowlist()).thenReturn(new HashSet<>());
-        sma = new SecurityMemberAccess(mockedProviderAllowlist);
+        when(mockedThreadAllowlist.getAllowlist()).thenReturn(new HashSet<>());
+        sma = new SecurityMemberAccess(mockedProviderAllowlist, mockedThreadAllowlist);
         sma.useAllowStaticFieldAccess(String.valueOf(allowStaticFieldAccess));
     }
 

--- a/core/src/test/java/org/apache/struts2/components/IteratorComponentTest.java
+++ b/core/src/test/java/org/apache/struts2/components/IteratorComponentTest.java
@@ -21,6 +21,7 @@ package org.apache.struts2.components;
 import com.opensymphony.xwork2.ActionContext;
 import com.opensymphony.xwork2.util.ValueStack;
 import org.apache.struts2.StrutsInternalTestCase;
+import org.apache.struts2.ognl.ThreadAllowlist;
 
 import java.io.StringWriter;
 import java.util.Arrays;
@@ -28,14 +29,25 @@ import java.util.List;
 
 public class IteratorComponentTest extends StrutsInternalTestCase {
 
+    private ValueStack stack;
+    private IteratorComponent ic;
+    private ThreadAllowlist threadAllowlist;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        stack = ActionContext.getContext().getValueStack();
+        ic = new IteratorComponent(stack);
+        threadAllowlist = new ThreadAllowlist();
+        ic.setThreadAllowlist(threadAllowlist);
+    }
+
     public void testIterator() throws Exception {
         // given
-        final ValueStack stack = ActionContext.getContext().getValueStack();
         stack.push(new FooAction());
 
         StringWriter out = new StringWriter();
 
-        IteratorComponent ic = new IteratorComponent(stack);
         ic.setValue("items");
         ic.setVar("val");
 
@@ -64,12 +76,10 @@ public class IteratorComponentTest extends StrutsInternalTestCase {
 
     public void testIteratorWithBegin() throws Exception {
         // given
-        final ValueStack stack = ActionContext.getContext().getValueStack();
         stack.push(new FooAction());
 
         StringWriter out = new StringWriter();
 
-        IteratorComponent ic = new IteratorComponent(stack);
         ic.setValue("items");
         ic.setVar("val");
         ic.setBegin("1");
@@ -96,7 +106,6 @@ public class IteratorComponentTest extends StrutsInternalTestCase {
 
     public void testIteratorWithNulls() throws Exception {
         // given
-        final ValueStack stack = ActionContext.getContext().getValueStack();
         stack.push(new FooAction() {
             private List items  = Arrays.asList("1", "2", null, "4");
 
@@ -107,7 +116,6 @@ public class IteratorComponentTest extends StrutsInternalTestCase {
 
         StringWriter out = new StringWriter();
 
-        IteratorComponent ic = new IteratorComponent(stack);
         ic.setValue("items");
         ic.setVar("val");
         Property prop = new Property(stack);

--- a/core/src/test/java/org/apache/struts2/interceptor/parameter/StrutsParameterAnnotationTest.java
+++ b/core/src/test/java/org/apache/struts2/interceptor/parameter/StrutsParameterAnnotationTest.java
@@ -1,0 +1,240 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.struts2.interceptor.parameter;
+
+import com.opensymphony.xwork2.security.AcceptedPatternsChecker;
+import com.opensymphony.xwork2.security.NotExcludedAcceptedPatternsChecker;
+import org.apache.struts2.dispatcher.HttpParameters;
+import org.apache.struts2.dispatcher.Parameter;
+import org.apache.struts2.ognl.ThreadAllowlist;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class StrutsParameterAnnotationTest {
+
+    private ParametersInterceptor parametersInterceptor;
+
+    private ThreadAllowlist threadAllowlist;
+
+    @Before
+    public void setUp() throws Exception {
+        parametersInterceptor = new ParametersInterceptor();
+        parametersInterceptor.setRequireAnnotations(Boolean.TRUE.toString());
+
+        threadAllowlist = new ThreadAllowlist();
+        parametersInterceptor.setThreadAllowlist(threadAllowlist);
+
+        NotExcludedAcceptedPatternsChecker checker = mock(NotExcludedAcceptedPatternsChecker.class);
+        when(checker.isAccepted(anyString())).thenReturn(AcceptedPatternsChecker.IsAccepted.yes(""));
+        when(checker.isExcluded(anyString())).thenReturn(NotExcludedAcceptedPatternsChecker.IsExcluded.no(new HashSet<>()));
+        parametersInterceptor.setAcceptedPatterns(checker);
+        parametersInterceptor.setExcludedPatterns(checker);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        threadAllowlist.clearAllowlist();
+    }
+
+    private void testParameter(Object action, String paramName, boolean shouldContain) {
+        Map<String, String[]> requestParamMap = new HashMap<>();
+        requestParamMap.put(paramName, new String[]{"value"});
+        HttpParameters httpParameters = HttpParameters.create(requestParamMap).build();
+
+        Map<String, Parameter> acceptedParameters = parametersInterceptor.toAcceptableParameters(httpParameters, action);
+
+        if (shouldContain) {
+            assertThat(acceptedParameters).containsOnlyKeys(paramName);
+        } else {
+            assertThat(acceptedParameters).isEmpty();
+            assertThat(threadAllowlist.getAllowlist()).isEmpty();
+        }
+    }
+
+    @Test
+    public void privateStrAnnotated() {
+        testParameter(new FieldAction(), "privateStr", false);
+    }
+
+    @Test
+    public void publicStrAnnotated() {
+        testParameter(new FieldAction(), "publicStr", true);
+        assertThat(threadAllowlist.getAllowlist()).isEmpty();
+    }
+
+    @Test
+    public void publicStrNotAnnotated() {
+        testParameter(new FieldAction(), "publicStrNotAnnotated", false);
+    }
+
+    @Test
+    public void privatePojoAnnotated() {
+        testParameter(new FieldAction(), "privatePojo.key", false);
+    }
+
+    @Test
+    public void publicPojoDepthZero() {
+        testParameter(new FieldAction(), "publicPojoDepthZero.key", false);
+    }
+
+    @Test
+    public void publicPojoDepthOne() {
+        testParameter(new FieldAction(), "publicPojoDepthOne.key", true);
+        assertThat(threadAllowlist.getAllowlist()).containsExactly(Pojo.class);
+    }
+
+    @Test
+    public void publicNestedPojoDepthOne() {
+        testParameter(new FieldAction(), "publicPojoDepthOne.key.key", false);
+    }
+
+    @Test
+    public void publicPojoDepthTwo() {
+        testParameter(new FieldAction(), "publicPojoDepthTwo.key", true);
+        assertThat(threadAllowlist.getAllowlist()).containsExactly(Pojo.class);
+    }
+
+    @Test
+    public void publicNestedPojoDepthTwo() {
+        testParameter(new FieldAction(), "publicPojoDepthTwo.key.key", true);
+        assertThat(threadAllowlist.getAllowlist()).containsExactly(Pojo.class);
+    }
+
+    @Test
+    public void privateStrAnnotatedMethod() {
+        testParameter(new MethodAction(), "privateStr", false);
+    }
+
+    @Test
+    public void publicStrAnnotatedMethod() {
+        testParameter(new MethodAction(), "publicStr", true);
+        assertThat(threadAllowlist.getAllowlist()).isEmpty();
+    }
+
+    @Test
+    public void publicStrNotAnnotatedMethod() {
+        testParameter(new MethodAction(), "publicStrNotAnnotated", false);
+    }
+
+    @Test
+    public void privatePojoAnnotatedMethod() {
+        testParameter(new MethodAction(), "privatePojo.key", false);
+    }
+
+    @Test
+    public void publicPojoDepthZeroMethod() {
+        testParameter(new MethodAction(), "publicPojoDepthZero.key", false);
+    }
+
+    @Test
+    public void publicPojoDepthOneMethod() {
+        testParameter(new MethodAction(), "publicPojoDepthOne.key", true);
+        assertThat(threadAllowlist.getAllowlist()).containsExactly(Pojo.class);
+    }
+
+    @Test
+    public void publicNestedPojoDepthOneMethod() {
+        testParameter(new MethodAction(), "publicPojoDepthOne.key.key", false);
+    }
+
+    @Test
+    public void publicPojoDepthTwoMethod() {
+        testParameter(new MethodAction(), "publicPojoDepthTwo.key", true);
+        assertThat(threadAllowlist.getAllowlist()).containsExactly(Pojo.class);
+    }
+
+    @Test
+    public void publicNestedPojoDepthTwoMethod() {
+        testParameter(new MethodAction(), "publicPojoDepthTwo.key.key", true);
+        assertThat(threadAllowlist.getAllowlist()).containsExactly(Pojo.class);
+    }
+
+    class FieldAction {
+        @StrutsParameter
+        private String privateStr;
+
+        @StrutsParameter
+        public String publicStr;
+
+        public String publicStrNotAnnotated;
+
+        @StrutsParameter(depth = 1)
+        private Pojo privatePojo;
+
+        @StrutsParameter
+        public Pojo publicPojoDepthZero;
+
+        @StrutsParameter(depth = 1)
+        public Pojo publicPojoDepthOne ;
+
+        @StrutsParameter(depth = 2)
+        public Pojo publicPojoDepthTwo;
+    }
+
+    class MethodAction {
+
+        @StrutsParameter
+        private void setPrivateStr(String str) {
+        }
+
+        @StrutsParameter
+        public void setPublicStr(String str) {
+        }
+
+        public void setPublicStrNotAnnotated(String str) {
+        }
+
+        @StrutsParameter(depth = 1)
+        private Pojo getPrivatePojo() {
+            return null;
+        }
+
+        @StrutsParameter
+        public Pojo getPublicPojoDepthZero() {
+            return null;
+        }
+
+        @StrutsParameter
+        public void setPublicPojoDepthZero() {
+        }
+
+        @StrutsParameter(depth = 1)
+        public Pojo getPublicPojoDepthOne() {
+            return null;
+        }
+
+        @StrutsParameter(depth = 2)
+        public Pojo getPublicPojoDepthTwo() {
+            return null;
+        }
+    }
+
+    class Pojo {
+    }
+}

--- a/core/src/test/java/org/apache/struts2/interceptor/parameter/StrutsParameterAnnotationTest.java
+++ b/core/src/test/java/org/apache/struts2/interceptor/parameter/StrutsParameterAnnotationTest.java
@@ -20,6 +20,7 @@ package org.apache.struts2.interceptor.parameter;
 
 import com.opensymphony.xwork2.security.AcceptedPatternsChecker;
 import com.opensymphony.xwork2.security.NotExcludedAcceptedPatternsChecker;
+import org.apache.commons.lang3.ClassUtils;
 import org.apache.struts2.dispatcher.HttpParameters;
 import org.apache.struts2.dispatcher.Parameter;
 import org.apache.struts2.ognl.ThreadAllowlist;
@@ -31,6 +32,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -78,6 +80,16 @@ public class StrutsParameterAnnotationTest {
         }
     }
 
+    private Set<Class<?>> getParentClasses(Class<?> ...clazzes) {
+        Set<Class<?>> set = new HashSet<>();
+        for (Class<?> clazz : clazzes) {
+            set.add(clazz);
+            set.addAll(ClassUtils.getAllSuperclasses(clazz));
+            set.addAll(ClassUtils.getAllInterfaces(clazz));
+        }
+        return set;
+    }
+
     @Test
     public void privateStrAnnotated() {
         testParameter(new FieldAction(), "privateStr", false);
@@ -107,19 +119,19 @@ public class StrutsParameterAnnotationTest {
     @Test
     public void publicPojoDepthOne() {
         testParameter(new FieldAction(), "publicPojoDepthOne.key", true);
-        assertThat(threadAllowlist.getAllowlist()).containsExactly(Pojo.class);
+        assertThat(threadAllowlist.getAllowlist()).containsExactlyInAnyOrderElementsOf(getParentClasses(Pojo.class));
     }
 
     @Test
     public void publicPojoDepthOne_sqrBracket() {
         testParameter(new FieldAction(), "publicPojoDepthOne['key']", true);
-        assertThat(threadAllowlist.getAllowlist()).containsExactly(Pojo.class);
+        assertThat(threadAllowlist.getAllowlist()).containsExactlyInAnyOrderElementsOf(getParentClasses(Pojo.class));
     }
 
     @Test
     public void publicPojoDepthOne_bracket() {
         testParameter(new FieldAction(), "publicPojoDepthOne('key')", true);
-        assertThat(threadAllowlist.getAllowlist()).containsExactly(Pojo.class);
+        assertThat(threadAllowlist.getAllowlist()).containsExactlyInAnyOrderElementsOf(getParentClasses(Pojo.class));
     }
 
     @Test
@@ -130,25 +142,25 @@ public class StrutsParameterAnnotationTest {
     @Test
     public void publicPojoDepthTwo() {
         testParameter(new FieldAction(), "publicPojoDepthTwo.key", true);
-        assertThat(threadAllowlist.getAllowlist()).containsExactly(Pojo.class);
+        assertThat(threadAllowlist.getAllowlist()).containsExactlyInAnyOrderElementsOf(getParentClasses(Pojo.class));
     }
 
     @Test
     public void publicNestedPojoDepthTwo() {
         testParameter(new FieldAction(), "publicPojoDepthTwo.key.key", true);
-        assertThat(threadAllowlist.getAllowlist()).containsExactly(Pojo.class);
+        assertThat(threadAllowlist.getAllowlist()).containsExactlyInAnyOrderElementsOf(getParentClasses(Pojo.class));
     }
 
     @Test
     public void publicNestedPojoDepthTwo_sqrBracket() {
         testParameter(new FieldAction(), "publicPojoDepthTwo['key']['key']", true);
-        assertThat(threadAllowlist.getAllowlist()).containsExactly(Pojo.class);
+        assertThat(threadAllowlist.getAllowlist()).containsExactlyInAnyOrderElementsOf(getParentClasses(Pojo.class));
     }
 
     @Test
     public void publicNestedPojoDepthTwo_bracket() {
         testParameter(new FieldAction(), "publicPojoDepthTwo('key')('key')", true);
-        assertThat(threadAllowlist.getAllowlist()).containsExactly(Pojo.class);
+        assertThat(threadAllowlist.getAllowlist()).containsExactlyInAnyOrderElementsOf(getParentClasses(Pojo.class));
     }
 
     @Test
@@ -180,7 +192,7 @@ public class StrutsParameterAnnotationTest {
     @Test
     public void publicPojoDepthOneMethod() {
         testParameter(new MethodAction(), "publicPojoDepthOne.key", true);
-        assertThat(threadAllowlist.getAllowlist()).containsExactly(Pojo.class);
+        assertThat(threadAllowlist.getAllowlist()).containsExactlyInAnyOrderElementsOf(getParentClasses(Pojo.class));
     }
 
     @Test
@@ -191,13 +203,13 @@ public class StrutsParameterAnnotationTest {
     @Test
     public void publicPojoDepthTwoMethod() {
         testParameter(new MethodAction(), "publicPojoDepthTwo.key", true);
-        assertThat(threadAllowlist.getAllowlist()).containsExactly(Pojo.class);
+        assertThat(threadAllowlist.getAllowlist()).containsExactlyInAnyOrderElementsOf(getParentClasses(Pojo.class));
     }
 
     @Test
     public void publicNestedPojoDepthTwoMethod() {
         testParameter(new MethodAction(), "publicPojoDepthTwo.key.key", true);
-        assertThat(threadAllowlist.getAllowlist()).containsExactly(Pojo.class);
+        assertThat(threadAllowlist.getAllowlist()).containsExactlyInAnyOrderElementsOf(getParentClasses(Pojo.class));
     }
 
     @Test
@@ -208,13 +220,13 @@ public class StrutsParameterAnnotationTest {
     @Test
     public void publicPojoListDepthTwo() {
         testParameter(new FieldAction(), "publicPojoListDepthTwo[0].key", true);
-        assertThat(threadAllowlist.getAllowlist()).containsExactlyInAnyOrder(List.class, Pojo.class);
+        assertThat(threadAllowlist.getAllowlist()).containsExactlyInAnyOrderElementsOf(getParentClasses(List.class, Pojo.class));
     }
 
     @Test
     public void publicPojoMapDepthTwo() {
         testParameter(new FieldAction(), "publicPojoMapDepthTwo['a'].key", true);
-        assertThat(threadAllowlist.getAllowlist()).containsExactlyInAnyOrder(Map.class, String.class, Pojo.class);
+        assertThat(threadAllowlist.getAllowlist()).containsExactlyInAnyOrderElementsOf(getParentClasses(Map.class, String.class, Pojo.class));
     }
 
     @Test
@@ -225,13 +237,13 @@ public class StrutsParameterAnnotationTest {
     @Test
     public void publicPojoListDepthTwoMethod() {
         testParameter(new MethodAction(), "publicPojoListDepthTwo[0].key", true);
-        assertThat(threadAllowlist.getAllowlist()).containsExactlyInAnyOrder(List.class, Pojo.class);
+        assertThat(threadAllowlist.getAllowlist()).containsExactlyInAnyOrderElementsOf(getParentClasses(List.class, Pojo.class));
     }
 
     @Test
     public void publicPojoMapDepthTwoMethod() {
         testParameter(new MethodAction(), "publicPojoMapDepthTwo['a'].key", true);
-        assertThat(threadAllowlist.getAllowlist()).containsExactlyInAnyOrder(Map.class, String.class, Pojo.class);
+        assertThat(threadAllowlist.getAllowlist()).containsExactlyInAnyOrderElementsOf(getParentClasses(Map.class, String.class, Pojo.class));
     }
 
     @Test

--- a/core/src/test/java/org/apache/struts2/interceptor/parameter/StrutsParameterAnnotationTest.java
+++ b/core/src/test/java/org/apache/struts2/interceptor/parameter/StrutsParameterAnnotationTest.java
@@ -234,6 +234,18 @@ public class StrutsParameterAnnotationTest {
         assertThat(threadAllowlist.getAllowlist()).containsExactlyInAnyOrder(Map.class, String.class, Pojo.class);
     }
 
+    @Test
+    public void publicStrNotAnnotated_transitionMode() {
+        parametersInterceptor.setRequireAnnotationsTransitionMode(Boolean.TRUE.toString());
+        testParameter(new FieldAction(), "publicStrNotAnnotated", true);
+    }
+
+    @Test
+    public void publicStrNotAnnotatedMethod_transitionMode() {
+        parametersInterceptor.setRequireAnnotationsTransitionMode(Boolean.TRUE.toString());
+        testParameter(new MethodAction(), "publicStrNotAnnotated", true);
+    }
+
 
     class FieldAction {
         @StrutsParameter

--- a/core/src/test/java/org/apache/struts2/interceptor/parameter/StrutsParameterAnnotationTest.java
+++ b/core/src/test/java/org/apache/struts2/interceptor/parameter/StrutsParameterAnnotationTest.java
@@ -29,6 +29,7 @@ import org.junit.Test;
 
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -199,6 +200,41 @@ public class StrutsParameterAnnotationTest {
         assertThat(threadAllowlist.getAllowlist()).containsExactly(Pojo.class);
     }
 
+    @Test
+    public void publicPojoListDepthOne() {
+        testParameter(new FieldAction(), "publicPojoListDepthOne[0].key", false);
+    }
+
+    @Test
+    public void publicPojoListDepthTwo() {
+        testParameter(new FieldAction(), "publicPojoListDepthTwo[0].key", true);
+        assertThat(threadAllowlist.getAllowlist()).containsExactlyInAnyOrder(List.class, Pojo.class);
+    }
+
+    @Test
+    public void publicPojoMapDepthTwo() {
+        testParameter(new FieldAction(), "publicPojoMapDepthTwo['a'].key", true);
+        assertThat(threadAllowlist.getAllowlist()).containsExactlyInAnyOrder(Map.class, String.class, Pojo.class);
+    }
+
+    @Test
+    public void publicPojoListDepthOneMethod() {
+        testParameter(new MethodAction(), "publicPojoListDepthOne[0].key", false);
+    }
+
+    @Test
+    public void publicPojoListDepthTwoMethod() {
+        testParameter(new MethodAction(), "publicPojoListDepthTwo[0].key", true);
+        assertThat(threadAllowlist.getAllowlist()).containsExactlyInAnyOrder(List.class, Pojo.class);
+    }
+
+    @Test
+    public void publicPojoMapDepthTwoMethod() {
+        testParameter(new MethodAction(), "publicPojoMapDepthTwo['a'].key", true);
+        assertThat(threadAllowlist.getAllowlist()).containsExactlyInAnyOrder(Map.class, String.class, Pojo.class);
+    }
+
+
     class FieldAction {
         @StrutsParameter
         private String privateStr;
@@ -219,6 +255,15 @@ public class StrutsParameterAnnotationTest {
 
         @StrutsParameter(depth = 2)
         public Pojo publicPojoDepthTwo;
+
+        @StrutsParameter(depth = 1)
+        public List<Pojo> publicPojoListDepthOne;
+
+        @StrutsParameter(depth = 2)
+        public List<Pojo> publicPojoListDepthTwo;
+
+        @StrutsParameter(depth = 2)
+        public Map<String, Pojo> publicPojoMapDepthTwo;
     }
 
     class MethodAction {
@@ -255,6 +300,21 @@ public class StrutsParameterAnnotationTest {
 
         @StrutsParameter(depth = 2)
         public Pojo getPublicPojoDepthTwo() {
+            return null;
+        }
+
+        @StrutsParameter(depth = 1)
+        public List<Pojo> getPublicPojoListDepthOne() {
+            return null;
+        }
+
+        @StrutsParameter(depth = 2)
+        public List<Pojo> getPublicPojoListDepthTwo() {
+            return null;
+        }
+
+        @StrutsParameter(depth = 2)
+        public Map<String, Pojo> getPublicPojoMapDepthTwo() {
             return null;
         }
     }

--- a/core/src/test/java/org/apache/struts2/interceptor/parameter/StrutsParameterAnnotationTest.java
+++ b/core/src/test/java/org/apache/struts2/interceptor/parameter/StrutsParameterAnnotationTest.java
@@ -110,6 +110,18 @@ public class StrutsParameterAnnotationTest {
     }
 
     @Test
+    public void publicPojoDepthOne_sqrBracket() {
+        testParameter(new FieldAction(), "publicPojoDepthOne['key']", true);
+        assertThat(threadAllowlist.getAllowlist()).containsExactly(Pojo.class);
+    }
+
+    @Test
+    public void publicPojoDepthOne_bracket() {
+        testParameter(new FieldAction(), "publicPojoDepthOne('key')", true);
+        assertThat(threadAllowlist.getAllowlist()).containsExactly(Pojo.class);
+    }
+
+    @Test
     public void publicNestedPojoDepthOne() {
         testParameter(new FieldAction(), "publicPojoDepthOne.key.key", false);
     }
@@ -123,6 +135,18 @@ public class StrutsParameterAnnotationTest {
     @Test
     public void publicNestedPojoDepthTwo() {
         testParameter(new FieldAction(), "publicPojoDepthTwo.key.key", true);
+        assertThat(threadAllowlist.getAllowlist()).containsExactly(Pojo.class);
+    }
+
+    @Test
+    public void publicNestedPojoDepthTwo_sqrBracket() {
+        testParameter(new FieldAction(), "publicPojoDepthTwo['key']['key']", true);
+        assertThat(threadAllowlist.getAllowlist()).containsExactly(Pojo.class);
+    }
+
+    @Test
+    public void publicNestedPojoDepthTwo_bracket() {
+        testParameter(new FieldAction(), "publicPojoDepthTwo('key')('key')", true);
         assertThat(threadAllowlist.getAllowlist()).containsExactly(Pojo.class);
     }
 


### PR DESCRIPTION
WW-5352
--
The final piece of the Struts 6.4 security overhaul. When this capability is enabled alongside the OGNL allowlist, security is greatly heightened with no additional complex configuration.

In addition to assisting OGNL allowlist configuration, the primary benefit of this new annotation is that it prevents inexperienced Struts developers from inadvertently introducing parameter injection points - as they often do not realise any public members on an Action class are parameter injectable. All parameter injection points will need to be explicitly annotated.

The OGNL allowlist capability can already be enabled using `struts.allowlist.enable`. It was introduced (#781) alongside the configuration options `struts.allowlist.classes` and `struts.allowlist.packageNames` using which you can define the allowlist. However, as one might have expected, the configuration of an exhaustive allowlist was a massively cumbersome task.

I later introduced #800 which was able to populate the allowlist on startup from all XML configuration provided to Struts. Whilst this significantly reduced the barrier to enabling the allowlist, with most applications only requiring that their model or DTO packages be allowlisted, I felt we could do better.

I had already planned to rework, strengthen and contribute an existing Struts interceptor capability used in Confluence - introduced in this PR as the `@StrutsParameter` annotation. As mentioned, its primary purpose is to prevent the unintentional introduction of parameter injection points. However, I now saw the opportunity to integrate this seamlessly with the OGNL allowlist capability.

Following a crucial contribution (#791) to make the `SecurityMemberAccess` policy more versatile, in this PR I was able to implement the capability to mutate the allowlist during runtime on a per-request basis.

The only code change required by applications is to annotate all Action class members intended for parameter injection with this new annotation. This can be scripted for large codebases by scanning for public members on classes which implement the Action interface.

This new annotation requirement is enabled using the option `struts.parameters.requireAnnotations`. I've added an additional option, `struts.parameters.requireAnnotations.transitionMode`, that applications can use to, as the name suggests, transition into this feature. When this mode is enabled, only 'nested' parameters, i.e. those represented by public getters on Action classes, will require annotations. This means public setters will still be exposed for parameter injection.

What's significant here is that in this mode, the auto-allowlisting capability is not degraded in any way, so it proves a useful transitioning option for applications that wish to enable the OGNL allowlist as soon as possible. These applications can then enable the full annotation capability once they have worked through annotating all their parameters and are ready.

Even with this annotation capability enabled, there will of course still be edge cases where applications will need to manually allowlist certain classes. One such edge case is when a POJO within a POJO needs to be parameter injected. The 'Showcase' application now requires zero manual allowlist configuration following the addition of the annotations.

I believe this to be a major step forward in Struts' security posture. Atlassian will be shipping both the OGNL allowlist and the StrutsParameter annotation capabilities (along with all other recently contributed security options) in Confluence DC 8.8.

I welcome all comments and feedback and encourage everyone to test both the allowlist and annotation capability with their own applications.