### PR TITLE
WW-5407 Extend SecurityMemberAccess proxy detection to other proxies

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -230,6 +230,15 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-text</artifactId>
         </dependency>
+
+        <!-- Optional used in com.opensymphony.xwork2.util.ProxyUtil to detect if object is HibernateProxy -->
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-core</artifactId>
+            <version>5.6.15.Final</version>
+            <optional>true</optional>
+        </dependency>
+
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>

--- a/core/src/main/java/com/opensymphony/xwork2/ognl/DefaultOgnlCacheFactory.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/DefaultOgnlCacheFactory.java
@@ -32,6 +32,7 @@ public class DefaultOgnlCacheFactory<Key, Value> implements OgnlCacheFactory<Key
 
     private CacheType defaultCacheType;
     private int cacheMaxSize;
+    private final int initialCapacity;
 
     /**
      * @deprecated since 6.4.0, use {@link #DefaultOgnlCacheFactory(int, CacheType)}
@@ -42,13 +43,18 @@ public class DefaultOgnlCacheFactory<Key, Value> implements OgnlCacheFactory<Key
     }
 
     public DefaultOgnlCacheFactory(int cacheMaxSize, CacheType defaultCacheType) {
+        this(cacheMaxSize, defaultCacheType, DEFAULT_INIT_CAPACITY);
+    }
+
+    public DefaultOgnlCacheFactory(int cacheMaxSize, CacheType defaultCacheType, int initialCapacity) {
         this.cacheMaxSize = cacheMaxSize;
         this.defaultCacheType = defaultCacheType;
+        this.initialCapacity = initialCapacity;
     }
 
     @Override
     public OgnlCache<Key, Value> buildOgnlCache() {
-        return buildOgnlCache(getCacheMaxSize(), DEFAULT_INIT_CAPACITY, DEFAULT_LOAD_FACTOR, defaultCacheType);
+        return buildOgnlCache(getCacheMaxSize(), initialCapacity, DEFAULT_LOAD_FACTOR, defaultCacheType);
     }
 
     @Override

--- a/core/src/main/java/com/opensymphony/xwork2/util/ProxyUtil.java
+++ b/core/src/main/java/com/opensymphony/xwork2/util/ProxyUtil.java
@@ -18,13 +18,20 @@
  */
 package com.opensymphony.xwork2.util;
 
+import com.opensymphony.xwork2.ognl.DefaultOgnlCacheFactory;
+import com.opensymphony.xwork2.ognl.OgnlCache;
+import com.opensymphony.xwork2.ognl.OgnlCacheFactory;
 import org.apache.commons.lang3.reflect.ConstructorUtils;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.commons.lang3.reflect.MethodUtils;
+import org.hibernate.proxy.HibernateProxy;
 
