### PR TITLE
INFRA-25666 Disables review by code owners

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -18,7 +18,8 @@ github:
       contexts:
         - build
       required_pull_request_reviews:
-        require_code_owner_reviews: true
+        # it does not work because our github teams are private/secret, see INFRA-25666
+        require_code_owner_reviews: false
         required_approving_review_count: 1
   autolink_jira:
     - WW


### PR DESCRIPTION
* this functionality requires to have public teams
* currently all ASF teams are private

You can find more info in the ticket [INFRA-25666](https://issues.apache.org/jira/browse/INFRA-25666)