### PR TITLE
[WW-5423] Fixes returning null instead of empty array in case of non-existing param

### DIFF
--- a/core/src/main/java/org/apache/struts2/dispatcher/multipart/AbstractMultiPartRequest.java
+++ b/core/src/main/java/org/apache/struts2/dispatcher/multipart/AbstractMultiPartRequest.java
@@ -372,8 +372,11 @@ public abstract class AbstractMultiPartRequest implements MultiPartRequest {
      * @see org.apache.struts2.dispatcher.multipart.MultiPartRequest#getParameterValues(java.lang.String)
      */
     public String[] getParameterValues(String name) {
-        return parameters.getOrDefault(name, Collections.emptyList())
-                .toArray(String[]::new);
+        List<String> values = parameters.get(name);
+        if (values == null) {
+            return null;
+        }
+        return values.toArray(new String[0]);
     }
 
     /* (non-Javadoc)

--- a/core/src/main/java/org/apache/struts2/dispatcher/multipart/MultiPartRequest.java
+++ b/core/src/main/java/org/apache/struts2/dispatcher/multipart/MultiPartRequest.java
@@ -95,6 +95,7 @@ public interface MultiPartRequest {
     /**
      * Returns a list of all parameter values associated with a parameter name. If there is only
      * one parameter value per name the resulting array will be of length 1.
+     * If the parameter doesn't exist, null should be returned instead of empty array.
      *
      * @param name the name of the parameter.
      * @return an array of all values associated with the parameter name.

--- a/core/src/test/java/org/apache/struts2/dispatcher/multipart/AbstractMultiPartRequestTest.java
+++ b/core/src/test/java/org/apache/struts2/dispatcher/multipart/AbstractMultiPartRequestTest.java
@@ -93,7 +93,7 @@ abstract class AbstractMultiPartRequestTest {
                 .isEmpty();
 
         assertThat(multiPart.getFileParameterNames().asIterator()).toIterable()
-                .asList()
+                .asInstanceOf(InstanceOfAssertFactories.LIST)
                 .containsOnly("file1", "file2");
         assertThat(multiPart.getFile("file1")).allSatisfy(file -> {
             assertThat(file.isFile())
@@ -142,7 +142,7 @@ abstract class AbstractMultiPartRequestTest {
                 .isEmpty();
 
         assertThat(multiPart.getFileParameterNames().asIterator()).toIterable()
-                .asList()
+                .asInstanceOf(InstanceOfAssertFactories.LIST)
                 .containsOnly("file1");
         assertThat(multiPart.getFile("file1")).allSatisfy(file -> {
             if (Objects.equals(file.getName(), "test1.csv")) {
@@ -193,7 +193,7 @@ abstract class AbstractMultiPartRequestTest {
                 .isEmpty();
 
         assertThat(multiPart.getFileParameterNames().asIterator()).toIterable()
-                .asList()
+                .asInstanceOf(InstanceOfAssertFactories.LIST)
                 .containsOnly("file1", "file2");
         assertThat(multiPart.getFile("file1")).allSatisfy(file -> {
             assertThat(file.isFile())
@@ -240,7 +240,7 @@ abstract class AbstractMultiPartRequestTest {
                 .isEmpty();
 
         assertThat(multiPart.getFileParameterNames().asIterator()).toIterable()
-                .asList()
+                .asInstanceOf(InstanceOfAssertFactories.LIST)
                 .containsOnly("file1", "file2");
         assertThat(multiPart.getFile("file1")).allSatisfy(file -> {
             assertThat(file.isFile())
@@ -306,7 +306,7 @@ abstract class AbstractMultiPartRequestTest {
                 .containsExactly("struts.messages.upload.error.FileUploadContentTypeException");
 
         assertThat(multiPart.getFileParameterNames().asIterator()).toIterable()
-                .asList()
+                .asInstanceOf(InstanceOfAssertFactories.LIST)
                 .isEmpty();
     }
 
@@ -410,7 +410,7 @@ abstract class AbstractMultiPartRequestTest {
                 .isEmpty();
 
         assertThat(multiPart.getFileParameterNames().asIterator()).toIterable()
-                .asList()
+                .asInstanceOf(InstanceOfAssertFactories.LIST)
                 .containsOnly("file1");
         assertThat(multiPart.getFile("file1")).allSatisfy(file -> {
             assertThat(file.isFile())
@@ -458,6 +458,8 @@ abstract class AbstractMultiPartRequestTest {
                 .isEqualTo("short text");
         assertThat(multiPart.getParameterValues("multi"))
                 .containsOnly("multi1", "multi2");
+        assertThat(multiPart.getParameterValues("not-existing"))
+                .isNull();
     }
 
     @Test


### PR DESCRIPTION

Fixes [WW-5423](https://issues.apache.org/jira/browse/WW-5423)