### PR TITLE
Reduces log level to debug to reduce noise in the logs

### DIFF
--- a/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlValueStackFactory.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlValueStackFactory.java
@@ -132,7 +132,7 @@ public class OgnlValueStackFactory implements ValueStackFactory {
             }
             MethodAccessor methodAccessor = container.getInstance(MethodAccessor.class, name);
             OgnlRuntime.setMethodAccessor(cls, methodAccessor);
-            LOG.info("Registered custom OGNL MethodAccessor [{}] for class [{}]", methodAccessor.getClass().getName(), cls.getName());
+            LOG.debug("Registered custom OGNL MethodAccessor [{}] for class [{}]", methodAccessor.getClass().getName(), cls.getName());
         }
     }
 
@@ -142,7 +142,7 @@ public class OgnlValueStackFactory implements ValueStackFactory {
             Class<?> cls = Class.forName(name);
             NullHandler nullHandler = container.getInstance(NullHandler.class, name);
             OgnlRuntime.setNullHandler(cls, new OgnlNullHandlerWrapper(nullHandler));
-            LOG.info("Registered custom OGNL NullHandler [{}] for class [{}]", nullHandler.getClass().getName(), cls.getName());
+            LOG.debug("Registered custom OGNL NullHandler [{}] for class [{}]", nullHandler.getClass().getName(), cls.getName());
         }
     }
 
@@ -156,7 +156,7 @@ public class OgnlValueStackFactory implements ValueStackFactory {
             }
             PropertyAccessor propertyAccessor = container.getInstance(PropertyAccessor.class, name);
             OgnlRuntime.setPropertyAccessor(cls, propertyAccessor);
-            LOG.info("Registered custom OGNL PropertyAccessor [{}] for class [{}]", propertyAccessor.getClass().getName(), cls.getName());
+            LOG.debug("Registered custom OGNL PropertyAccessor [{}] for class [{}]", propertyAccessor.getClass().getName(), cls.getName());
         }
     }
 


### PR DESCRIPTION
See an [example PR run](https://github.com/apache/struts/actions/runs/7442031148/job/20244935590?pr=836) to notice enormous number of the log entries as this is happening for each unit test.