### PR TITLE
WW-5251 Reinstate deleted interfaces with transparent compat

### DIFF
--- a/core/src/main/java/org/apache/struts2/interceptor/ApplicationAware.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/ApplicationAware.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.struts2.interceptor;
+
+import java.util.Map;
+
+@Deprecated
+public interface ApplicationAware extends org.apache.struts2.action.ApplicationAware {
+
+    void setApplication(Map<String, Object> application);
+
+    @Override
+    default void withApplication(Map<String, Object> application) {
+        setApplication(application);
+    }
+}

--- a/core/src/main/java/org/apache/struts2/interceptor/HttpParametersAware.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/HttpParametersAware.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.struts2.interceptor;
+
+import org.apache.struts2.dispatcher.HttpParameters;
+
+@Deprecated
+public interface HttpParametersAware extends org.apache.struts2.action.ParametersAware {
+
+    void setParameters(HttpParameters parameters);
+
+    @Override
+    default void withParameters(HttpParameters parameters) {
+        setParameters(parameters);
+    }
+}

--- a/core/src/main/java/org/apache/struts2/interceptor/ParameterAware.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/ParameterAware.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.struts2.interceptor;
+
+import org.apache.struts2.dispatcher.HttpParameters;
+
+import java.util.Map;
+
+@Deprecated
+public interface ParameterAware extends org.apache.struts2.action.ParametersAware {
+
+    void setParameters(Map map);
+
+    @Override
+    default void withParameters(HttpParameters parameters) {
+        setParameters(parameters);
+    }
+}

--- a/core/src/main/java/org/apache/struts2/interceptor/ParameterAware.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/ParameterAware.java
@@ -22,6 +22,8 @@ import org.apache.struts2.dispatcher.HttpParameters;
 
 import java.util.Map;
 
+import static java.util.stream.Collectors.toMap;
+
 @Deprecated
 public interface ParameterAware extends org.apache.struts2.action.ParametersAware {
 
@@ -29,6 +31,6 @@ public interface ParameterAware extends org.apache.struts2.action.ParametersAwar
 
     @Override
     default void withParameters(HttpParameters parameters) {
-        setParameters(parameters);
+        setParameters(parameters.entrySet().stream().collect(toMap(Map.Entry::getKey, e -> e.getValue().getMultipleValues())));
     }
 }

--- a/core/src/main/java/org/apache/struts2/interceptor/PrincipalAware.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/PrincipalAware.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.struts2.interceptor;
+
+@Deprecated
+public interface PrincipalAware extends org.apache.struts2.action.PrincipalAware {
+
+    void setPrincipalProxy(PrincipalProxy principalProxy);
+
+    @Override
+    default void withPrincipalProxy(PrincipalProxy principalProxy) {
+        setPrincipalProxy(principalProxy);
+    }
+}

--- a/core/src/main/java/org/apache/struts2/interceptor/RequestAware.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/RequestAware.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.struts2.interceptor;
+
+import org.apache.struts2.dispatcher.RequestMap;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.Map;
+
+@Deprecated
+public interface RequestAware extends ServletRequestAware {
+
+    @Override
+    default void setServletRequest(HttpServletRequest httpServletRequest) {
+        // default no-op
+    }
+
+    @Override
+    default void withServletRequest(HttpServletRequest request) {
+        ServletRequestAware.super.withServletRequest(request);
+        setRequest(new RequestMap(request));
+    }
+
+    void setRequest(Map<String, Object> request);
+}

--- a/core/src/main/java/org/apache/struts2/interceptor/ServletRequestAware.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/ServletRequestAware.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.struts2.interceptor;
+
+import javax.servlet.http.HttpServletRequest;
+
+@Deprecated
+public interface ServletRequestAware extends org.apache.struts2.action.ServletRequestAware {
+
+    void setServletRequest(HttpServletRequest httpServletRequest);
+
+    @Override
+    default void withServletRequest(HttpServletRequest request) {
+        setServletRequest(request);
+    }
+}

