### PR TITLE
[WW-5357] Adds support for disabled attribute to anchor tag

### DIFF
--- a/core/src/main/resources/template/simple/a-close.ftl
+++ b/core/src/main/resources/template/simple/a-close.ftl
@@ -25,6 +25,9 @@
 <#if parameters.href??>
  href="${parameters.href?no_esc}"<#rt/>
 </#if>
+<#if parameters.disabled!false>
+ disabled="disabled"<#rt/>
+</#if>
 <#if parameters.tabindex??>
  tabindex="${parameters.tabindex}"<#rt/>
 </#if>

--- a/core/src/test/java/org/apache/struts2/views/jsp/ui/AnchorTest.java
+++ b/core/src/test/java/org/apache/struts2/views/jsp/ui/AnchorTest.java
@@ -276,6 +276,23 @@ public class AnchorTest extends AbstractUITagTest {
         verifyResource("href-5.txt");
     }
 
+    public void testSimpleDisabled() throws Exception {
+        createAction();
+
+        AnchorTag tag = createTag();
+        tag.setHref("a");
+        tag.setDisabled("true");
+
+        StrutsBodyContent body = new StrutsBodyContent(null);
+        body.print("should have disabled attribute");
+        tag.setBodyContent(body);
+
+        tag.doStartTag();
+        tag.doEndTag();
+
+        verifyResource("href-6.txt");
+    }
+
     public void testInjectEscapeHtmlBodyFlag() throws Exception {
         // given
         initDispatcherWithConfigs("struts-default.xml, struts-escape-body.xml");

--- a/core/src/test/resources/org/apache/struts2/views/jsp/ui/href-6.txt
+++ b/core/src/test/resources/org/apache/struts2/views/jsp/ui/href-6.txt
@@ -1,0 +1,1 @@
+<a id="mylink" href="a" disabled="disabled">should have disabled attribute</a>


### PR DESCRIPTION
PR adds missing support for the `disabled` attribute to the Anchor tag.

[WW-5357](https://issues.apache.org/jira/browse/WW-5357)