### PR TITLE
Stop polluting JIRA tickets

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -8,7 +8,7 @@ notifications:
   # Send individual PR comments/reviews to issues@
   pullrequests_comment: notifications@struts.apache.org
   # Link opened PRs with JIRA
-  jira_options: link label worklog
+  jira_options: link label
 
 github:
   del_branch_on_merge: true


### PR DESCRIPTION
Currently all the commits are pushed as comments into JIRA making ticket a mess.