--- a/core/src/main/java/org/apache/struts2/interceptor/ServletResponseAware.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/ServletResponseAware.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.struts2.interceptor;
+
+import javax.servlet.http.HttpServletResponse;
+
+@Deprecated
+public interface ServletResponseAware extends org.apache.struts2.action.ServletResponseAware {
+
+    void setServletResponse(HttpServletResponse httpServletResponse);
+
+    @Override
+    default void withServletResponse(HttpServletResponse response) {
+        setServletResponse(response);
+    }
+}

--- a/core/src/main/java/org/apache/struts2/interceptor/SessionAware.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/SessionAware.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.struts2.interceptor;
+
+import java.util.Map;
+
+@Deprecated
+public interface SessionAware extends org.apache.struts2.action.SessionAware {
+
+    void setSession(Map<String, Object> session);
+
+    @Override
+    default void withSession(Map<String, Object> session) {
+        setSession(session);
+    }
+}

--- a/core/src/main/java/org/apache/struts2/util/ServletContextAware.java
+++ b/core/src/main/java/org/apache/struts2/util/ServletContextAware.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.struts2.util;
+
+import javax.servlet.ServletContext;
+
+@Deprecated
+public interface ServletContextAware extends org.apache.struts2.action.ServletContextAware {
+
+    void setServletContext(ServletContext context);
+
+    @Override
+    default void withServletContext(ServletContext context) {
+        setServletContext(context);
+    }
+}

--- a/plugins/portlet/src/main/java/org/apache/struts2/portlet/interceptor/PortletContextAware.java
+++ b/plugins/portlet/src/main/java/org/apache/struts2/portlet/interceptor/PortletContextAware.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.struts2.portlet.interceptor;
+
+import javax.portlet.PortletContext;
+
+@Deprecated
+public interface PortletContextAware extends org.apache.struts2.portlet.action.PortletContextAware {
+
+    void setPortletContext(PortletContext portletContext);
+
+    @Override
+    default void withPortletContext(PortletContext context) {
+        setPortletContext(context);
+    }
+}

--- a/plugins/portlet/src/main/java/org/apache/struts2/portlet/interceptor/PortletPreferencesAware.java
+++ b/plugins/portlet/src/main/java/org/apache/struts2/portlet/interceptor/PortletPreferencesAware.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.struts2.portlet.interceptor;
+
+import javax.portlet.PortletPreferences;
+
+@Deprecated
+public interface PortletPreferencesAware extends org.apache.struts2.portlet.action.PortletPreferencesAware {
+
+    void setPortletPreferences(PortletPreferences prefs);
+
+    @Override
+    default void withPortletPreferences(PortletPreferences prefs) {
+        setPortletPreferences(prefs);
+    }
+}

--- a/plugins/portlet/src/main/java/org/apache/struts2/portlet/interceptor/PortletRequestAware.java
+++ b/plugins/portlet/src/main/java/org/apache/struts2/portlet/interceptor/PortletRequestAware.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.struts2.portlet.interceptor;
+
+import javax.portlet.PortletRequest;
+
+@Deprecated
+public interface PortletRequestAware extends org.apache.struts2.portlet.action.PortletRequestAware {
+
+    void setPortletRequest(PortletRequest request);
+
+    @Override
+    default void withPortletRequest(PortletRequest request) {
+        setPortletRequest(request);
+    }
+}

--- a/plugins/portlet/src/main/java/org/apache/struts2/portlet/interceptor/PortletResponseAware.java
+++ b/plugins/portlet/src/main/java/org/apache/struts2/portlet/interceptor/PortletResponseAware.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.struts2.portlet.interceptor;
+
+import javax.portlet.PortletResponse;
+
+@Deprecated
+public interface PortletResponseAware extends org.apache.struts2.portlet.action.PortletResponseAware {
+
+    void setPortletResponse(PortletResponse response);
+
+    @Override
+    default void withPortletResponse(PortletResponse response) {
+        setPortletResponse(response);
+    }
+}


### PR DESCRIPTION
Partially reverts https://github.com/apache/struts/pull/670 to restore compatibility with deprecated interfaces
Refs [WW-5251](https://issues.apache.org/jira/browse/WW-5251)