### PR TITLE
[WW-5388] Fixes a few issues in Servlet 6 file upload usage

### DIFF
--- a/core/src/main/java/org/apache/struts2/dispatcher/multipart/JakartaStreamMultiPartRequest.java
+++ b/core/src/main/java/org/apache/struts2/dispatcher/multipart/JakartaStreamMultiPartRequest.java
@@ -143,11 +143,12 @@ public class JakartaStreamMultiPartRequest extends AbstractMultiPartRequest<File
                 LOG.debug("Cannot accept another file: {} as it will exceed max files: {}",
                         sanitizeNewlines(fileItemInput.getName()), maxFiles);
             }
-            LocalizedMessage errorMessage = buildErrorMessage(new FileUploadFileCountLimitException(
-                            String.format("File %s exceeds allowed maximum number of files %s",
-                                    fileItemInput.getName(), maxFiles),
-                            maxFiles, uploadedFiles.size()),
-                    new Object[]{maxFiles, uploadedFiles.size()});
+            LocalizedMessage errorMessage = buildErrorMessage(
+                    FileUploadFileCountLimitException.class,
+                    String.format("File %s exceeds allowed maximum number of files %s",
+                            fileItemInput.getName(), maxFiles),
+                    new Object[]{maxFiles, uploadedFiles.size()}
+            );
             if (!errors.contains(errorMessage)) {
                 errors.add(errorMessage);
             }
@@ -162,11 +163,12 @@ public class JakartaStreamMultiPartRequest extends AbstractMultiPartRequest<File
                     sanitizeNewlines(fileItemInput.getName()), file.length(), maxSizeOfFiles, currentFilesSize
             );
         }
-        LocalizedMessage errorMessage = buildErrorMessage(new FileUploadSizeException(
-                        String.format("Size %s of file %s exceeds allowed max size %s",
-                                file.length(), fileItemInput.getName(), maxSizeOfFiles),
-                        maxSizeOfFiles, currentFilesSize),
-                new Object[]{maxSizeOfFiles, currentFilesSize});
+        LocalizedMessage errorMessage = buildErrorMessage(
+                FileUploadSizeException.class,
+                String.format("Size %s of file %s exceeds allowed max size %s", file.length(),
+                        fileItemInput.getName(), maxSizeOfFiles),
+                new Object[]{maxSizeOfFiles, currentFilesSize}
+        );
         if (!errors.contains(errorMessage)) {
             errors.add(errorMessage);
         }

--- a/core/src/main/java/org/apache/struts2/interceptor/AbstractFileUploadInterceptor.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/AbstractFileUploadInterceptor.java
@@ -34,6 +34,7 @@ import org.apache.struts2.dispatcher.multipart.MultiPartRequestWrapper;
 import org.apache.struts2.dispatcher.multipart.UploadedFile;
 import org.apache.struts2.util.ContentTypeMatcher;
 
+import java.io.File;
 import java.text.NumberFormat;
 import java.util.Arrays;
 import java.util.Collection;
@@ -108,7 +109,7 @@ public abstract class AbstractFileUploadInterceptor extends AbstractInterceptor 
      * @param inputName        - inputName of the file.
      * @return true if the proposed file is acceptable by contentType and size.
      */
-    protected boolean acceptFile(Object action, UploadedFile file, String originalFilename, String contentType, String inputName) {
+    protected boolean acceptFile(Object action, UploadedFile<File> file, String originalFilename, String contentType, String inputName) {
         Set<String> errorMessages = new HashSet<>();
 
         ValidationAware validation = null;

--- a/core/src/main/resources/org/apache/struts2/struts-messages.properties
+++ b/core/src/main/resources/org/apache/struts2/struts-messages.properties
@@ -72,7 +72,8 @@ struts.messages.upload.error.FileUploadSizeException=Request exceeded allowed si
 # 0 - content type
 struts.messages.upload.error.FileUploadContentTypeException=Request has wrong content type: {0}!
 
-struts.messages.upload.error.FileUploadException=Error uploading: {0}!
+# Default error message when handling multi-part request
+struts.messages.upload.error.FileUploadException=Error parsing the multi-part request.
 
 devmode.notification=Developer Notification (set struts.devMode to false to disable this message):\n{0}
 

--- a/core/src/test/java/org/apache/struts2/dispatcher/multipart/AbstractMultiPartRequestTest.java
+++ b/core/src/test/java/org/apache/struts2/dispatcher/multipart/AbstractMultiPartRequestTest.java
@@ -460,6 +460,20 @@ abstract class AbstractMultiPartRequestTest {
                 .containsOnly("multi1", "multi2");
     }
 
+    @Test
+    public void unableParseRequest() throws IOException {
+        String content = formFile("file1", "test1.csv", "1,2,3,4");
+        mockRequest.setContent(content.getBytes(StandardCharsets.UTF_8));
+
+        assertThat(JakartaServletDiskFileUpload.isMultipartContent(mockRequest)).isTrue();
+
+        multiPart.parse(mockRequest, tempDir);
+
+        assertThat(multiPart.getErrors())
+                .map(LocalizedMessage::getTextKey)
+                .containsExactly("struts.messages.upload.error.FileUploadException");
+    }
+
     protected String formFile(String fieldName, String filename, String content) {
         return endline +
                 "--" + boundary + endline +


### PR DESCRIPTION
- removes duplicated validation messages where both interceptors have been used
- defines a proper error message on a general file upload exception
- removes generic definition in tests

Follow ups #861
Refs [WW-5388](https://issues.apache.org/jira/browse/WW-5388)