### PR TITLE
[WW-5374] Allows to prepend reportUri with Servlet context

### DIFF
--- a/core/src/main/java/org/apache/struts2/interceptor/csp/CspInterceptor.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/csp/CspInterceptor.java
@@ -43,7 +43,8 @@ public final class CspInterceptor extends AbstractInterceptor {
 
     private static final Logger LOG = LogManager.getLogger(CspInterceptor.class);
 
-    private Boolean enforcingMode;
+    private boolean prependServletContext = true;
+    private boolean enforcingMode;
     private String reportUri;
 
     @Override
@@ -60,17 +61,22 @@ public final class CspInterceptor extends AbstractInterceptor {
     }
 
     private void applySettings(ActionInvocation invocation, CspSettings cspSettings) {
-        if (enforcingMode != null) {
-            LOG.trace("Applying: {} to enforcingMode", enforcingMode);
-            cspSettings.setEnforcingMode(enforcingMode);
-        }
-        if (reportUri != null) {
-            LOG.trace("Applying: {} to reportUri", reportUri);
-            cspSettings.setReportUri(reportUri);
-        }
-
         HttpServletRequest request = invocation.getInvocationContext().getServletRequest();
         HttpServletResponse response = invocation.getInvocationContext().getServletResponse();
+
+        LOG.trace("Applying: {} to enforcingMode", enforcingMode);
+        cspSettings.setEnforcingMode(enforcingMode);
+
+        if (reportUri != null) {
+            LOG.trace("Applying: {} to reportUri", reportUri);
+            String finalReportUri = reportUri;
+
+            if (prependServletContext && (request.getContextPath() != null) && (!request.getContextPath().isEmpty())) {
+                finalReportUri = request.getContextPath() + finalReportUri;
+            }
+
+            cspSettings.setReportUri(finalReportUri);
+        }
 
         invocation.addPreResultListener((actionInvocation, resultCode) -> {
             LOG.trace("Applying CSP header: {} to the request", cspSettings);
@@ -99,8 +105,22 @@ public final class CspInterceptor extends AbstractInterceptor {
         }
     }
 
-    public void setEnforcingMode(String value) {
-        this.enforcingMode = Boolean.parseBoolean(value);
+    /**
+     * Enables enforcing mode, by default all exceptions are only reported
+     *
+     * @param enforcingMode <tt>true</tt> to enable enforcing mode, <tt>false</tt> to keep reporting mode.
+     */
+    public void setEnforcingMode(boolean enforcingMode) {
+        this.enforcingMode = enforcingMode;
+    }
+
+    /**
+     * Sets whether to prepend the servlet context path to the {@link #reportUri}.
+     *
+     * @param prependServletContext true</tt> to prepend the location with the servlet context path, <tt>false</tt> otherwise.
+     */
+    public void setPrependServletContext(boolean prependServletContext) {
+        this.prependServletContext = prependServletContext;
     }
 
 }

--- a/core/src/main/java/org/apache/struts2/interceptor/csp/CspInterceptor.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/csp/CspInterceptor.java
@@ -108,7 +108,7 @@ public final class CspInterceptor extends AbstractInterceptor {
     /**
      * Enables enforcing mode, by default all exceptions are only reported
      *
-     * @param enforcingMode <tt>true</tt> to enable enforcing mode, <tt>false</tt> to keep reporting mode.
+     * @param enforcingMode {@code true} to enable enforcing mode, {@code false} to keep reporting mode.
      */
     public void setEnforcingMode(boolean enforcingMode) {
         this.enforcingMode = enforcingMode;
@@ -117,7 +117,8 @@ public final class CspInterceptor extends AbstractInterceptor {
     /**
      * Sets whether to prepend the servlet context path to the {@link #reportUri}.
      *
-     * @param prependServletContext true</tt> to prepend the location with the servlet context path, <tt>false</tt> otherwise.
+     * @param prependServletContext {@code true} to prepend the location with the servlet context path,
+     *                              {@code false} otherwise.
      */
     public void setPrependServletContext(boolean prependServletContext) {
         this.prependServletContext = prependServletContext;

--- a/core/src/test/java/org/apache/struts2/interceptor/CspInterceptorTest.java
+++ b/core/src/test/java/org/apache/struts2/interceptor/CspInterceptorTest.java
@@ -160,6 +160,20 @@ public class CspInterceptorTest extends StrutsInternalTestCase {
         checkHeader("/app/report-uri", enforcingMode);
     }
 
+    public void testNoPrependContext() throws Exception {
+        boolean enforcingMode = true;
+        mai.setAction(new TestAction());
+        request.setContextPath("/app");
+
+        interceptor.setEnforcingMode(enforcingMode);
+        interceptor.setReportUri("/report-uri");
+        interceptor.setPrependServletContext(false);
+
+        interceptor.intercept(mai);
+
+        checkHeader("/report-uri", enforcingMode);
+    }
+
     public void checkHeader(String reportUri, boolean enforcingMode) {
         String expectedCspHeader;
         if (Strings.isEmpty(reportUri)) {


### PR DESCRIPTION
Prepends `reportUri` with servlet context by default

Closes [WW-5374](https://issues.apache.org/jira/browse/WW-5374)