### PR TITLE
WW-5437 Swap order of sysStrSubstitutor and envStrSubstitutor in substitute method

### DIFF
--- a/core/src/main/java/com/opensymphony/xwork2/config/providers/EnvsValueSubstitutor.java
+++ b/core/src/main/java/com/opensymphony/xwork2/config/providers/EnvsValueSubstitutor.java
@@ -46,7 +46,7 @@ public class EnvsValueSubstitutor implements ValueSubstitutor {
     public String substitute(String value) {
         LOG.debug("Substituting value {} with proper System variable or environment variable", value);
 
-        String substituted = sysStrSubstitutor.replace(value);
-        return envStrSubstitutor.replace(substituted);
+        String substituted = envStrSubstitutor.replace(value);
+        return sysStrSubstitutor.replace(substituted);
     }
 }


### PR DESCRIPTION
According to the documentation at https://struts.apache.org/core-developers/constant-configuration it should be possible to use both system and environment variables in the constants section. Currently environment variables are ignored if a default value is defined.

The sysStrSubstitutor has a less specific prefix which also includes and replaces those, which should be passed to the envStrSubstitutor later.

Given
`<constant name="struts.devMode" value="${env.STRUTS_DEV_MODE:false}"/>`
and System.getenv('STRUTS_DEV_MODE') is "true"

The old code:
```
String substituted = sysStrSubstitutor.replace(value);
return envStrSubstitutor.replace(substituted);
```
The sysStrSubstitutor checks, if there is a system property with the key "env.STRUTS_DEV_MODE" which is unset. It then replaces the expression with its default. substituted is "false" now. Afterwards the envStrSubstitutor doesn't find any expression to substitute, because the string is "false".

The new code:
```
String substituted = envStrSubstitutor.replace(value);
return sysStrSubstitutor.replace(substituted);
```
The envStrSubstitutor only accepts expressions prefixed with "env.", so it ignores any unprefixed (aka system-) variables. If not set, substituted remains unchanged and is replaced by the system variable or eventually the default in the next step.

I'm not sure if this all is right and understandable but for me, the new behavior is what I've exprected after reading the docs and telling my DevOps team how to enable the devMode for my test-container :)

Closes [WW-5437](https://issues.apache.org/jira/browse/WW-5437)