### PR TITLE
[WW-5360] Introduces additional countStr & indexStr to allow to ignore conversion

### DIFF
--- a/core/src/main/java/org/apache/struts2/views/jsp/IteratorStatus.java
+++ b/core/src/main/java/org/apache/struts2/views/jsp/IteratorStatus.java
@@ -26,23 +26,29 @@ package org.apache.struts2.views.jsp;
  * <li>count: iterations so far, starts on 1. count is always index + 1</li>
  * <li>first: true if index == 0</li>
  * <li>even: true if (index + 1) % 2 == 0</li>
- * <li>last: true if current iteration is the last iteration</li> 
+ * <li>last: true if current iteration is the last iteration</li>
  * <li>odd: true if (index + 1) % 2 == 1</li>
  * </ul>
  * <p>Example</p>
  * <pre>
  *   &lt;s:iterator status="status" value='{0, 1}'&gt;
  *      Index: &lt;s:property value="%{#status.index}" /&gt; &lt;br /&gt;
- *      Count: &lt;s:property value="%{#status.count}" /&gt; &lt;br /&gt;  
+ *      Index Str: &lt;s:property value="%{#status.indexStr}" /&gt; &lt;br /&gt;
+ *      Count: &lt;s:property value="%{#status.count}" /&gt; &lt;br /&gt;
+ *      Count Str: &lt;s:property value="%{#status.countStr}" /&gt; &lt;br /&gt;
  *   &lt;/s:iterator&gt;
  * </pre>
- * 
+ *
  * <p>will print</p>
  * <pre>
  *      Index: 0
+ *      Index Str: 0
  *      Count: 1
+ *      Count Str: 1
  *      Index: 1
+ *      Index Str: 1
  *      Count: 2
