### PR TITLE
Extends sleep period to avoid breaking a build

### DIFF
--- a/core/src/test/java/org/apache/struts2/interceptor/exec/StrutsBackgroundProcessTest.java
+++ b/core/src/test/java/org/apache/struts2/interceptor/exec/StrutsBackgroundProcessTest.java
@@ -112,7 +112,7 @@ public class StrutsBackgroundProcessTest extends StrutsInternalTestCase {
             executor.execute(bp);
         }
 
-        Thread.sleep(500);
+        Thread.sleep(800);
 
         for (BackgroundProcess bp : bps) {
             assertTrue("Process is still active: " + bp, bp.isDone());


### PR DESCRIPTION
This test quite often breaks the [builds](https://ci-builds.apache.org/job/Struts/job/Struts%20Core/job/master/342/console)

```
[ERROR] Failures: 
[ERROR]   StrutsBackgroundProcessTest.testMultipleProcesses:118 Process is still active: StrutsBackgroundProcess { name = Order: 17 }
```