### PR TITLE
WW-5408 add option to not fallback to empty namespace when unresolved

### DIFF
--- a/core/src/main/java/com/opensymphony/xwork2/config/impl/DefaultConfiguration.java
+++ b/core/src/main/java/com/opensymphony/xwork2/config/impl/DefaultConfiguration.java
@@ -590,11 +590,15 @@ public class DefaultConfiguration implements Configuration {
             }
 
             // fail over to empty namespace
-            if (config == null && StringUtils.isNotBlank(namespace) && ("/".equals(namespace) || fallbackToEmptyNamespace)) {
+            if (config == null && shouldFallbackToEmptyNamespace(namespace)) {
                 config = findActionConfigInNamespace("", name);
             }
 
             return config;
+        }
+
+        private boolean shouldFallbackToEmptyNamespace(String namespace) {
+            return StringUtils.isNotBlank(namespace) && ("/".equals(namespace) || fallbackToEmptyNamespace);
         }
 
         private ActionConfig findActionConfigInNamespace(String namespace, String name) {

--- a/core/src/main/java/org/apache/struts2/StrutsConstants.java
+++ b/core/src/main/java/org/apache/struts2/StrutsConstants.java
@@ -230,8 +230,8 @@ public final class StrutsConstants {
     public static final String STRUTS_XWORKCONVERTER = "struts.xworkConverter";
 
     public static final String STRUTS_ALWAYS_SELECT_FULL_NAMESPACE = "struts.mapper.alwaysSelectFullNamespace";
-    /** Disable fallback to empty namespace when request namespace didn't match any in action configuration */
-    public static final String STRUTS_DISABLE_EMPTY_NAMESPACE_FALLBACK = "struts.disableActionConfigFallbackToEmptyNamespace";
+    /** Fallback to empty namespace when request namespace didn't match any in action configuration */
+    public static final String STRUTS_ACTION_CONFIG_FALLBACK_TO_EMPTY_NAMESPACE = "struts.actionConfig.fallbackToEmptyNamespace";
 
     /** The {@link com.opensymphony.xwork2.LocaleProviderFactory} implementation class */
     public static final String STRUTS_LOCALE_PROVIDER_FACTORY = "struts.localeProviderFactory";

--- a/core/src/main/java/org/apache/struts2/StrutsConstants.java
+++ b/core/src/main/java/org/apache/struts2/StrutsConstants.java
@@ -230,6 +230,8 @@ public final class StrutsConstants {
     public static final String STRUTS_XWORKCONVERTER = "struts.xworkConverter";
 
     public static final String STRUTS_ALWAYS_SELECT_FULL_NAMESPACE = "struts.mapper.alwaysSelectFullNamespace";
+    /** Disable fallback to empty namespace when request namespace didn't match any in action configuration */
+    public static final String STRUTS_DISABLE_EMPTY_NAMESPACE_FALLBACK = "struts.disableActionConfigFallbackToEmptyNamespace";
 
     /** The {@link com.opensymphony.xwork2.LocaleProviderFactory} implementation class */
     public static final String STRUTS_LOCALE_PROVIDER_FACTORY = "struts.localeProviderFactory";

--- a/core/src/main/java/org/apache/struts2/config/entities/ConstantConfig.java
+++ b/core/src/main/java/org/apache/struts2/config/entities/ConstantConfig.java
@@ -90,7 +90,7 @@ public class ConstantConfig {
     private Boolean freemarkerWrapperAltMap;
     private BeanConfig xworkConverter;
     private Boolean mapperAlwaysSelectFullNamespace;
-    private Boolean proxyDisableEmptyNamespaceFallback;
+    private Boolean actionConfigFallbackToEmptyNamespace;
     private BeanConfig localeProviderFactory;
     private String mapperIdParameterName;
     private Boolean ognlAllowStaticFieldAccess;
@@ -226,7 +226,7 @@ public class ConstantConfig {
         map.put(StrutsConstants.STRUTS_FREEMARKER_WRAPPER_ALT_MAP, Objects.toString(freemarkerWrapperAltMap, null));
         map.put(StrutsConstants.STRUTS_XWORKCONVERTER, beanConfToString(xworkConverter));
         map.put(StrutsConstants.STRUTS_ALWAYS_SELECT_FULL_NAMESPACE, Objects.toString(mapperAlwaysSelectFullNamespace, null));
-        map.put(StrutsConstants.STRUTS_DISABLE_EMPTY_NAMESPACE_FALLBACK, Objects.toString(proxyDisableEmptyNamespaceFallback, null));
+        map.put(StrutsConstants.STRUTS_ACTION_CONFIG_FALLBACK_TO_EMPTY_NAMESPACE, Objects.toString(actionConfigFallbackToEmptyNamespace, null));
         map.put(StrutsConstants.STRUTS_LOCALE_PROVIDER_FACTORY, beanConfToString(localeProviderFactory));
         map.put(StrutsConstants.STRUTS_ID_PARAMETER_NAME, mapperIdParameterName);
         map.put(StrutsConstants.STRUTS_ALLOW_STATIC_FIELD_ACCESS, Objects.toString(ognlAllowStaticFieldAccess, null));
@@ -814,12 +814,12 @@ public class ConstantConfig {
         this.mapperAlwaysSelectFullNamespace = mapperAlwaysSelectFullNamespace;
     }
 
-    public Boolean getProxyDisableEmptyNamespaceFallback() {
-        return proxyDisableEmptyNamespaceFallback;
+    public Boolean getActionConfigFallbackToEmptyNamespace() {
+        return actionConfigFallbackToEmptyNamespace;
     }
 
-    public void setProxyDisableEmptyNamespaceFallback(Boolean proxyDisableEmptyNamespaceFallback) {
-        this.proxyDisableEmptyNamespaceFallback = proxyDisableEmptyNamespaceFallback;
+    public void setActionConfigFallbackToEmptyNamespace(Boolean actionConfigFallbackToEmptyNamespace) {
+        this.actionConfigFallbackToEmptyNamespace = actionConfigFallbackToEmptyNamespace;
     }
 
     public BeanConfig getLocaleProviderFactory() {

--- a/core/src/main/java/org/apache/struts2/config/entities/ConstantConfig.java
+++ b/core/src/main/java/org/apache/struts2/config/entities/ConstantConfig.java
@@ -90,6 +90,7 @@ public class ConstantConfig {
     private Boolean freemarkerWrapperAltMap;
     private BeanConfig xworkConverter;
     private Boolean mapperAlwaysSelectFullNamespace;
+    private Boolean proxyDisableEmptyNamespaceFallback;
     private BeanConfig localeProviderFactory;
     private String mapperIdParameterName;
     private Boolean ognlAllowStaticFieldAccess;
@@ -225,6 +226,7 @@ public class ConstantConfig {
         map.put(StrutsConstants.STRUTS_FREEMARKER_WRAPPER_ALT_MAP, Objects.toString(freemarkerWrapperAltMap, null));
         map.put(StrutsConstants.STRUTS_XWORKCONVERTER, beanConfToString(xworkConverter));
         map.put(StrutsConstants.STRUTS_ALWAYS_SELECT_FULL_NAMESPACE, Objects.toString(mapperAlwaysSelectFullNamespace, null));
+        map.put(StrutsConstants.STRUTS_DISABLE_EMPTY_NAMESPACE_FALLBACK, Objects.toString(proxyDisableEmptyNamespaceFallback, null));
         map.put(StrutsConstants.STRUTS_LOCALE_PROVIDER_FACTORY, beanConfToString(localeProviderFactory));
         map.put(StrutsConstants.STRUTS_ID_PARAMETER_NAME, mapperIdParameterName);
         map.put(StrutsConstants.STRUTS_ALLOW_STATIC_FIELD_ACCESS, Objects.toString(ognlAllowStaticFieldAccess, null));
@@ -810,6 +812,14 @@ public class ConstantConfig {
 
     public void setMapperAlwaysSelectFullNamespace(Boolean mapperAlwaysSelectFullNamespace) {
         this.mapperAlwaysSelectFullNamespace = mapperAlwaysSelectFullNamespace;
+    }
+
+    public Boolean getProxyDisableEmptyNamespaceFallback() {
+        return proxyDisableEmptyNamespaceFallback;
+    }
+
+    public void setProxyDisableEmptyNamespaceFallback(Boolean proxyDisableEmptyNamespaceFallback) {
+        this.proxyDisableEmptyNamespaceFallback = proxyDisableEmptyNamespaceFallback;
     }
 
     public BeanConfig getLocaleProviderFactory() {

--- a/core/src/main/resources/org/apache/struts2/default.properties
+++ b/core/src/main/resources/org/apache/struts2/default.properties
@@ -215,6 +215,9 @@ struts.xslt.nocache=false
 ### Whether to always select the namespace to be everything before the last slash or not
 struts.mapper.alwaysSelectFullNamespace=false
 
+### Whether to fallback to empty namespace when request namespace does not match any in configuration
+struts.actionConfig.fallbackToEmptyNamespace=true
+
 ### Whether to allow static field access in OGNL expressions or not
 struts.ognl.allowStaticFieldAccess=true
 

--- a/core/src/test/java/com/opensymphony/xwork2/config/ConfigurationTest.java
+++ b/core/src/test/java/com/opensymphony/xwork2/config/ConfigurationTest.java
@@ -240,8 +240,8 @@ public class ConfigurationTest extends XWorkTestCase {
         mockContainerProvider.verify();
     }
 
-    public void testGetActionConfigFallbackToEmptyNamespaceWhenNamespaceDontMatchAndEmptyNamespaceFallbackIsNotDisabled() {
-        // struts.disableEmptyNamespaceFallback default to null, so it's not disabled
+    public void testGetActionConfigFallbackToEmptyNamespaceWhenNamespaceDontMatchAndEmptyNamespaceFallbackIsEnabled() {
+        // struts.actionConfig.fallbackToEmptyNamespace default to true, so it is enabled
         RuntimeConfiguration configuration = configurationManager.getConfiguration().getRuntimeConfiguration();
 
         // check namespace that doesn't match fallback to empty namespace
@@ -259,8 +259,8 @@ public class ConfigurationTest extends XWorkTestCase {
     }
 
     public void testGetActionConfigReturnNullWhenNamespaceDontMatchAndEmptyNamespaceFallbackIsDisabled() {
-        // set the struts.disableEmptyNamespaceFallback to true and reload the configuration
-        setStrutsConstant(StrutsConstants.STRUTS_DISABLE_EMPTY_NAMESPACE_FALLBACK, "true");
+        // set the struts.actionConfig.fallbackToEmptyNamespace to false and reload the configuration
+        setStrutsConstant(StrutsConstants.STRUTS_ACTION_CONFIG_FALLBACK_TO_EMPTY_NAMESPACE, "false");
         RuntimeConfiguration configuration = configurationManager.getConfiguration().getRuntimeConfiguration();
 
         // check namespace that doesn't match NOT fallback to empty namespace and return null

--- a/core/src/test/java/com/opensymphony/xwork2/config/ConfigurationTest.java
+++ b/core/src/test/java/com/opensymphony/xwork2/config/ConfigurationTest.java
@@ -31,6 +31,7 @@ import com.opensymphony.xwork2.inject.ContainerBuilder;
 import com.opensymphony.xwork2.mock.MockInterceptor;
 import com.opensymphony.xwork2.test.StubConfigurationProvider;
 import com.opensymphony.xwork2.util.location.LocatableProperties;
+import org.apache.struts2.StrutsConstants;
 import org.apache.struts2.config.StrutsXmlConfigurationProvider;
 import org.apache.struts2.dispatcher.HttpParameters;
 
@@ -237,6 +238,41 @@ public class ConfigurationTest extends XWorkTestCase {
         assertNotNull(configuration.getActionConfig("/foo/bar", "Bar"));
 
         mockContainerProvider.verify();
+    }
+
+    public void testGetActionConfigFallbackToEmptyNamespaceWhenNamespaceDontMatchAndEmptyNamespaceFallbackIsNotDisabled() {
+        // struts.disableEmptyNamespaceFallback default to null, so it's not disabled
+        RuntimeConfiguration configuration = configurationManager.getConfiguration().getRuntimeConfiguration();
+
+        // check namespace that doesn't match fallback to empty namespace
+        ActionConfig actionConfig = configuration.getActionConfig("/something/that/is/not/in/the/namespace/config", "LazyFoo");
+        assertEquals("default", actionConfig.getPackageName()); // fallback to empty namespace (package name is default)
+        assertEquals("LazyFoo", actionConfig.getName());
+
+        // check non-empty namespace and name in config still matches
+        assertNotNull(configuration.getActionConfig("includeTest", "Foo"));
+
+        // check root namespace and name in config still matches
+        actionConfig = configuration.getActionConfig("/", "LazyFoo");
+        assertEquals("default", actionConfig.getPackageName());
+        assertEquals("LazyFoo", actionConfig.getName());
+    }
+
+    public void testGetActionConfigReturnNullWhenNamespaceDontMatchAndEmptyNamespaceFallbackIsDisabled() {
+        // set the struts.disableEmptyNamespaceFallback to true and reload the configuration
+        setStrutsConstant(StrutsConstants.STRUTS_DISABLE_EMPTY_NAMESPACE_FALLBACK, "true");
+        RuntimeConfiguration configuration = configurationManager.getConfiguration().getRuntimeConfiguration();
+
+        // check namespace that doesn't match NOT fallback to empty namespace and return null
+        assertNull(configuration.getActionConfig("/something/that/is/not/in/the/namespace/config", "LazyFoo"));
+
+        // check non-empty namespace and name in config still matches
+        assertNotNull(configuration.getActionConfig("includeTest", "Foo"));
+
+        // check root namespace and name in config still matches
+        ActionConfig actionConfig = configuration.getActionConfig("/", "LazyFoo");
+        assertEquals("default", actionConfig.getPackageName());
+        assertEquals("LazyFoo", actionConfig.getName());
     }
 
     public void testInitForPackageProviders() {

--- a/core/src/test/java/org/apache/struts2/views/jsp/ui/DebugTagTest.java
+++ b/core/src/test/java/org/apache/struts2/views/jsp/ui/DebugTagTest.java
@@ -217,23 +217,9 @@ public class DebugTagTest extends AbstractUITagTest {
     /**
      * Overwrite the Struts Constant and reload container
      */
-    private void setStrutsConstant(final Map<String, String> overwritePropeties) {
-        configurationManager.addContainerProvider(new StubConfigurationProvider() {
-            @Override
-            public boolean needsReload() {
-                return true;
-            }
-
-            @Override
-            public void register(ContainerBuilder builder, LocatableProperties props) throws ConfigurationException {
-                for (Map.Entry<String, String> stringStringEntry : overwritePropeties.entrySet()) {
-                    props.setProperty(stringStringEntry.getKey(), stringStringEntry.getValue(), null);
-                }
-            }
-        });
-
-        configurationManager.reload();
-        container = configurationManager.getConfiguration().getContainer();
+    @Override
+    protected void setStrutsConstant(final Map<String, String> overwritePropeties) {
+        super.setStrutsConstant(overwritePropeties);
         stack.getActionContext().withContainer(container);
     }
 }


### PR DESCRIPTION
WW-5408

**Reason**
There is a case we want to enhance to improve security for struts url mapping: Be able to prevent arbitrary namespace fallback to empty (root) namespace when not match

&nbsp;
 
**Changes/ Solution**
*  introduce new Struts constant ` STRUTS_DISABLE_EMPTY_NAMESPACE_FALLBACK [struts.disableActionConfigFallbackToEmptyNamespace]` to disable fallback to empty namespace when not match
*  default as null which means does not disable (Need to manually set as true in confluence struts.xml)

 &nbsp;
 
**Result & Impact**
* By default `struts.disableActionConfigFallbackToEmptyNamespace` is `null`, no difference.
* Set `struts.disableActionConfigFallbackToEmptyNamespace`  as `true`, not matched namepsace **WILL NOT** fallback to empty namespace anymore, and struts will threw `ConfigurationException`, it relies on the application to handle this exception.