+ *      Count Str: 2
  * </pre>
  */
 public class IteratorStatus {
@@ -56,6 +62,10 @@ public class IteratorStatus {
         return state.index + 1;
     }
 
+    public String getCountStr() {
+        return String.valueOf(state.index + 1);
+    }
+
     public boolean isEven() {
         return ((state.index + 1) % 2) == 0;
     }
@@ -66,6 +76,10 @@ public class IteratorStatus {
 
     public int getIndex() {
         return state.index;
+    }
+
+    public String getIndexStr() {
+        return String.valueOf(state.index);
     }
 
     public boolean isLast() {

--- a/core/src/test/java/com/opensymphony/xwork2/test/User.java
+++ b/core/src/test/java/com/opensymphony/xwork2/test/User.java
@@ -37,6 +37,12 @@ public class User implements UserMarker {
     private String email2;
     private String name;
 
+    public User() {
+    }
+
+    public User(String name) {
+        this.name = name;
+    }
 
     public void setCollection(Collection collection) {
         this.collection = collection;

--- a/core/src/test/java/org/apache/struts2/TestAction.java
+++ b/core/src/test/java/org/apache/struts2/TestAction.java
@@ -45,6 +45,7 @@ public class TestAction extends ActionSupport {
     private String result;
     private User user;
     private String[] array;
+    private Object[] objectArray;
     private String[][] list;
     private List list2;
     private List list3;
@@ -133,6 +134,14 @@ public class TestAction extends ActionSupport {
 
     public void setArray(String[] array) {
         this.array = array;
+    }
+
+    public Object[] getObjectArray() {
+        return objectArray;
+    }
+
+    public void setObjectArray(Object[] arrayObject) {
+        this.objectArray = arrayObject;
     }
 
     public String[][] getList() {

--- a/core/src/test/java/org/apache/struts2/components/IteratorComponentTest.java
+++ b/core/src/test/java/org/apache/struts2/components/IteratorComponentTest.java
@@ -19,26 +19,29 @@
 package org.apache.struts2.components;
 
 import com.opensymphony.xwork2.ActionContext;
+import com.opensymphony.xwork2.test.User;
 import com.opensymphony.xwork2.util.ValueStack;
 import org.apache.struts2.StrutsInternalTestCase;
 import org.apache.struts2.ognl.ThreadAllowlist;
+import org.apache.struts2.TestAction;
 
 import java.io.StringWriter;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 
 public class IteratorComponentTest extends StrutsInternalTestCase {
 
     private ValueStack stack;
     private IteratorComponent ic;
-    private ThreadAllowlist threadAllowlist;
 
     @Override
     public void setUp() throws Exception {
         super.setUp();
         stack = ActionContext.getContext().getValueStack();
         ic = new IteratorComponent(stack);
-        threadAllowlist = new ThreadAllowlist();
+        ThreadAllowlist threadAllowlist = new ThreadAllowlist();
         ic.setThreadAllowlist(threadAllowlist);
     }
 
@@ -74,7 +77,48 @@ public class IteratorComponentTest extends StrutsInternalTestCase {
         assertEquals("item1 item2 item3 item4 ", out.getBuffer().toString());
     }
 
-    public void testIteratorWithBegin() throws Exception {
+    public void testSimpleIterator() {
+        // given
+        stack.push(new FooAction());
+
+        StringWriter out = new StringWriter();
+
+        ic.setBegin("1");
+        ic.setEnd("8");
+        ic.setStep("2");
+        ic.setStatus("status");
+
+        Property prop = new Property(stack);
+        Property status = new Property(stack);
+        status.setValue("#status.index");
+
+        ic.getComponentStack().push(prop);
+        ic.getComponentStack().push(status);
+        ic.getComponentStack().push(prop);
+        ic.getComponentStack().push(status);
+        ic.getComponentStack().push(prop);
+        ic.getComponentStack().push(status);
+        ic.getComponentStack().push(prop);
+        ic.getComponentStack().push(status);
+
+        String body = " ";
+
+        // when
+        assertTrue(ic.start(out));
+
+        for (int i = 0; i < 4; i++) {
+            status.start(out);
+            status.end(out, body);
+            prop.start(out);
+            prop.end(out, body);
+            ic.end(out, null);
+        }
+
+        // then
+        assertEquals("0 1 1 3 2 5 3 7 ", out.getBuffer().toString());
+    }
+
+    public void testIteratorWithBegin() {
         // given
         stack.push(new FooAction());
 
@@ -104,12 +148,12 @@ public class IteratorComponentTest extends StrutsInternalTestCase {
         assertEquals("item2 item3 item4 ", out.getBuffer().toString());
     }
 
-    public void testIteratorWithNulls() throws Exception {
+    public void testIteratorWithNulls() {
         // given
         stack.push(new FooAction() {
-            private List items  = Arrays.asList("1", "2", null, "4");
+            private final List<String> items = Arrays.asList("1", "2", null, "4");
 
-            public List getItems() {
+            public List<String> getItems() {
                 return items;
             }
         });
@@ -140,15 +184,147 @@ public class IteratorComponentTest extends StrutsInternalTestCase {
         assertEquals("1, 2, , 4, ", out.getBuffer().toString());
     }
 
+    public void testIteratorWithDifferentLocale() {
+        // given
+        ActionContext.getContext().withLocale(new Locale("fa_IR"));
+        stack.push(new FooAction());
+
+        StringWriter out = new StringWriter();
+
+        ic.setBegin("1");
+        ic.setEnd("3");
+        ic.setStatus("status");
+
+        Property prop = new Property(stack);
+        Property status = new Property(stack);
+        status.setValue("#status.count");
+
+        ic.getComponentStack().push(prop);
+        ic.getComponentStack().push(status);
+        ic.getComponentStack().push(prop);
+        ic.getComponentStack().push(status);
+        ic.getComponentStack().push(prop);
+        ic.getComponentStack().push(status);
+
+        String body = ",";
+
+        // when
+        assertTrue(ic.start(out));
+
+        for (int i = 0; i < 3; i++) {
+            status.start(out);
+            status.end(out, body);
+
+            prop.start(out);
+            prop.end(out, body);
+            ic.end(out, null);
+        }
+
+        // then
+        assertEquals("1,1,2,2,3,3,", out.getBuffer().toString());
+    }
+
+    public void testListOfBeansIterator() {
+        // given
+        TestAction action = new TestAction();
+        action.setList2(new ArrayList<User>() {{
+            add(new User("Anton"));
+            add(new User("Tym"));
+            add(new User("Luk"));
+        }});
+        stack.push(action);
+
+        StringWriter out = new StringWriter();
+
+        ic.setValue("list2");
+        ic.setStatus("status");
+
+        Property prop = new Property(stack);
+        prop.setValue("name");
+        Property status = new Property(stack);
+        status.setValue("#status.indexStr");
+
+        ic.getComponentStack().push(status);
+        ic.getComponentStack().push(prop);
+        ic.getComponentStack().push(status);
+        ic.getComponentStack().push(prop);
+        ic.getComponentStack().push(status);
+        ic.getComponentStack().push(prop);
+
+        String body = ",";
+
+        // when
+        assertTrue(ic.start(out));
+
+        for (int i = 0; i < 3; i++) {
+            status.start(out);
+            status.end(out, body);
+
+            prop.start(out);
+            prop.end(out, body);
+
+            ic.end(out, null);
+        }
+
+        // then
+        assertEquals("0,Anton,1,Tym,2,Luk,", out.getBuffer().toString());
+    }
+
+    public void testArrayOfBeansIterator() {
+        // given
+        TestAction action = new TestAction();
+        action.setObjectArray(new ArrayList<User>() {{
+            add(new User("Anton"));
+            add(new User("Tym"));
+            add(new User("Luk"));
+        }}.toArray());
+        stack.push(action);
+
+        StringWriter out = new StringWriter();
+
+        ic.setValue("objectArray");
+        ic.setStatus("status");
+
+        Property prop = new Property(stack);
+        prop.setValue("name");
+        Property status = new Property(stack);
+        status.setValue("#status.countStr");
+
+        ic.getComponentStack().push(status);
+        ic.getComponentStack().push(prop);
+        ic.getComponentStack().push(status);
+        ic.getComponentStack().push(prop);
+        ic.getComponentStack().push(status);
+        ic.getComponentStack().push(prop);
+
+        String body = " ";
+
+        // when
+        assertTrue(ic.start(out));
+
+        for (int i = 0; i < 3; i++) {
+            status.start(out);
+            status.end(out, body);
+
+            prop.start(out);
+            prop.end(out, body);
+
+            ic.end(out, null);
+        }
+
+        // then
+        assertEquals("1 Anton 2 Tym 3 Luk ", out.getBuffer().toString());
+    }
+
     static class FooAction {
 
-        private List items;
+        private final List<String> items;
 
         public FooAction() {
             items = Arrays.asList("item1", "item2", "item3", "item4");
         }
 
-        public List getItems() {
+        public List<String> getItems() {
             return items;
         }
     }

--- a/core/src/test/java/org/apache/struts2/views/jsp/IteratorTagTest.java
+++ b/core/src/test/java/org/apache/struts2/views/jsp/IteratorTagTest.java
@@ -20,6 +20,7 @@ package org.apache.struts2.views.jsp;
 
 import com.mockobjects.servlet.MockBodyContent;
 import com.mockobjects.servlet.MockJspWriter;
+import com.opensymphony.xwork2.ActionContext;
 import org.apache.commons.collections.ListUtils;
 
 import javax.servlet.jsp.JspException;
@@ -29,20 +30,15 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
-
-/**
- * Test Case for Iterator Tag
- *
- */
 public class IteratorTagTest extends AbstractUITagTest {
 
-    IteratorTag tag;
-
+    private IteratorTag tag;
 
     public void testIteratingWithIdSpecified() throws Exception {
-        List list = new ArrayList();
+        List<String> list = new ArrayList<>();
         list.add("one");
         list.add("two");
         list.add("three");
@@ -104,12 +100,12 @@ public class IteratorTagTest extends AbstractUITagTest {
         IteratorTag freshTag = new IteratorTag();
         freshTag.setPageContext(pageContext);
         assertFalse("Tag state after doEndTag() under default tag clear state is equal to new Tag with pageContext/parent set.  " +
-                "May indicate that clearTagStateForTagPoolingServers() calls are not working properly.",
+                        "May indicate that clearTagStateForTagPoolingServers() calls are not working properly.",
                 strutsBodyTagsAreReflectionEqual(tag, freshTag));
     }
 
     public void testIteratingWithIdSpecified_clearTagStateSet() throws Exception {
-        List list = new ArrayList();
+        List<String> list = new ArrayList<>();
         list.add("one");
         list.add("two");
         list.add("three");
@@ -174,12 +170,12 @@ public class IteratorTagTest extends AbstractUITagTest {
         freshTag.setPerformClearTagStateForTagPoolingServers(true);
         freshTag.setPageContext(pageContext);
         assertTrue("Tag state after doEndTag() and explicit tag state clearing is inequal to new Tag with pageContext/parent set.  " +
-                "May indicate that clearTagStateForTagPoolingServers() calls are not working properly.",
+                        "May indicate that clearTagStateForTagPoolingServers() calls are not working properly.",
                 strutsBodyTagsAreReflectionEqual(tag, freshTag));
     }
 
     public void testIteratingWithIdSpecifiedAndNullElementOnCollection() throws Exception {
-        List list = new ArrayList();
+        List<String> list = new ArrayList<>();
         list.add("one");
         list.add(null);
         list.add("three");
@@ -224,12 +220,12 @@ public class IteratorTagTest extends AbstractUITagTest {
         IteratorTag freshTag = new IteratorTag();
         freshTag.setPageContext(pageContext);
         assertFalse("Tag state after doEndTag() under default tag clear state is equal to new Tag with pageContext/parent set.  " +
-                "May indicate that clearTagStateForTagPoolingServers() calls are not working properly.",
+                        "May indicate that clearTagStateForTagPoolingServers() calls are not working properly.",
                 strutsBodyTagsAreReflectionEqual(tag, freshTag));
     }
 
     public void testIteratingWithIdSpecifiedAndNullElementOnCollection_clearTagStateSet() throws Exception {
-        List list = new ArrayList();
+        List<String> list = new ArrayList<>();
         list.add("one");
         list.add(null);
         list.add("three");
@@ -277,7 +273,7 @@ public class IteratorTagTest extends AbstractUITagTest {
         freshTag.setPerformClearTagStateForTagPoolingServers(true);
         freshTag.setPageContext(pageContext);
         assertTrue("Tag state after doEndTag() and explicit tag state clearing is inequal to new Tag with pageContext/parent set.  " +
-                "May indicate that clearTagStateForTagPoolingServers() calls are not working properly.",
+                        "May indicate that clearTagStateForTagPoolingServers() calls are not working properly.",
                 strutsBodyTagsAreReflectionEqual(tag, freshTag));
     }
 
@@ -294,7 +290,7 @@ public class IteratorTagTest extends AbstractUITagTest {
 
     public void testCollectionIterator() {
         Foo foo = new Foo();
-        ArrayList list = new ArrayList();
+        List<String> list = new ArrayList<>();
         list.add("test1");
         list.add("test2");
         list.add("test3");
@@ -314,7 +310,7 @@ public class IteratorTagTest extends AbstractUITagTest {
 
     public void testMapIterator() {
         Foo foo = new Foo();
-        HashMap map = new HashMap();
+        HashMap<String, String> map = new HashMap<>();
         map.put("test1", "123");
         map.put("test2", "456");
         map.put("test3", "789");
@@ -329,8 +325,7 @@ public class IteratorTagTest extends AbstractUITagTest {
         try {
             result = tag.doStartTag();
         } catch (JspException e) {
-            e.printStackTrace();
-            fail();
+            fail(e.getMessage());
         }
 
         assertEquals(TagSupport.EVAL_BODY_INCLUDE, result);
@@ -340,8 +335,7 @@ public class IteratorTagTest extends AbstractUITagTest {
         try {
             result = tag.doAfterBody();
         } catch (JspException e) {
-            e.printStackTrace();
-            fail();
+            fail(e.getMessage());
         }
 
         assertEquals(TagSupport.EVAL_BODY_AGAIN, result);
@@ -351,8 +345,7 @@ public class IteratorTagTest extends AbstractUITagTest {
         try {
             result = tag.doAfterBody();
         } catch (JspException e) {
-            e.printStackTrace();
-            fail();
+            fail(e.getMessage());
         }
 
         assertEquals(TagSupport.EVAL_BODY_AGAIN, result);
@@ -362,8 +355,7 @@ public class IteratorTagTest extends AbstractUITagTest {
         try {
             result = tag.doAfterBody();
         } catch (JspException e) {
-            e.printStackTrace();
-            fail();
+            fail(e.getMessage());
         }
 
         assertEquals(TagSupport.SKIP_BODY, result);
@@ -372,8 +364,7 @@ public class IteratorTagTest extends AbstractUITagTest {
         try {
             result = tag.doEndTag();
         } catch (JspException e) {
-            e.printStackTrace();
-            fail();
+            fail(e.getMessage());
         }
 
         assertEquals(TagSupport.EVAL_PAGE, result);
@@ -382,13 +373,13 @@ public class IteratorTagTest extends AbstractUITagTest {
         IteratorTag freshTag = new IteratorTag();
         freshTag.setPageContext(pageContext);
         assertFalse("Tag state after doEndTag() under default tag clear state is equal to new Tag with pageContext/parent set.  " +
-                "May indicate that clearTagStateForTagPoolingServers() calls are not working properly.",
+                        "May indicate that clearTagStateForTagPoolingServers() calls are not working properly.",
                 strutsBodyTagsAreReflectionEqual(tag, freshTag));
     }
 
     public void testMapIterator_clearTagStateSet() {
         Foo foo = new Foo();
-        HashMap map = new HashMap();
+        HashMap<String, String> map = new HashMap<>();
         map.put("test1", "123");
         map.put("test2", "456");
         map.put("test3", "789");
@@ -405,8 +396,7 @@ public class IteratorTagTest extends AbstractUITagTest {
             result = tag.doStartTag();
             setComponentTagClearTagState(tag, true);  // Ensure component tag state clearing is set true (to match tag).
         } catch (JspException e) {
-            e.printStackTrace();
-            fail();
+            fail(e.getMessage());
         }
 
         assertEquals(TagSupport.EVAL_BODY_INCLUDE, result);
@@ -416,8 +406,7 @@ public class IteratorTagTest extends AbstractUITagTest {
         try {
             result = tag.doAfterBody();
         } catch (JspException e) {
-            e.printStackTrace();
-            fail();
+            fail(e.getMessage());
         }
 
         assertEquals(TagSupport.EVAL_BODY_AGAIN, result);
@@ -427,8 +416,7 @@ public class IteratorTagTest extends AbstractUITagTest {
         try {
             result = tag.doAfterBody();
         } catch (JspException e) {
-            e.printStackTrace();
-            fail();
+            fail(e.getMessage());
         }
 
         assertEquals(TagSupport.EVAL_BODY_AGAIN, result);
@@ -438,8 +426,7 @@ public class IteratorTagTest extends AbstractUITagTest {
         try {
             result = tag.doAfterBody();
         } catch (JspException e) {
-            e.printStackTrace();
-            fail();
+            fail(e.getMessage());
         }
 
         assertEquals(TagSupport.SKIP_BODY, result);
@@ -448,8 +435,7 @@ public class IteratorTagTest extends AbstractUITagTest {
         try {
             result = tag.doEndTag();
         } catch (JspException e) {
-            e.printStackTrace();
-            fail();
+            fail(e.getMessage());
         }
 
         assertEquals(TagSupport.EVAL_PAGE, result);
@@ -459,7 +445,7 @@ public class IteratorTagTest extends AbstractUITagTest {
         freshTag.setPerformClearTagStateForTagPoolingServers(true);
         freshTag.setPageContext(pageContext);
         assertTrue("Tag state after doEndTag() and explicit tag state clearing is inequal to new Tag with pageContext/parent set.  " +
-                "May indicate that clearTagStateForTagPoolingServers() calls are not working properly.",
+                        "May indicate that clearTagStateForTagPoolingServers() calls are not working properly.",
                 strutsBodyTagsAreReflectionEqual(tag, freshTag));
     }
 
@@ -477,8 +463,7 @@ public class IteratorTagTest extends AbstractUITagTest {
         try {
             result = tag.doStartTag();
         } catch (JspException e) {
-            e.printStackTrace();
-            fail();
+            fail(e.getMessage());
         }
 
         assertEquals(TagSupport.EVAL_BODY_INCLUDE, result);
@@ -490,15 +475,16 @@ public class IteratorTagTest extends AbstractUITagTest {
         assertFalse(status.isLast());
         assertTrue(status.isFirst());
         assertEquals(0, status.getIndex());
+        assertEquals("0", status.getIndexStr());
         assertEquals(1, status.getCount());
+        assertEquals("1", status.getCountStr());
         assertTrue(status.isOdd());
         assertFalse(status.isEven());
 
         try {
             result = tag.doAfterBody();
         } catch (JspException e) {
-            e.printStackTrace();
-            fail();
+            fail(e.getMessage());
         }
 
         assertEquals(TagSupport.EVAL_BODY_AGAIN, result);
@@ -517,8 +503,7 @@ public class IteratorTagTest extends AbstractUITagTest {
         try {
             result = tag.doAfterBody();
         } catch (JspException e) {
-            e.printStackTrace();
-            fail();
+            fail(e.getMessage());
         }
 
         assertEquals(TagSupport.EVAL_BODY_AGAIN, result);
@@ -537,8 +522,7 @@ public class IteratorTagTest extends AbstractUITagTest {
         try {
             result = tag.doEndTag();
         } catch (JspException e) {
-            e.printStackTrace();
-            fail();
+            fail(e.getMessage());
         }
 
         assertEquals(TagSupport.EVAL_PAGE, result);
@@ -547,7 +531,7 @@ public class IteratorTagTest extends AbstractUITagTest {
         IteratorTag freshTag = new IteratorTag();
         freshTag.setPageContext(pageContext);
         assertFalse("Tag state after doEndTag() under default tag clear state is equal to new Tag with pageContext/parent set.  " +
-                "May indicate that clearTagStateForTagPoolingServers() calls are not working properly.",
+                        "May indicate that clearTagStateForTagPoolingServers() calls are not working properly.",
                 strutsBodyTagsAreReflectionEqual(tag, freshTag));
     }
 
@@ -567,8 +551,7 @@ public class IteratorTagTest extends AbstractUITagTest {
             result = tag.doStartTag();
             setComponentTagClearTagState(tag, true);  // Ensure component tag state clearing is set true (to match tag).
         } catch (JspException e) {
-            e.printStackTrace();
-            fail();
+            fail(e.getMessage());
         }
 
         assertEquals(TagSupport.EVAL_BODY_INCLUDE, result);
@@ -587,8 +570,7 @@ public class IteratorTagTest extends AbstractUITagTest {
         try {
             result = tag.doAfterBody();
         } catch (JspException e) {
-            e.printStackTrace();
-            fail();
+            fail(e.getMessage());
         }
 
         assertEquals(TagSupport.EVAL_BODY_AGAIN, result);
@@ -607,8 +589,7 @@ public class IteratorTagTest extends AbstractUITagTest {
         try {
             result = tag.doAfterBody();
         } catch (JspException e) {
-            e.printStackTrace();
-            fail();
+            fail(e.getMessage());
         }
 
         assertEquals(TagSupport.EVAL_BODY_AGAIN, result);
@@ -627,8 +608,7 @@ public class IteratorTagTest extends AbstractUITagTest {
         try {
             result = tag.doEndTag();
         } catch (JspException e) {
-            e.printStackTrace();
-            fail();
+            fail(e.getMessage());
         }
 
         assertEquals(TagSupport.EVAL_PAGE, result);
@@ -638,7 +618,7 @@ public class IteratorTagTest extends AbstractUITagTest {
         freshTag.setPerformClearTagStateForTagPoolingServers(true);
         freshTag.setPageContext(pageContext);
         assertTrue("Tag state after doEndTag() and explicit tag state clearing is inequal to new Tag with pageContext/parent set.  " +
-                "May indicate that clearTagStateForTagPoolingServers() calls are not working properly.",
+                        "May indicate that clearTagStateForTagPoolingServers() calls are not working properly.",
                 strutsBodyTagsAreReflectionEqual(tag, freshTag));
     }
 
@@ -666,7 +646,7 @@ public class IteratorTagTest extends AbstractUITagTest {
 
     public void testEmptyCollection() {
         Foo foo = new Foo();
-        foo.setList(new ArrayList());
+        foo.setList(new ArrayList<>());
 
         stack.push(foo);
 
@@ -692,17 +672,41 @@ public class IteratorTagTest extends AbstractUITagTest {
         validateCounter(new Integer[]{0, 1, 2, 3, 4, 5});
     }
 
-     public void testCounterWithStackValues() throws JspException {
+    public void testCounterWithDifferentLocale() throws JspException {
+        stack.getActionContext().withLocale(new Locale("fa_IR"));
+        tag.setVar("it");
+        tag.setBegin("0");
+        tag.setEnd("5");
+        List<String> expectedValues = Arrays.asList("0", "1", "2", "3", "4", "5");
+
+        ArrayList<String> values = new ArrayList<>();
+        try {
+            int result = tag.doStartTag();
+            assertEquals(TagSupport.EVAL_BODY_INCLUDE, result);
+            values.add((String) stack.findValue("it", String.class));
+        } catch (JspException e) {
+            fail(e.getMessage());
+        }
+
+        while (tag.doAfterBody() == TagSupport.EVAL_BODY_AGAIN) {
+            values.add((String) stack.findValue("top", String.class));
+        }
+
+        assertEquals(expectedValues.size(), values.size());
+        assertEquals(expectedValues, values);
+    }
+
+    public void testCounterWithStackValues() throws JspException {
         stack.getContext().put("begin", 0);
         stack.getContext().put("end", 5);
-        tag.setBegin("%{#begin}");
-        tag.setEnd("%{#end}");
+        tag.setBegin("begin");
+        tag.setEnd("end");
         validateCounter(new Integer[]{0, 1, 2, 3, 4, 5});
     }
 
     public void testCounterWithList() throws JspException {
         Foo foo = new Foo();
-        ArrayList list = new ArrayList();
+        ArrayList<String> list = new ArrayList<>();
         list.add("a");
         list.add("b");
         list.add("c");
@@ -720,7 +724,6 @@ public class IteratorTagTest extends AbstractUITagTest {
 
     public void testCounterWithArray() throws JspException {
         Foo foo = new Foo();
-        ArrayList list = new ArrayList();
         foo.setArray(new String[]{"a", "b", "c", "d"});
 
         stack.push(foo);
@@ -735,7 +738,7 @@ public class IteratorTagTest extends AbstractUITagTest {
 
     public void testCounterWithListNoEnd() throws JspException {
         Foo foo = new Foo();
-        ArrayList list = new ArrayList();
+        ArrayList<String> list = new ArrayList<>();
         list.add("a");
         list.add("b");
         list.add("c");
@@ -752,7 +755,6 @@ public class IteratorTagTest extends AbstractUITagTest {
 
     public void testCounterWithArrayNoEnd() throws JspException {
         Foo foo = new Foo();
-        ArrayList list = new ArrayList();
         foo.setArray(new String[]{"a", "b", "c", "d"});
 
         stack.push(foo);
@@ -765,7 +767,7 @@ public class IteratorTagTest extends AbstractUITagTest {
 
     public void testCounterWithList2() throws JspException {
         Foo foo = new Foo();
-        ArrayList list = new ArrayList();
+        ArrayList<String> list = new ArrayList<>();
         list.add("a");
         list.add("b");
         list.add("c");
@@ -783,7 +785,6 @@ public class IteratorTagTest extends AbstractUITagTest {
 
     public void testCounterWithArray2() throws JspException {
         Foo foo = new Foo();
-        ArrayList list = new ArrayList();
         foo.setArray(new String[]{"a", "b", "c", "d"});
 
         stack.push(foo);
@@ -797,7 +798,7 @@ public class IteratorTagTest extends AbstractUITagTest {
 
     public void testCounterWithListNoEnd2() throws JspException {
         Foo foo = new Foo();
-        ArrayList list = new ArrayList();
+        ArrayList<String> list = new ArrayList<>();
         list.add("a");
         list.add("b");
         list.add("c");
@@ -812,9 +813,8 @@ public class IteratorTagTest extends AbstractUITagTest {
         validateCounter(new String[]{"c", "d"});
     }
 
-     public void testCounterWithArrayNoEnd2() throws JspException {
+    public void testCounterWithArrayNoEnd2() throws JspException {
         Foo foo = new Foo();
-        ArrayList list = new ArrayList();
         foo.setArray(new String[]{"a", "b", "c", "d"});
 
         stack.push(foo);
@@ -838,9 +838,9 @@ public class IteratorTagTest extends AbstractUITagTest {
         validateCounter(new Integer[]{0, 2, 4});
     }
 
-     public void testCounterWithListAndStep() throws JspException {
+    public void testCounterWithListAndStep() throws JspException {
         Foo foo = new Foo();
-        ArrayList list = new ArrayList();
+        ArrayList<String> list = new ArrayList<>();
         list.add("a");
         list.add("b");
         list.add("c");
@@ -858,9 +858,8 @@ public class IteratorTagTest extends AbstractUITagTest {
         validateCounter(new String[]{"a", "c"});
     }
 
-     public void testCounterWithArrayAndStep() throws JspException {
+    public void testCounterWithArrayAndStep() throws JspException {
         Foo foo = new Foo();
-        ArrayList list = new ArrayList();
         foo.setArray(new String[]{"a", "b", "c", "d"});
 
         stack.push(foo);
@@ -876,7 +875,7 @@ public class IteratorTagTest extends AbstractUITagTest {
 
     public void testCounterWithListAndStepNoEnd() throws JspException {
         Foo foo = new Foo();
-        ArrayList list = new ArrayList();
+        ArrayList<String> list = new ArrayList<>();
         list.add("a");
         list.add("b");
         list.add("c");
@@ -895,7 +894,6 @@ public class IteratorTagTest extends AbstractUITagTest {
 
     public void testCounterWithArrayAndStepNoEnd() throws JspException {
         Foo foo = new Foo();
-        ArrayList list = new ArrayList();
         foo.setArray(new String[]{"a", "b", "c", "d"});
 
         stack.push(foo);
@@ -917,7 +915,7 @@ public class IteratorTagTest extends AbstractUITagTest {
 
     public void testCounterWithListAndNegativeStep() throws JspException {
         Foo foo = new Foo();
-        ArrayList list = new ArrayList();
+        ArrayList<String> list = new ArrayList<>();
         list.add("a");
         list.add("b");
         list.add("c");
@@ -937,7 +935,7 @@ public class IteratorTagTest extends AbstractUITagTest {
 
     public void testCounterWithListAndNegativeStepNoEnd() throws JspException {
         Foo foo = new Foo();
-        ArrayList list = new ArrayList();
+        ArrayList<String> list = new ArrayList<>();
         list.add("a");
         list.add("b");
         list.add("c");
@@ -954,9 +952,9 @@ public class IteratorTagTest extends AbstractUITagTest {
         validateCounter(new String[]{"d", "c", "b", "a"});
     }
 
-     public void testCounterWithArrayAndNegativeStep() throws JspException {
+    public void testCounterWithArrayAndNegativeStep() throws JspException {
         Foo foo = new Foo();
-        ArrayList list = new ArrayList();
+        ArrayList<String> list = new ArrayList<>();
         list.add("a");
         list.add("b");
         list.add("c");
@@ -976,7 +974,7 @@ public class IteratorTagTest extends AbstractUITagTest {
 
     public void testCounterWithArrayAndNegativeStepNoEnd() throws JspException {
         Foo foo = new Foo();
-        ArrayList list = new ArrayList();
+        ArrayList<String> list = new ArrayList<>();
         list.add("a");
         list.add("b");
         list.add("c");
@@ -994,14 +992,13 @@ public class IteratorTagTest extends AbstractUITagTest {
     }
 
     protected void validateCounter(Object[] expectedValues) throws JspException {
-        List values = new ArrayList();
+        ArrayList<Object> values = new ArrayList<>();
         try {
             int result = tag.doStartTag();
             assertEquals(TagSupport.EVAL_BODY_INCLUDE, result);
             values.add(stack.getRoot().peek());
         } catch (JspException e) {
-            e.printStackTrace();
-            fail();
+            fail(e.getMessage());
         }
 
         while (tag.doAfterBody() == TagSupport.EVAL_BODY_AGAIN) {
@@ -1009,7 +1006,7 @@ public class IteratorTagTest extends AbstractUITagTest {
         }
 
         assertEquals(expectedValues.length, values.size());
-        ListUtils.isEqualList(Arrays.asList(expectedValues), values);
+        assertTrue(ListUtils.isEqualList(Arrays.asList(expectedValues), values));
     }
 
     @Override
@@ -1033,8 +1030,7 @@ public class IteratorTagTest extends AbstractUITagTest {
         try {
             result = tag.doStartTag();
         } catch (JspException e) {
-            e.printStackTrace();
-            fail();
+            fail(e.getMessage());
         }
 
         assertEquals(TagSupport.EVAL_BODY_INCLUDE, result);
@@ -1044,8 +1040,7 @@ public class IteratorTagTest extends AbstractUITagTest {
         try {
             result = tag.doAfterBody();
         } catch (JspException e) {
-            e.printStackTrace();
-            fail();
+            fail(e.getMessage());
         }
 
         assertEquals(TagSupport.EVAL_BODY_AGAIN, result);
@@ -1055,8 +1050,7 @@ public class IteratorTagTest extends AbstractUITagTest {
         try {
             result = tag.doAfterBody();
         } catch (JspException e) {
-            e.printStackTrace();
-            fail();
+            fail(e.getMessage());
         }
 
         assertEquals(TagSupport.EVAL_BODY_AGAIN, result);
@@ -1066,8 +1060,7 @@ public class IteratorTagTest extends AbstractUITagTest {
         try {
             result = tag.doAfterBody();
         } catch (JspException e) {
-            e.printStackTrace();
-            fail();
+            fail(e.getMessage());
         }
 
         assertEquals(TagSupport.SKIP_BODY, result);
@@ -1080,16 +1073,14 @@ public class IteratorTagTest extends AbstractUITagTest {
         try {
             result = tag.doStartTag();
         } catch (JspException e) {
-            e.printStackTrace();
-            fail();
+            fail(e.getMessage());
         }
 
         assertEquals(TagSupport.SKIP_BODY, result);
         try {
             result = tag.doEndTag();
         } catch (JspException e) {
-            e.printStackTrace();
-            fail();
+            fail(e.getMessage());
         }
 
         assertEquals(TagSupport.EVAL_PAGE, result);
@@ -1098,13 +1089,13 @@ public class IteratorTagTest extends AbstractUITagTest {
         IteratorTag freshTag = new IteratorTag();
         freshTag.setPageContext(pageContext);
         assertFalse("Tag state after doEndTag() under default tag clear state is equal to new Tag with pageContext/parent set.  " +
-                "May indicate that clearTagStateForTagPoolingServers() calls are not working properly.",
+                        "May indicate that clearTagStateForTagPoolingServers() calls are not working properly.",
                 strutsBodyTagsAreReflectionEqual(tag, freshTag));
     }
 
-    class Foo {
-        private Collection list;
-        private Map map;
+    static class Foo {
+        private Collection<String> list;
+        private Map<String, String> map;
         private String[] array;
 
         public void setArray(String[] array) {
@@ -1115,24 +1106,24 @@ public class IteratorTagTest extends AbstractUITagTest {
             return array;
         }
 
-        public void setList(Collection list) {
+        public void setList(Collection<String> list) {
             this.list = list;
         }
 
-        public Collection getList() {
+        public Collection<String> getList() {
             return list;
         }
 
-        public void setMap(Map map) {
+        public void setMap(Map<String, String> map) {
             this.map = map;
         }
 
-        public Map getMap() {
+        public Map<String, String> getMap() {
             return map;
         }
     }
 
-    class TestMockBodyContent extends MockBodyContent {
+    static class TestMockBodyContent extends MockBodyContent {
         public String getString() {
             return ".-.";
         }


### PR DESCRIPTION
Direct output of `<s:iterator/>` tag is automatically converted from Integer to String by the internal conversion mechanism. In some languages this isn't a desired behaviour as you still want to use a proper european numbers when generating HTML tags. To overcome this problem you can use `countStr` and `indexStr` (**hint**: propose a better naming) to avoid the conversion.

This will allow to produce a proper form:

```jsp
<s:iterator begin="1" end="3" status="status">
    <s:property/>
    <s:textfield id="text_%{#status.countStr}" name="test[%{#status.indexStr}]"/>
</s:iterator>
```

```html
    ۰
    <input type="text" name="test[0]" value="" id="text_1">
    ۱
    <input type="text" name="test[1]" value="" id="text_2">
    ۲
    <input type="text" name="test[2]" value="" id="text_3">
```

Closes [WW-5360](https://issues.apache.org/jira/browse/WW-5360)