### PR TITLE
WW-5428 Allowlist capability should resolve Hibernate proxies when disableProxyObjects is not set

### DIFF
--- a/core/src/main/java/com/opensymphony/xwork2/ognl/SecurityMemberAccess.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/SecurityMemberAccess.java
@@ -209,6 +209,10 @@ public class SecurityMemberAccess implements MemberAccess {
      * @return {@code true} if member access is allowed
      */
     protected boolean checkAllowlist(Object target, Member member) {
+        if (!enforceAllowlistEnabled) {
+            return true;
+        }
+
         if (!disallowProxyObjectAccess && target != null && ProxyUtil.isProxy(target)) {
             // If `disallowProxyObjectAccess` is not set, allow resolving Hibernate entities to their underlying
             // classes/members. This allows the allowlist capability to continue working and offer some level of
@@ -222,9 +226,6 @@ public class SecurityMemberAccess implements MemberAccess {
         }
 
         Class<?> memberClass = member.getDeclaringClass();
-        if (!enforceAllowlistEnabled) {
-            return true;
-        }
         if (!isClassAllowlisted(memberClass)) {
             LOG.warn(format("Declaring class [{0}] of member type [{1}] is not allowlisted!", memberClass, member));
             return false;

--- a/core/src/main/java/com/opensymphony/xwork2/ognl/SecurityMemberAccess.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/SecurityMemberAccess.java
@@ -217,6 +217,7 @@ public class SecurityMemberAccess implements MemberAccess {
      */
     protected boolean checkAllowlist(Object target, Member member) {
         if (!enforceAllowlistEnabled) {
+            logAllowlistDisabled();
             return true;
         }
 
@@ -249,6 +250,21 @@ public class SecurityMemberAccess implements MemberAccess {
         return true;
     }
 
+    private void logAllowlistDisabled() {
+        if (!isDevMode && !LOG.isDebugEnabled()) {
+            return;
+        }
+        String msg = "OGNL allowlist is disabled!" +
+                " We strongly recommend keeping it enabled to protect against critical vulnerabilities." +
+                " Set the configuration `{0}=true` to enable it.";
+        Object[] args = {StrutsConstants.STRUTS_ALLOWLIST_ENABLE};
+        if (isDevMode) {
+            LOG.warn(msg, args);
+        } else {
+            LOG.debug(msg, args);
+        }
+    }
+
     private void logAllowlistHibernateEntity(Object original, Object resolved) {
         if (!isDevMode && !LOG.isDebugEnabled()) {
             return;
@@ -261,7 +277,6 @@ public class SecurityMemberAccess implements MemberAccess {
         } else {
             LOG.debug(msg, args);
         }
-
     }
 
     protected boolean isClassAllowlisted(Class<?> clazz) {

--- a/core/src/main/java/com/opensymphony/xwork2/ognl/SecurityMemberAccess.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/SecurityMemberAccess.java
@@ -51,6 +51,8 @@ import static java.text.MessageFormat.format;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.unmodifiableSet;
+import static org.apache.struts2.StrutsConstants.STRUTS_ALLOWLIST_CLASSES;
+import static org.apache.struts2.StrutsConstants.STRUTS_ALLOWLIST_PACKAGE_NAMES;
 
 /**
  * Allows access decisions to be made on the basis of whether a member is static or not.
@@ -236,7 +238,8 @@ public class SecurityMemberAccess implements MemberAccess {
 
         Class<?> memberClass = member.getDeclaringClass();
         if (!isClassAllowlisted(memberClass)) {
-            LOG.warn(format("Declaring class [{0}] of member type [{1}] is not allowlisted!", memberClass, member));
+            LOG.warn("Declaring class [{}] of member type [{}] is not allowlisted! Add to '{}' or '{}' configuration.",
+                    memberClass, member, STRUTS_ALLOWLIST_CLASSES, STRUTS_ALLOWLIST_PACKAGE_NAMES);
             return false;
         }
         if (target == null || target.getClass() == memberClass) {
@@ -244,7 +247,8 @@ public class SecurityMemberAccess implements MemberAccess {
         }
         Class<?> targetClass = target.getClass();
         if (!isClassAllowlisted(targetClass)) {
-            LOG.warn(format("Target class [{0}] of target [{1}] is not allowlisted!", targetClass, target));
+            LOG.warn("Target class [{}] of target [{}] is not allowlisted! Add to '{}' or '{}' configuration.",
+                    targetClass, target, STRUTS_ALLOWLIST_CLASSES, STRUTS_ALLOWLIST_PACKAGE_NAMES);
             return false;
         }
         return true;
@@ -487,12 +491,12 @@ public class SecurityMemberAccess implements MemberAccess {
         this.enforceAllowlistEnabled = BooleanUtils.toBoolean(enforceAllowlistEnabled);
     }
 
-    @Inject(value = StrutsConstants.STRUTS_ALLOWLIST_CLASSES, required = false)
+    @Inject(value = STRUTS_ALLOWLIST_CLASSES, required = false)
     public void useAllowlistClasses(String commaDelimitedClasses) {
         this.allowlistClasses = toClassObjectsSet(commaDelimitedClasses);
     }
 
-    @Inject(value = StrutsConstants.STRUTS_ALLOWLIST_PACKAGE_NAMES, required = false)
+    @Inject(value = STRUTS_ALLOWLIST_PACKAGE_NAMES, required = false)
     public void useAllowlistPackageNames(String commaDelimitedPackageNames) {
         this.allowlistPackageNames = toPackageNamesSet(commaDelimitedPackageNames);
     }


### PR DESCRIPTION
WW-5428
--
The OGNL allowlist capability cannot resolve proxy objects and thus will not work in applications where proxy objects such as Spring beans and Hibernate entities are accessed via OGNL.

Allowing access to such objects via OGNL is not recommended anyway as such access can be used to escalate an SSTI vulnerability.

However, given there seem to be many applications that still rely on accessing Hibernate entities directly, it would still offer much greater security in these cases, if the allowlist were enabled with exemptions for Hibernate proxies, rather than disabled altogether.

As such, in this PR, if an application is configured with `struts.disallowProxyObjectAccess=false`, the allowlist capability will resolve the underlying class of any Hibernate proxies and enforce the allowlist against this class instead.
