### PR TITLE
WW-5400 Extend default configuration options for the CSP interceptor.

### DIFF
--- a/core/src/main/java/org/apache/struts2/interceptor/csp/CspInterceptor.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/csp/CspInterceptor.java
@@ -46,6 +46,9 @@ public final class CspInterceptor extends AbstractInterceptor {
     private boolean prependServletContext = true;
     private boolean enforcingMode;
     private String reportUri;
+    private String reportTo;
+
+    private String defaultCspSettingsClassName = DefaultCspSettings.class.getName();
 
     @Override
     public String intercept(ActionInvocation invocation) throws Exception {
@@ -54,8 +57,24 @@ public final class CspInterceptor extends AbstractInterceptor {
             LOG.trace("Using CspSettings provided by the action: {}", action);
             applySettings(invocation, ((CspSettingsAware) action).getCspSettings());
         } else {
-            LOG.trace("Using DefaultCspSettings with action: {}", action);
-            applySettings(invocation, new DefaultCspSettings());
+            LOG.trace("Using {} with action: {}", defaultCspSettingsClassName, action);
+
+            // if the defaultCspSettingsClassName is not a real class, throw an exception
+            try {
+                Class.forName(defaultCspSettingsClassName, false, Thread.currentThread().getContextClassLoader());
+            }
+            catch (ClassNotFoundException e) {
+                throw new IllegalArgumentException("The defaultCspSettingsClassName must be a real class.");
+            }
+
+            // if defaultCspSettingsClassName does not implement CspSettings, throw an exception
+            if (!CspSettings.class.isAssignableFrom(Class.forName(defaultCspSettingsClassName))) {
+                throw new IllegalArgumentException("The defaultCspSettingsClassName must implement CspSettings.");
+            }
+
+            CspSettings cspSettings = (CspSettings) Class.forName(defaultCspSettingsClassName)
+                    .getDeclaredConstructor().newInstance();
+            applySettings(invocation, cspSettings);
         }
         return invocation.invoke();
     }
@@ -76,6 +95,12 @@ public final class CspInterceptor extends AbstractInterceptor {
             }
 
             cspSettings.setReportUri(finalReportUri);
+
+            // apply reportTo if set
+            if (reportTo != null) {
+                LOG.trace("Applying: {} to reportTo", reportTo);
+                cspSettings.setReportTo(reportTo);
+            }
         }
 
         invocation.addPreResultListener((actionInvocation, resultCode) -> {
@@ -95,6 +120,10 @@ public final class CspInterceptor extends AbstractInterceptor {
         }
 
         this.reportUri = reportUri;
+    }
+
+    public void setReportTo(String reportTo) {
+        this.reportTo = reportTo;
     }
 
     private Optional<URI> buildUri(String reportUri) {
@@ -124,4 +153,11 @@ public final class CspInterceptor extends AbstractInterceptor {
         this.prependServletContext = prependServletContext;
     }
 
+    /**
+     * Sets the class name of the default {@link CspSettings} implementation to use when the action does not
+     * set its own values. If not set, the default is {@link DefaultCspSettings}.
+     */
+    public void setDefaultCspSettingsClassName(String defaultCspSettingsClassName) {
+        this.defaultCspSettingsClassName = defaultCspSettingsClassName;
+    }
 }

--- a/core/src/main/java/org/apache/struts2/interceptor/csp/CspInterceptor.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/csp/CspInterceptor.java
@@ -122,6 +122,14 @@ public final class CspInterceptor extends AbstractInterceptor {
         this.reportUri = reportUri;
     }
 
+    /**
+     * Sets the report group where csp violation reports will be sent. This will
+     * only be used if the reportUri is set.
+     *
+     * @param reportTo the report group where csp violation reports will be sent
+     *
+     * @since Struts 6.5.0
+     */
     public void setReportTo(String reportTo) {
         this.reportTo = reportTo;
     }
@@ -156,6 +164,8 @@ public final class CspInterceptor extends AbstractInterceptor {
     /**
      * Sets the class name of the default {@link CspSettings} implementation to use when the action does not
      * set its own values. If not set, the default is {@link DefaultCspSettings}.
+     *
+     * @since Struts 6.5.0
      */
     public void setDefaultCspSettingsClassName(String defaultCspSettingsClassName) {
         this.defaultCspSettingsClassName = defaultCspSettingsClassName;

--- a/core/src/main/java/org/apache/struts2/interceptor/csp/CspSettings.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/csp/CspSettings.java
@@ -37,6 +37,7 @@ public interface CspSettings {
     String SCRIPT_SRC = "script-src";
     String BASE_URI = "base-uri";
     String REPORT_URI = "report-uri";
+    String REPORT_TO = "report-to";
     String NONE = "none";
     String STRICT_DYNAMIC = "strict-dynamic";
     String HTTP = "http:";
@@ -55,6 +56,11 @@ public interface CspSettings {
      * Sets the uri where csp violation reports will be sent
      */
     void setReportUri(String uri);
+
+    /**
+     * Sets the report group where csp violation reports will be sent
+     */
+    void setReportTo(String group);
 
     /**
      * Sets CSP headers in enforcing mode when true, and report-only when false

--- a/core/src/main/java/org/apache/struts2/interceptor/csp/CspSettings.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/csp/CspSettings.java
@@ -59,6 +59,8 @@ public interface CspSettings {
 
     /**
      * Sets the report group where csp violation reports will be sent
+     *
+     * @since Struts 6.5.0
      */
     void setReportTo(String group);
 

--- a/core/src/main/java/org/apache/struts2/interceptor/csp/DefaultCspSettings.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/csp/DefaultCspSettings.java
@@ -134,7 +134,7 @@ public class DefaultCspSettings implements CspSettings {
     public String toString() {
         return "DefaultCspSettings{" +
             "reportUri='" + reportUri + '\'' +
-            "reportTo='" + reportTo + '\'' +
+            ", reportTo='" + reportTo + '\'' +
             ", cspHeader='" + cspHeader + '\'' +
             '}';
     }


### PR DESCRIPTION
Previously, it was impossible to set global options for the CSP interceptor. The only option was to have every action individually implement CspSettingsAware.

To fix this, we add an interceptor parameter of defaultCspSettingsClassName. Values from this class will be used in the CSP header instead of DefaultCspSettings. Users may define their own custom class which implements CspSettings, and that will be the default for all actions that do not implement the CspSettingsAware interface. It is now possible to create this custom class by simply extending DefaultCspSettings.

I have fixed a spelling error in DefaultCspSettings.java -- cratePolicyFormat renamed to createPolicyFormat.

Closes [WW-5400](https://issues.apache.org/jira/browse/WW-5400)