### PR TITLE
WW-5428 Stop excessive logging in DevMode

### DIFF
--- a/core/src/main/java/com/opensymphony/xwork2/ognl/SecurityMemberAccess.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/SecurityMemberAccess.java
@@ -224,7 +224,6 @@ public class SecurityMemberAccess implements MemberAccess {
      */
     protected boolean checkAllowlist(Object target, Member member) {
         if (!enforceAllowlistEnabled) {
-            logAllowlistDisabled();
             return true;
         }
 
@@ -257,21 +256,6 @@ public class SecurityMemberAccess implements MemberAccess {
             return false;
         }
         return true;
-    }
-
-    private void logAllowlistDisabled() {
-        if (!isDevMode && !LOG.isDebugEnabled()) {
-            return;
-        }
-        String msg = "OGNL allowlist is disabled!" +
-                " We strongly recommend keeping it enabled to protect against critical vulnerabilities." +
-                " Set the configuration `{0}=true` to enable it.";
-        Object[] args = {StrutsConstants.STRUTS_ALLOWLIST_ENABLE};
-        if (isDevMode) {
-            LOG.warn(msg, args);
-        } else {
-            LOG.debug(msg, args);
-        }
     }
 
     private void logAllowlistHibernateEntity(Object original, Object resolved) {


### PR DESCRIPTION
WW-5428
--
As per title, this is too much logging, even in DevMode.

I can't think of a better place to put this right now so am deleting it. I considered the allowlist-enabled injection method but that also causes issues as we override that as false from OgnlUtil and that causes a false-positive warning.