### PR TITLE
[WW-5369] Re-define minimal library set

### DIFF
--- a/assembly/src/main/assembly/min-lib.xml
+++ b/assembly/src/main/assembly/min-lib.xml
@@ -41,6 +41,8 @@
         <include>ognl:ognl</include>
         <include>commons-fileupload:commons-fileupload</include>
         <include>org.apache.commons:commons-io</include>
+        <include>com.github.ben-manes.caffeine:caffeine</include>
+        <include>org.javassist:javassist</include>
       </includes>
     </dependencySet>
   </dependencySets>


### PR DESCRIPTION
This PR adds missing `caffeine-x.x.x.jar` &  `javassist-x.x.x.jar`

[WW-5369](https://issues.apache.org/jira/browse/WW-5369)