-import java.lang.reflect.*;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Member;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.Proxy;
 
 /**
  * <code>ProxyUtil</code>
@@ -38,11 +45,13 @@ public class ProxyUtil {
     private static final String SPRING_SPRINGPROXY_CLASS_NAME = "org.springframework.aop.SpringProxy";
     private static final String SPRING_SINGLETONTARGETSOURCE_CLASS_NAME = "org.springframework.aop.target.SingletonTargetSource";
     private static final String SPRING_TARGETCLASSAWARE_CLASS_NAME = "org.springframework.aop.TargetClassAware";
-
-    private static final Map<Class<?>, Boolean> isProxyCache =
-            new ConcurrentHashMap<>(256);
-    private static final Map<Member, Boolean> isProxyMemberCache =
-            new ConcurrentHashMap<>(256);
+    private static final String HIBERNATE_HIBERNATEPROXY_CLASS_NAME = "org.hibernate.proxy.HibernateProxy";
+    private static final int CACHE_MAX_SIZE = 10000;
+    private static final int CACHE_INITIAL_CAPACITY = 256;
+    private static final OgnlCache<Class<?>, Boolean> isProxyCache = new DefaultOgnlCacheFactory<Class<?>, Boolean>(
+            CACHE_MAX_SIZE, OgnlCacheFactory.CacheType.WTLFU, CACHE_INITIAL_CAPACITY).buildOgnlCache();
+    private static final OgnlCache<Member, Boolean> isProxyMemberCache = new DefaultOgnlCacheFactory<Member, Boolean>(
+            CACHE_MAX_SIZE, OgnlCacheFactory.CacheType.WTLFU, CACHE_INITIAL_CAPACITY).buildOgnlCache();
 
     /**
      * Determine the ultimate target class of the given instance, traversing
@@ -75,7 +84,7 @@ public class ProxyUtil {
             return flag;
         }
 
-        boolean isProxy = isSpringAopProxy(object);
+        boolean isProxy = isSpringAopProxy(object) || isHibernateProxy(object);
 
         isProxyCache.put(clazz, isProxy);
         return isProxy;
@@ -87,7 +96,7 @@ public class ProxyUtil {
      * @param object the object to check
      */
     public static boolean isProxyMember(Member member, Object object) {
-        if (!Modifier.isStatic(member.getModifiers()) && !isProxy(object)) {
+        if (!Modifier.isStatic(member.getModifiers()) && !isProxy(object) && !isHibernateProxy(object)) {
             return false;
         }
 
@@ -96,10 +105,39 @@ public class ProxyUtil {
             return flag;
         }
 
-        boolean isProxyMember = isSpringProxyMember(member);
+        boolean isProxyMember = isSpringProxyMember(member) || isHibernateProxyMember(member);
 
         isProxyMemberCache.put(member, isProxyMember);
         return isProxyMember;
+    }
+
+    /**
+     * Check whether the given object is a Hibernate proxy.
+     *
+     * @param object the object to check
+     */
+    public static boolean isHibernateProxy(Object object) {
+        try {
+            return HibernateProxy.class.isAssignableFrom(object.getClass());
+        } catch (NoClassDefFoundError ignored) {
+            return false;
+        }
+    }
+
+    /**
+     * Check whether the given member is a member of a Hibernate proxy.
+     *
+     * @param member the member to check
+     */
+    public static boolean isHibernateProxyMember(Member member) {
+        try {
+            Class<?> clazz = ClassLoaderUtil.loadClass(HIBERNATE_HIBERNATEPROXY_CLASS_NAME, ProxyUtil.class);
+            if (hasMember(clazz, member))
+                return true;
+        } catch (ClassNotFoundException ignored) {
+        }
+
+        return false;
     }
 
     /**

--- a/core/src/main/java/com/opensymphony/xwork2/util/ProxyUtil.java
+++ b/core/src/main/java/com/opensymphony/xwork2/util/ProxyUtil.java
@@ -132,8 +132,7 @@ public class ProxyUtil {
     public static boolean isHibernateProxyMember(Member member) {
         try {
             Class<?> clazz = ClassLoaderUtil.loadClass(HIBERNATE_HIBERNATEPROXY_CLASS_NAME, ProxyUtil.class);
-            if (hasMember(clazz, member))
-                return true;
+            return hasMember(clazz, member);
         } catch (ClassNotFoundException ignored) {
         }
 

--- a/core/src/main/java/org/apache/struts2/StrutsConstants.java
+++ b/core/src/main/java/org/apache/struts2/StrutsConstants.java
@@ -480,6 +480,7 @@ public final class StrutsConstants {
     public static final String STRUTS_TEXT_PROVIDER_FACTORY = "struts.textProviderFactory";
     public static final String STRUTS_LOCALIZED_TEXT_PROVIDER = "struts.localizedTextProvider";
 
+    public static final String STRUTS_DISALLOW_PROXY_OBJECT_ACCESS = "struts.disallowProxyObjectAccess";
     public static final String STRUTS_DISALLOW_PROXY_MEMBER_ACCESS = "struts.disallowProxyMemberAccess";
     public static final String STRUTS_DISALLOW_DEFAULT_PACKAGE_ACCESS = "struts.disallowDefaultPackageAccess";
 

--- a/core/src/main/java/org/apache/struts2/config/entities/ConstantConfig.java
+++ b/core/src/main/java/org/apache/struts2/config/entities/ConstantConfig.java
@@ -145,6 +145,7 @@ public class ConstantConfig {
     private String strictMethodInvocationMethodRegex;
     private BeanConfig textProviderFactory;
     private BeanConfig localizedTextProvider;
+    private Boolean disallowProxyObjectAccess;
     private Boolean disallowProxyMemberAccess;
     private Integer ognlAutoGrowthCollectionLimit;
     private String staticContentPath;
@@ -279,6 +280,7 @@ public class ConstantConfig {
         map.put(StrutsConstants.STRUTS_SMI_METHOD_REGEX, strictMethodInvocationMethodRegex);
         map.put(StrutsConstants.STRUTS_TEXT_PROVIDER_FACTORY, beanConfToString(textProviderFactory));
         map.put(StrutsConstants.STRUTS_LOCALIZED_TEXT_PROVIDER, beanConfToString(localizedTextProvider));
+        map.put(StrutsConstants.STRUTS_DISALLOW_PROXY_OBJECT_ACCESS, Objects.toString(disallowProxyObjectAccess, null));
         map.put(StrutsConstants.STRUTS_DISALLOW_PROXY_MEMBER_ACCESS, Objects.toString(disallowProxyMemberAccess, null));
         map.put(StrutsConstants.STRUTS_OGNL_AUTO_GROWTH_COLLECTION_LIMIT, Objects.toString(ognlAutoGrowthCollectionLimit, null));
         map.put(StrutsConstants.STRUTS_UI_STATIC_CONTENT_PATH, Objects.toString(staticContentPath, StaticContentLoader.DEFAULT_STATIC_CONTENT_PATH));
@@ -1358,6 +1360,14 @@ public class ConstantConfig {
 
     public void setLocalizedTextProvider(Class<?> clazz) {
         this.localizedTextProvider = new BeanConfig(clazz, clazz.getName());
+    }
+
+    public Boolean getDisallowProxyObjectAccess() {
+        return disallowProxyObjectAccess;
+    }
+
+    public void setDisallowProxyObjectAccess(Boolean disallowProxyObjectAccess) {
+        this.disallowProxyObjectAccess = disallowProxyObjectAccess;
     }
 
     public Boolean getDisallowProxyMemberAccess() {


### PR DESCRIPTION
WW-5407 
--
**Reason**
Currently `SecurityMemberAccess#isAccessible` return true for a method of a proxy object, which expose the beans at risk of being changed. We need to have the ability to detect proxy object and reject the access if required.

See Jira card above for more details.

&nbsp;
 
**Changes/ Solution**
currently in  `isAccessible -> checkProxyMemberAccess` , it use `disallowProxyMemberAccess && ProxyUtil.isProxyMember(member, target)`  which is not enough, as `isProxyMember` only matches the member **directly** from proxy class, and does not match those ones **original** from the target class.

 &nbsp;
 
So we update the `isAccessible`:
* add one extra checking `checkProxyAccess` before `checkProxyMemberAccess` which is controlled by:
    * `struts.disallowProxyObjectAccess` : an new struts constant to enable or disable this checking (default as `false`)
    * if disallow, then we do the proxy checking against  the target object.
 
 &nbsp;
 
**Result & Impact**
* By default `struts.disallowProxyObjectAccess` as `default`, no difference.
* Set `struts.disallowProxyObjectAccess`  as `true`, access to any member of a proxy object will be rejected, including both proxy member and original member of class. Which means whenever chained parameter `a.b.c.d.x` has one part that is a proxy, we reject the set to the last `x`
