### PR TITLE
WW-5440 Fix OGNL allowlist compat with Convention plugin

### DIFF
--- a/apps/rest-showcase/src/main/java/org/demo/rest/example/OrdersController.java
+++ b/apps/rest-showcase/src/main/java/org/demo/rest/example/OrdersController.java
@@ -18,30 +18,30 @@
  */
 package org.demo.rest.example;
 
-import java.util.Collection;
-
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.apache.struts2.rest.DefaultHttpHeaders;
-import org.apache.struts2.rest.HttpHeaders;
-import org.apache.struts2.convention.annotation.Results;
-import org.apache.struts2.convention.annotation.Result;
-
 import com.opensymphony.xwork2.ModelDriven;
 import com.opensymphony.xwork2.Validateable;
 import com.opensymphony.xwork2.ValidationAwareSupport;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.struts2.convention.annotation.Result;
+import org.apache.struts2.convention.annotation.Results;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
+import org.apache.struts2.rest.DefaultHttpHeaders;
+import org.apache.struts2.rest.HttpHeaders;
+
+import java.util.Collection;
 
 @Results({
     @Result(name="success", type="redirectAction", params = {"actionName" , "orders"})
 })
-public class OrdersController extends ValidationAwareSupport implements ModelDriven<Object>, Validateable{
+public class OrdersController extends ValidationAwareSupport implements ModelDriven<Object>, Validateable {
 
     private static final Logger log = LogManager.getLogger(OrdersController.class);
 
     private Order model = new Order();
     private String id;
     private Collection<Order> list;
-    private OrdersService ordersService = new OrdersService();
+    private final OrdersService ordersService = new OrdersService();
 
     // GET /orders/1
     public HttpHeaders show() {
@@ -54,7 +54,7 @@ public class OrdersController extends ValidationAwareSupport implements ModelDri
         return new DefaultHttpHeaders("index")
             .disableCaching();
     }
-    
+
     // GET /orders/1/edit
     public String edit() {
         return "edit";
@@ -101,13 +101,15 @@ public class OrdersController extends ValidationAwareSupport implements ModelDri
         }
     }
 
+    @StrutsParameter
     public void setId(String id) {
         if (id != null) {
             this.model = ordersService.get(id);
         }
         this.id = id;
     }
-    
+
+    @Override
     public Object getModel() {
         return (list != null ? list : model);
     }

--- a/apps/rest-showcase/src/main/java/org/demo/rest/example/OrdersService.java
+++ b/apps/rest-showcase/src/main/java/org/demo/rest/example/OrdersService.java
@@ -18,11 +18,14 @@
  */
 package org.demo.rest.example;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class OrdersService {
 
-    private static Map<String,Order> orders = new HashMap<String,Order>();
+    private static final Map<String,Order> orders = new HashMap<>();
     private static int nextId = 6;
     static {
         orders.put("3", new Order("3", "Bob", 33));

--- a/apps/showcase/pom.xml
+++ b/apps/showcase/pom.xml
@@ -137,6 +137,12 @@
            <scope>test</scope>
        </dependency>
 
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
        <dependency>
             <groupId>net.sourceforge.htmlunit</groupId>
             <artifactId>htmlunit</artifactId>

--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/DynamicTreeSelectAction.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/DynamicTreeSelectAction.java
@@ -21,6 +21,7 @@
 package org.apache.struts2.showcase;
 
 import com.opensymphony.xwork2.ActionSupport;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 import org.apache.struts2.showcase.ajax.tree.Category;
 
 //START SNIPPET: treeExampleDynamicJavaSelected
@@ -30,7 +31,7 @@ public class DynamicTreeSelectAction extends ActionSupport {
 	private long nodeId;
 	private Category currentCategory;
 
-
+	@StrutsParameter
 	public void setNodeId(long nodeId) {
 		this.nodeId = nodeId;
 	}

--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/LotsOfOptiontransferselectAction.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/LotsOfOptiontransferselectAction.java
@@ -21,6 +21,7 @@
 package org.apache.struts2.showcase;
 
 import com.opensymphony.xwork2.ActionSupport;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -74,6 +75,7 @@ public class LotsOfOptiontransferselectAction extends ActionSupport {
 		return _favouriteCartoonCharactersKeys;
 	}
 
+	@StrutsParameter
 	public void setFavouriteCartoonCharacters(List favouriteCartoonCharacters) {
 		_favouriteCartoonCharactersKeys = favouriteCartoonCharacters;
 	}
@@ -82,6 +84,7 @@ public class LotsOfOptiontransferselectAction extends ActionSupport {
 		return _notFavouriteCartoonCharactersKeys;
 	}
 
+	@StrutsParameter
 	public void setNotFavouriteCartoonCharacters(List notFavouriteCartoonCharacters) {
 		_notFavouriteCartoonCharactersKeys = notFavouriteCartoonCharacters;
 	}
@@ -108,6 +111,7 @@ public class LotsOfOptiontransferselectAction extends ActionSupport {
 		return _favouriteCarsKeys;
 	}
 
+	@StrutsParameter
 	public void setFavouriteCars(List favouriteCars) {
 		_favouriteCarsKeys = favouriteCars;
 	}
@@ -116,6 +120,7 @@ public class LotsOfOptiontransferselectAction extends ActionSupport {
 		return _notFavouriteCarsKeys;
 	}
 
+	@StrutsParameter
 	public void setNotFavouriteCars(List notFavouriteCars) {
 		_notFavouriteCarsKeys = notFavouriteCars;
 	}
@@ -142,6 +147,7 @@ public class LotsOfOptiontransferselectAction extends ActionSupport {
 		return _favouriteMotorcyclesKeys;
 	}
 
+	@StrutsParameter
 	public void setFavouriteMotorcycles(List favouriteMotorcycles) {
 		_favouriteMotorcyclesKeys = favouriteMotorcycles;
 	}
@@ -150,6 +156,7 @@ public class LotsOfOptiontransferselectAction extends ActionSupport {
 		return _notFavouriteMotorcyclesKeys;
 	}
 
+	@StrutsParameter
 	public void setNotFavouriteMotorcycles(List notFavouriteMotorcycles) {
 		_notFavouriteMotorcyclesKeys = notFavouriteMotorcycles;
 	}
@@ -176,6 +183,7 @@ public class LotsOfOptiontransferselectAction extends ActionSupport {
 		return _favouriteCountriesKeys;
 	}
 
+	@StrutsParameter
 	public void setFavouriteCountries(List favouriteCountries) {
 		_favouriteCountriesKeys = favouriteCountries;
 	}
@@ -184,6 +192,7 @@ public class LotsOfOptiontransferselectAction extends ActionSupport {
 		return _notFavouriteCountriesKeys;
 	}
 
+	@StrutsParameter
 	public void setNotFavouriteCountries(List notFavouriteCountries) {
 		_notFavouriteCountriesKeys = notFavouriteCountries;
 	}
@@ -205,6 +214,7 @@ public class LotsOfOptiontransferselectAction extends ActionSupport {
 		return _favouriteSportsKeys;
 	}
 
+	@StrutsParameter
 	public void setFavouriteSports(List favouriteSportsKeys) {
 		this._favouriteSportsKeys = favouriteSportsKeys;
 	}
@@ -213,6 +223,7 @@ public class LotsOfOptiontransferselectAction extends ActionSupport {
 		return _nonFavouriteSportsKeys;
 	}
 
+	@StrutsParameter
 	public void setNonFavouriteSports(List notFavouriteSportsKeys) {
 		this._nonFavouriteSportsKeys = notFavouriteSportsKeys;
 	}
@@ -222,6 +233,7 @@ public class LotsOfOptiontransferselectAction extends ActionSupport {
 		return _prioritisedFavouriteCartoonCharacters;
 	}
 
+	@StrutsParameter
 	public void setPrioritisedFavouriteCartoonCharacters(List prioritisedFavouriteCartoonCharacters) {
 		_prioritisedFavouriteCartoonCharacters = prioritisedFavouriteCartoonCharacters;
 	}
@@ -230,6 +242,7 @@ public class LotsOfOptiontransferselectAction extends ActionSupport {
 		return _prioritisedFavouriteCars;
 	}
 
+	@StrutsParameter
 	public void setPrioritisedFavouriteCars(List prioritisedFavouriteCars) {
 		_prioritisedFavouriteCars = prioritisedFavouriteCars;
 	}
@@ -239,6 +252,7 @@ public class LotsOfOptiontransferselectAction extends ActionSupport {
 		return _prioritisedFavouriteCountries;
 	}
 
+	@StrutsParameter
 	public void setPrioritisedFavouriteCountries(List prioritisedFavouriteCountries) {
 		_prioritisedFavouriteCountries = prioritisedFavouriteCountries;
 	}
@@ -264,12 +278,13 @@ public class LotsOfOptiontransferselectAction extends ActionSupport {
 		return _favouriteCities;
 	}
 
+	@StrutsParameter
 	public void setFavouriteCities(List favouriteCities) {
 		this._favouriteCities = favouriteCities;
 	}
 
 	// actions
-
+	@Override
 	public String input() throws Exception {
 		return SUCCESS;
 	}

--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/LotsOfRichtexteditorAction.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/LotsOfRichtexteditorAction.java
@@ -21,6 +21,7 @@
 package org.apache.struts2.showcase;
 
 import com.opensymphony.xwork2.ActionSupport;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
 /**
  *
@@ -36,6 +37,7 @@ public class LotsOfRichtexteditorAction extends ActionSupport {
 		return this.description1;
 	}
 
+	@StrutsParameter
 	public void setDescription1(String description1) {
 		this.description1 = description1;
 	}
@@ -45,6 +47,7 @@ public class LotsOfRichtexteditorAction extends ActionSupport {
 		return this.description2;
 	}
 
+	@StrutsParameter
 	public void setDescription2(String description2) {
 		this.description2 = description2;
 	}
@@ -54,6 +57,7 @@ public class LotsOfRichtexteditorAction extends ActionSupport {
 		return this.description3;
 	}
 
+	@StrutsParameter
 	public void setDescription3(String description3) {
 		this.description3 = description3;
 	}
@@ -63,11 +67,12 @@ public class LotsOfRichtexteditorAction extends ActionSupport {
 		return this.description4;
 	}
 
+	@StrutsParameter
 	public void setDescription4(String description4) {
 		this.description4 = description4;
 	}
 
-
+	@Override
 	public String input() throws Exception {
 		return SUCCESS;
 	}

--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/MoreSelectsAction.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/MoreSelectsAction.java
@@ -21,6 +21,7 @@
 package org.apache.struts2.showcase;
 
 import com.opensymphony.xwork2.ActionSupport;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -75,11 +76,11 @@ public class MoreSelectsAction extends ActionSupport {
 		return list;
 	}
 
-
 	public List getPrioritisedFavouriteCartoonCharacters() {
 		return _prioritisedFavouriteCartoonCharacters;
 	}
 
+	@StrutsParameter
 	public void setPrioritisedFavouriteCartoonCharacters(List prioritisedFavouriteCartoonCharacters) {
 		_prioritisedFavouriteCartoonCharacters = prioritisedFavouriteCartoonCharacters;
 	}
@@ -88,15 +89,16 @@ public class MoreSelectsAction extends ActionSupport {
 		return _prioritisedFavouriteCars;
 	}
 
+	@StrutsParameter
 	public void setPrioritisedFavouriteCars(List prioritisedFavouriteCars) {
 		_prioritisedFavouriteCars = prioritisedFavouriteCars;
 	}
-
 
 	public List getPrioritisedFavouriteCountries() {
 		return _prioritisedFavouriteCountries;
 	}
 
+	@StrutsParameter
 	public void setPrioritisedFavouriteCountries(List prioritisedFavouriteCountries) {
 		_prioritisedFavouriteCountries = prioritisedFavouriteCountries;
 	}
@@ -105,6 +107,7 @@ public class MoreSelectsAction extends ActionSupport {
 		return favouriteNumbers;
 	}
 
+	@StrutsParameter
 	public void setFavouriteNumbers(List favouriteNumbers) {
 		this.favouriteNumbers = favouriteNumbers;
 	}
@@ -129,12 +132,13 @@ public class MoreSelectsAction extends ActionSupport {
 		return favouriteCities;
 	}
 
+	@StrutsParameter
 	public void setFavouriteCities(List favouriteCities) {
 		this.favouriteCities = favouriteCities;
 	}
 
 	// actions
-
+	@Override
 	public String input() throws Exception {
 		return SUCCESS;
 	}

--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/ShowAjaxDynamicTreeAction.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/ShowAjaxDynamicTreeAction.java
@@ -21,6 +21,7 @@
 package org.apache.struts2.showcase;
 
 import com.opensymphony.xwork2.ActionSupport;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 import org.apache.struts2.showcase.ajax.tree.Category;
 
 public class ShowAjaxDynamicTreeAction extends ActionSupport {
@@ -34,6 +35,7 @@ public class ShowAjaxDynamicTreeAction extends ActionSupport {
 		return nodeId;
 	}
 
+	@StrutsParameter
 	public void setNodeId(int nodeId) {
 		this.nodeId = nodeId;
 	}

--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/UITagExample.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/UITagExample.java
@@ -200,6 +200,7 @@ public class UITagExample extends ActionSupport implements Validateable {
 		return bestFriend;
 	}
 
+	@StrutsParameter
 	public void setBestFriend(String bestFriend) {
 		this.bestFriend = bestFriend;
 	}
@@ -231,6 +232,7 @@ public class UITagExample extends ActionSupport implements Validateable {
 		this.region = region;
 	}
 
+	@StrutsParameter
 	public void setPicture(File picture) {
 		this.picture = picture;
 	}
@@ -239,10 +241,12 @@ public class UITagExample extends ActionSupport implements Validateable {
 		return this.picture;
 	}
 
+	@StrutsParameter
 	public void setPictureContentType(String pictureContentType) {
 		this.pictureContentType = pictureContentType;
 	}
 
+	@StrutsParameter
 	public void setPictureFileName(String pictureFileName) {
 		this.pictureFileName = pictureFileName;
 	}
@@ -323,6 +327,7 @@ public class UITagExample extends ActionSupport implements Validateable {
 			return this.description;
 		}
 
+		@Override
 		public boolean equals(Object obj) {
 			if (!(obj instanceof VehicalType)) {
 				return false;
@@ -331,6 +336,7 @@ public class UITagExample extends ActionSupport implements Validateable {
 			}
 		}
 
+		@Override
 		public int hashCode() {
 			return key.hashCode();
 		}
@@ -354,6 +360,7 @@ public class UITagExample extends ActionSupport implements Validateable {
 			return this.description;
 		}
 
+		@Override
 		public boolean equals(Object obj) {
 			if (!(obj instanceof VehicalSpecific)) {
 				return false;
@@ -362,6 +369,7 @@ public class UITagExample extends ActionSupport implements Validateable {
 			}
 		}
 
+		@Override
 		public int hashCode() {
 			return key.hashCode();
 		}

--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/action/AbstractCRUDAction.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/action/AbstractCRUDAction.java
@@ -34,62 +34,62 @@ import java.util.Collection;
 
 public abstract class AbstractCRUDAction extends ActionSupport {
 
-	private static final Logger log = LogManager.getLogger(AbstractCRUDAction.class);
+    private static final Logger log = LogManager.getLogger(AbstractCRUDAction.class);
 
-	private Collection availableItems;
-	private String[] toDelete;
+    private Collection availableItems;
+    private String[] toDelete;
 
-	protected abstract Dao getDao();
+    protected abstract Dao getDao();
 
-	public Collection getAvailableItems() {
-		return availableItems;
-	}
+    public Collection getAvailableItems() {
+        return availableItems;
+    }
 
-	public String[] getToDelete() {
-		return toDelete;
-	}
+    public String[] getToDelete() {
+        return toDelete;
+    }
 
-	@StrutsParameter
-	public void setToDelete(String[] toDelete) {
-		this.toDelete = toDelete;
-	}
+    @StrutsParameter
+    public void setToDelete(String[] toDelete) {
+        this.toDelete = toDelete;
+    }
 
-	public String list() throws Exception {
-		this.availableItems = getDao().findAll();
-		if (log.isDebugEnabled()) {
-			log.debug("AbstractCRUDAction - [list]: " + (availableItems != null ? "" + availableItems.size() : "no") + " items found");
-		}
-		return execute();
-	}
+    public String list() throws Exception {
+        this.availableItems = getDao().findAll();
+        if (log.isDebugEnabled()) {
+            log.debug("AbstractCRUDAction - [list]: " + (availableItems != null ? "" + availableItems.size() : "no") + " items found");
+        }
+        return execute();
+    }
 
-	public String delete() throws Exception {
-		if (toDelete != null) {
-			int count = 0;
+    public String delete() throws Exception {
+        if (toDelete != null) {
+            int count = 0;
             for (String s : toDelete) {
                 count = count + getDao().delete(s);
             }
-			if (log.isDebugEnabled()) {
+            if (log.isDebugEnabled()) {
                 log.debug("AbstractCRUDAction - [delete]: {} items deleted.", count);
-			}
-		}
-		return SUCCESS;
-	}
+            }
+        }
+        return SUCCESS;
+    }
 
-	/**
-	 * Utility method for fetching already persistent object from storage for usage in params-prepare-params cycle.
-	 *
-	 * @param tryId     The id to try to get persistent object for
-	 * @param tryObject The object, induced by first params invocation, possibly containing id to try to get persistent
-	 *                  object for
-	 * @return The persistent object, if found. <tt>null</tt> otherwise.
-	 */
-	protected IdEntity fetch(Serializable tryId, IdEntity tryObject) {
-		IdEntity result = null;
-		if (tryId != null) {
-			result = getDao().get(tryId);
-		} else if (tryObject != null) {
-			result = getDao().get(tryObject.getId());
-		}
-		return result;
-	}
+    /**
+     * Utility method for fetching already persistent object from storage for usage in params-prepare-params cycle.
+     *
+     * @param tryId     The id to try to get persistent object for
+     * @param tryObject The object, induced by first params invocation, possibly containing id to try to get persistent
+     *                  object for
+     * @return The persistent object, if found. <tt>null</tt> otherwise.
+     */
+    protected IdEntity fetch(Serializable tryId, IdEntity tryObject) {
+        IdEntity result = null;
+        if (tryId != null) {
+            result = getDao().get(tryId);
+        } else if (tryObject != null) {
+            result = getDao().get(tryObject.getId());
+        }
+        return result;
+    }
 }

--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/action/AbstractCRUDAction.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/action/AbstractCRUDAction.java
@@ -21,6 +21,7 @@ package org.apache.struts2.showcase.action;
 import com.opensymphony.xwork2.ActionSupport;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 import org.apache.struts2.showcase.dao.Dao;
 import org.apache.struts2.showcase.model.IdEntity;
 
@@ -40,7 +41,6 @@ public abstract class AbstractCRUDAction extends ActionSupport {
 
 	protected abstract Dao getDao();
 
-
 	public Collection getAvailableItems() {
 		return availableItems;
 	}
@@ -49,6 +49,7 @@ public abstract class AbstractCRUDAction extends ActionSupport {
 		return toDelete;
 	}
 
+	@StrutsParameter
 	public void setToDelete(String[] toDelete) {
 		this.toDelete = toDelete;
 	}
@@ -64,11 +65,11 @@ public abstract class AbstractCRUDAction extends ActionSupport {
 	public String delete() throws Exception {
 		if (toDelete != null) {
 			int count = 0;
-			for (int i = 0, j = toDelete.length; i < j; i++) {
-				count = count + getDao().delete(toDelete[i]);
-			}
+            for (String s : toDelete) {
+                count = count + getDao().delete(s);
+            }
 			if (log.isDebugEnabled()) {
-				log.debug("AbstractCRUDAction - [delete]: " + count + " items deleted.");
+                log.debug("AbstractCRUDAction - [delete]: {} items deleted.", count);
 			}
 		}
 		return SUCCESS;

--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/action/EmployeeAction.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/action/EmployeeAction.java
@@ -21,6 +21,7 @@ package org.apache.struts2.showcase.action;
 import com.opensymphony.xwork2.Preparable;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 import org.apache.struts2.showcase.application.TestDataProvider;
 import org.apache.struts2.showcase.dao.Dao;
 import org.apache.struts2.showcase.dao.EmployeeDao;
@@ -52,7 +53,7 @@ public class EmployeeAction extends AbstractCRUDAction implements Preparable {
 
 	public String execute() throws Exception {
 		if (getCurrentEmployee() != null && getCurrentEmployee().getOtherSkills() != null) {
-			setSelectedSkills(new ArrayList<String>());
+			setSelectedSkills(new ArrayList<>());
 			Iterator it = getCurrentEmployee().getOtherSkills().iterator();
 			while (it.hasNext()) {
 				getSelectedSkills().add(((Skill) it.next()).getName());
@@ -73,10 +74,12 @@ public class EmployeeAction extends AbstractCRUDAction implements Preparable {
 		return empId;
 	}
 
+	@StrutsParameter
 	public void setEmpId(Long empId) {
 		this.empId = empId;
 	}
 
+	@StrutsParameter(depth = 2)
 	public Employee getCurrentEmployee() {
 		return currentEmployee;
 	}

--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/action/ExampleAction.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/action/ExampleAction.java
@@ -20,7 +20,11 @@ package org.apache.struts2.showcase.action;
 
 import com.opensymphony.xwork2.ActionSupport;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class ExampleAction extends ActionSupport {
 	public static final String CONSTANT = "Struts Rocks!";
@@ -46,7 +50,7 @@ public class ExampleAction extends ActionSupport {
 	}
 
 	public Map<String, Book> getBooks() {
-		Map<String, Book> books = new HashMap<String, Book>();
+		Map<String, Book> books = new HashMap<>();
 		books.put("Iliad", new Book("Iliad", "Homer"));
 		books.put("The Republic", new Book("The Replublic", "Plato"));
 		books.put("Thus Spake Zarathustra", new Book("Thus Spake Zarathustra",

--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/action/JSPEvalAction.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/action/JSPEvalAction.java
@@ -21,8 +21,13 @@ package org.apache.struts2.showcase.action;
 import com.opensymphony.xwork2.Action;
 import com.opensymphony.xwork2.interceptor.annotations.After;
 import org.apache.struts2.ServletActionContext;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
-import java.io.*;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.FileWriter;
+import java.io.IOException;
 import java.net.URL;
 
 /**
@@ -62,6 +67,7 @@ public class JSPEvalAction extends ExampleAction {
 		}
 	}
 
+	@StrutsParameter
 	public void setJsp(String jsp) {
 		this.jsp = jsp;
 	}

--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/action/SkillAction.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/action/SkillAction.java
@@ -46,6 +46,7 @@ public class SkillAction extends AbstractCRUDAction implements Preparable {
 	 *
 	 * @throws Exception thrown if a system level exception occurs.
 	 */
+	@Override
 	public void prepare() throws Exception {
 		Skill preFetched = (Skill) fetch(getSkillName(), getCurrentSkill());
 		if (preFetched != null) {
@@ -64,6 +65,7 @@ public class SkillAction extends AbstractCRUDAction implements Preparable {
 		return skillName;
 	}
 
+	@StrutsParameter
 	public void setSkillName(String skillName) {
 		this.skillName = skillName;
 	}

--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/actionchaining/ActionChain1.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/actionchaining/ActionChain1.java
@@ -19,6 +19,7 @@
 package org.apache.struts2.showcase.actionchaining;
 
 import com.opensymphony.xwork2.ActionSupport;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
 public class ActionChain1 extends ActionSupport {
 
@@ -26,6 +27,7 @@ public class ActionChain1 extends ActionSupport {
 
 	private String actionChain1Property1 = "Property Set In Action Chain 1";
 
+	@Override
 	public String input() throws Exception {
 		return SUCCESS;
 	}
@@ -34,6 +36,7 @@ public class ActionChain1 extends ActionSupport {
 		return actionChain1Property1;
 	}
 
+	@StrutsParameter
 	public void setActionChain1Property1(String actionChain1Property1) {
 		this.actionChain1Property1 = actionChain1Property1;
 	}

--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/actionchaining/ActionChain2.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/actionchaining/ActionChain2.java
@@ -19,6 +19,7 @@
 package org.apache.struts2.showcase.actionchaining;
 
 import com.opensymphony.xwork2.ActionSupport;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
 public class ActionChain2 extends ActionSupport {
 
@@ -27,6 +28,7 @@ public class ActionChain2 extends ActionSupport {
 	private String actionChain1Property1;
 	private String actionChain2Property1 = "Property Set in Action Chain 2";
 
+	@Override
 	public String execute() throws Exception {
 		return SUCCESS;
 	}
@@ -35,15 +37,16 @@ public class ActionChain2 extends ActionSupport {
 		return actionChain1Property1;
 	}
 
+	@StrutsParameter
 	public void setActionChain1Property1(String actionChain1Property1) {
 		this.actionChain1Property1 = actionChain1Property1;
 	}
-
 
 	public String getActionChain2Property1() {
 		return actionChain2Property1;
 	}
 
+	@StrutsParameter
 	public void setActionChain2Property1(String actionChain2Property1) {
 		this.actionChain2Property1 = actionChain2Property1;
 	}

--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/actionchaining/ActionChain3.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/actionchaining/ActionChain3.java
@@ -19,6 +19,7 @@
 package org.apache.struts2.showcase.actionchaining;
 
 import com.opensymphony.xwork2.ActionSupport;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
 public class ActionChain3 extends ActionSupport {
 
@@ -28,7 +29,7 @@ public class ActionChain3 extends ActionSupport {
 	private String actionChain2Property1;
 	private String actionChain3Property1 = "Property set in Action Chain 3";
 
-
+	@Override
 	public String execute() throws Exception {
 		return SUCCESS;
 	}
@@ -37,24 +38,25 @@ public class ActionChain3 extends ActionSupport {
 		return actionChain1Property1;
 	}
 
+	@StrutsParameter
 	public void setActionChain1Property1(String actionChain1Property1) {
 		this.actionChain1Property1 = actionChain1Property1;
 	}
-
 
 	public String getActionChain2Property1() {
 		return actionChain2Property1;
 	}
 
+	@StrutsParameter
 	public void setActionChain2Property1(String actionChain2Property1) {
 		this.actionChain2Property1 = actionChain2Property1;
 	}
-
 
 	public String getActionChain3Property1() {
 		return actionChain3Property1;
 	}
 
+	@StrutsParameter
 	public void setActionChain3Property1(String actionChain3Property1) {
 		this.actionChain3Property1 = actionChain3Property1;
 	}

--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/ajax/AjaxTestAction.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/ajax/AjaxTestAction.java
@@ -21,9 +21,9 @@
 package org.apache.struts2.showcase.ajax;
 
 import com.opensymphony.xwork2.Action;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
 import java.io.Serializable;
-
 
 public class AjaxTestAction implements Action, Serializable {
 
@@ -46,6 +46,7 @@ public class AjaxTestAction implements Action, Serializable {
 		return data;
 	}
 
+	@StrutsParameter
 	public void setData(String data) {
 		this.data = data;
 	}

--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/ajax/AutocompleterExampleAction.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/ajax/AutocompleterExampleAction.java
@@ -21,16 +21,18 @@
 package org.apache.struts2.showcase.ajax;
 
 import com.opensymphony.xwork2.ActionSupport;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public class AutocompleterExampleAction extends ActionSupport {
 	private String select;
-	private List<String> options = new ArrayList<String>();
+	private final List<String> options = new ArrayList<>();
 
 	private static final long serialVersionUID = -8481638176160014396L;
 
+	@Override
 	public String execute() throws Exception {
 		if ("fruits".equals(select)) {
 			options.add("apple");
@@ -49,6 +51,7 @@ public class AutocompleterExampleAction extends ActionSupport {
 		return select;
 	}
 
+	@StrutsParameter
 	public void setSelect(String select) {
 		this.select = select;
 	}

--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/ajax/Example4ShowPanelAction.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/ajax/Example4ShowPanelAction.java
@@ -21,6 +21,7 @@
 package org.apache.struts2.showcase.ajax;
 
 import com.opensymphony.xwork2.ActionSupport;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -51,6 +52,7 @@ public class Example4ShowPanelAction extends ActionSupport {
 		return gender;
 	}
 
+	@StrutsParameter
 	public void setGender(String gender) {
 		this.gender = gender;
 	}
@@ -59,6 +61,7 @@ public class Example4ShowPanelAction extends ActionSupport {
 		return name;
 	}
 
+	@StrutsParameter
 	public void setName(String name) {
 		this.name = name;
 	}

--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/ajax/Example5Action.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/ajax/Example5Action.java
@@ -21,6 +21,7 @@
 package org.apache.struts2.showcase.ajax;
 
 import com.opensymphony.xwork2.ActionSupport;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
 public class Example5Action extends ActionSupport {
 
@@ -37,6 +38,7 @@ public class Example5Action extends ActionSupport {
 		return name;
 	}
 
+	@StrutsParameter
 	public void setName(String name) {
 		this.name = name;
 	}
@@ -45,6 +47,7 @@ public class Example5Action extends ActionSupport {
 		return age;
 	}
 
+	@StrutsParameter
 	public void setAge(Integer age) {
 		this.age = age;
 	}

--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/ajax/tree/GetCategory.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/ajax/tree/GetCategory.java
@@ -21,6 +21,7 @@
 package org.apache.struts2.showcase.ajax.tree;
 
 import com.opensymphony.xwork2.ActionSupport;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
 /**
  */
@@ -28,6 +29,7 @@ public class GetCategory extends ActionSupport {
 	private long catId;
 	private Category category;
 
+	@Override
 	public String execute() throws Exception {
 		if (catId < 1) {
 			// force the root
@@ -39,6 +41,7 @@ public class GetCategory extends ActionSupport {
 		return SUCCESS;
 	}
 
+	@StrutsParameter
 	public void setCatId(long catId) {
 		this.catId = catId;
 	}

--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/ajax/tree/Toggle.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/ajax/tree/Toggle.java
@@ -24,6 +24,8 @@ package org.apache.struts2.showcase.ajax.tree;
 /**
  */
 public class Toggle extends GetCategory {
+
+	@Override
 	public String execute() throws Exception {
 		super.execute();
 

--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/async/ChatRoomAction.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/async/ChatRoomAction.java
@@ -50,15 +50,12 @@ public class ChatRoomAction extends ActionSupport {
     }
 
     public Callable<String> receiveNewMessages() throws Exception {
-        return new Callable<String>() {
-            @Override
-            public String call() throws Exception {
-                while (lastIndex >= messages.size()) {
-                    Thread.sleep(3000);
-                }
-                newMessages = messages.subList(lastIndex, messages.size());
-                return SUCCESS;
+        return () -> {
+            while (lastIndex >= messages.size()) {
+                Thread.sleep(3000);
             }
+            newMessages = messages.subList(lastIndex, messages.size());
+            return SUCCESS;
         };
     }
 

--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/chat/ChatLoginAction.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/chat/ChatLoginAction.java
@@ -21,10 +21,10 @@
 package org.apache.struts2.showcase.chat;
 
 import com.opensymphony.xwork2.ActionSupport;
+import org.apache.struts2.action.SessionAware;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
 import java.util.Map;
-
-import org.apache.struts2.action.SessionAware;
 
 public class ChatLoginAction extends ActionSupport implements SessionAware {
 
@@ -43,6 +43,7 @@ public class ChatLoginAction extends ActionSupport implements SessionAware {
 		return this.name;
 	}
 
+	@StrutsParameter
 	public void setName(String name) {
 		this.name = name;
 	}

--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/chat/CrudRoomAction.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/chat/CrudRoomAction.java
@@ -21,6 +21,7 @@
 package org.apache.struts2.showcase.chat;
 
 import com.opensymphony.xwork2.ActionSupport;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
 public class CrudRoomAction extends ActionSupport {
 
@@ -36,6 +37,7 @@ public class CrudRoomAction extends ActionSupport {
 		return description;
 	}
 
+	@StrutsParameter
 	public void setDescription(String description) {
 		this.description = description;
 	}
@@ -44,6 +46,7 @@ public class CrudRoomAction extends ActionSupport {
 		return name;
 	}
 
+	@StrutsParameter
 	public void setName(String name) {
 		this.name = name;
 	}

--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/chat/EnterRoomAction.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/chat/EnterRoomAction.java
@@ -21,10 +21,10 @@
 package org.apache.struts2.showcase.chat;
 
 import com.opensymphony.xwork2.ActionSupport;
+import org.apache.struts2.action.SessionAware;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
 import java.util.Map;
-
-import org.apache.struts2.action.SessionAware;
 
 public class EnterRoomAction extends ActionSupport implements SessionAware {
 
@@ -38,6 +38,7 @@ public class EnterRoomAction extends ActionSupport implements SessionAware {
 		return this.roomName;
 	}
 
+	@StrutsParameter
 	public void setRoomName(String roomName) {
 		this.roomName = roomName;
 	}

--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/chat/ExitRoomAction.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/chat/ExitRoomAction.java
@@ -21,10 +21,10 @@
 package org.apache.struts2.showcase.chat;
 
 import com.opensymphony.xwork2.ActionSupport;
+import org.apache.struts2.action.SessionAware;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
 import java.util.Map;
-
-import org.apache.struts2.action.SessionAware;
 
 public class ExitRoomAction extends ActionSupport implements SessionAware {
 
@@ -38,6 +38,7 @@ public class ExitRoomAction extends ActionSupport implements SessionAware {
 		return roomName;
 	}
 
+	@StrutsParameter
 	public void setRoomName(String roomName) {
 		this.roomName = roomName;
 	}

--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/chat/MessagesAvailableInRoomAction.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/chat/MessagesAvailableInRoomAction.java
@@ -21,6 +21,7 @@
 package org.apache.struts2.showcase.chat;
 
 import com.opensymphony.xwork2.ActionSupport;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -30,13 +31,14 @@ public class MessagesAvailableInRoomAction extends ActionSupport {
 	private static final long serialVersionUID = 1L;
 
 	private String roomName;
-	private ChatService chatService;
-	private List<ChatMessage> messagesAvailableInRoom = new ArrayList<ChatMessage>();
+	private final ChatService chatService;
+	private List<ChatMessage> messagesAvailableInRoom = new ArrayList<>();
 
 	public String getRoomName() {
 		return this.roomName;
 	}
 
+	@StrutsParameter
 	public void setRoomName(String roomName) {
 		this.roomName = roomName;
 	}

--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/chat/SendMessageToRoomAction.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/chat/SendMessageToRoomAction.java
@@ -21,16 +21,16 @@
 package org.apache.struts2.showcase.chat;
 
 import com.opensymphony.xwork2.ActionSupport;
+import org.apache.struts2.action.SessionAware;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
 import java.util.Map;
-
-import org.apache.struts2.action.SessionAware;
 
 public class SendMessageToRoomAction extends ActionSupport implements SessionAware {
 
 	private static final long serialVersionUID = 1L;
 
-	private ChatService chatService;
+	private final ChatService chatService;
 
 	private String roomName;
 	private String message;
@@ -45,6 +45,7 @@ public class SendMessageToRoomAction extends ActionSupport implements SessionAwa
 		return this.roomName;
 	}
 
+	@StrutsParameter
 	public void setRoomName(String roomName) {
 		this.roomName = roomName;
 	}
@@ -53,11 +54,12 @@ public class SendMessageToRoomAction extends ActionSupport implements SessionAwa
 		return this.message;
 	}
 
+	@StrutsParameter
 	public void setMessage(String message) {
 		this.message = message;
 	}
 
-
+	@Override
 	public String execute() throws Exception {
 		User user = (User) session.get(ChatAuthenticationInterceptor.USER_SESSION_KEY);
 		try {

--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/chat/UsersAvailableInRoomAction.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/chat/UsersAvailableInRoomAction.java
@@ -21,6 +21,7 @@
 package org.apache.struts2.showcase.chat;
 
 import com.opensymphony.xwork2.ActionSupport;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -29,8 +30,8 @@ public class UsersAvailableInRoomAction extends ActionSupport {
 
 	private static final long serialVersionUID = 1L;
 
-	private ChatService chatService;
-	private List<User> usersAvailableInRoom = new ArrayList<User>();
+	private final ChatService chatService;
+	private List<User> usersAvailableInRoom = new ArrayList<>();
 
 	private String roomName;
 
@@ -43,6 +44,7 @@ public class UsersAvailableInRoomAction extends ActionSupport {
 		return this.roomName;
 	}
 
+	@StrutsParameter
 	public void setRoomName(String roomName) {
 		this.roomName = roomName;
 	}
@@ -51,6 +53,7 @@ public class UsersAvailableInRoomAction extends ActionSupport {
 		return usersAvailableInRoom;
 	}
 
+	@Override
 	public String execute() throws Exception {
 		try {
 			usersAvailableInRoom = chatService.getUsersAvailableInRoom(roomName);

--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/conversion/OperationsEnumAction.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/conversion/OperationsEnumAction.java
@@ -34,7 +34,7 @@ public class OperationsEnumAction extends ActionSupport {
 
 	private static final long serialVersionUID = -2229489704988870318L;
 
-	private List<OperationsEnum> selectedOperations = new LinkedList<OperationsEnum>();
+	private List<OperationsEnum> selectedOperations = new LinkedList<>();
 
 	public String input() throws Exception {
 		return SUCCESS;
@@ -52,7 +52,6 @@ public class OperationsEnumAction extends ActionSupport {
 	public void setSelectedOperations(List<OperationsEnum> selectedOperations) {
 		this.selectedOperations = selectedOperations;
 	}
-
 
 	public List<OperationsEnum> getAvailableOperations() {
 		return Arrays.asList(OperationsEnum.values());

--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/fileupload/MultipleFileUploadUsingArrayAction.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/fileupload/MultipleFileUploadUsingArrayAction.java
@@ -28,11 +28,15 @@ import org.apache.struts2.dispatcher.multipart.UploadedFile;
 import java.util.List;
 
 /**
- * Showcase action - mutiple file upload using array.
+ * Showcase action - multiple file upload using array.
  */
 public class MultipleFileUploadUsingArrayAction extends ActionSupport implements UploadedFilesAware {
 
     private List<UploadedFile> uploadedFiles;
+
+    public List<UploadedFile> getUpload() {
+        return this.uploadedFiles;
+    }
 
     public String upload() throws Exception {
         System.out.println("\n\n upload2");

--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/freemarker/StandardTagsAction.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/freemarker/StandardTagsAction.java
@@ -22,6 +22,7 @@ package org.apache.struts2.showcase.freemarker;
 
 import com.opensymphony.xwork2.ActionSupport;
 import com.opensymphony.xwork2.Preparable;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
 import java.text.DateFormatSymbols;
 
@@ -34,6 +35,7 @@ public class StandardTagsAction extends ActionSupport implements Preparable {
 	private String[] gender;
 	private String[] months;
 
+	@Override
 	public void prepare() {
 		months = new DateFormatSymbols().getMonths();
 		name = StandardTagsAction.class.getName().substring(StandardTagsAction.class.getName().lastIndexOf(".") + 1);
@@ -44,6 +46,7 @@ public class StandardTagsAction extends ActionSupport implements Preparable {
 		return name;
 	}
 
+	@StrutsParameter
 	public void setName(String name) {
 		this.name = name;
 	}
@@ -52,15 +55,16 @@ public class StandardTagsAction extends ActionSupport implements Preparable {
 		return months;
 	}
 
+	@StrutsParameter
 	public void setMonths(String[] months) {
 		this.months = months;
 	}
-
 
 	public String[] getGender() {
 		return gender;
 	}
 
+	@StrutsParameter
 	public void setGender(String[] gender) {
 		this.gender = gender;
 	}

--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/hangman/GuessCharacterAction.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/hangman/GuessCharacterAction.java
@@ -21,10 +21,10 @@
 package org.apache.struts2.showcase.hangman;
 
 import com.opensymphony.xwork2.ActionSupport;
+import org.apache.struts2.action.SessionAware;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
 import java.util.Map;
-
-import org.apache.struts2.action.SessionAware;
 
 public class GuessCharacterAction extends ActionSupport implements SessionAware {
 
@@ -34,6 +34,7 @@ public class GuessCharacterAction extends ActionSupport implements SessionAware 
 	private Character character;
 	private Hangman hangman;
 
+	@Override
 	public String execute() throws Exception {
 		hangman = (Hangman) session.get(HangmanConstants.HANGMAN_SESSION_KEY);
 		hangman.guess(character);
@@ -45,6 +46,7 @@ public class GuessCharacterAction extends ActionSupport implements SessionAware 
 		return hangman;
 	}
 
+	@StrutsParameter
 	public void setCharacter(Character character) {
 		this.character = character;
 	}

--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/modelDriven/ModelDrivenAction.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/modelDriven/ModelDrivenAction.java
@@ -30,14 +30,17 @@ public class ModelDrivenAction extends ActionSupport implements ModelDriven {
 
 	private static final long serialVersionUID = 1271130427666936592L;
 
+	@Override
 	public String input() throws Exception {
 		return SUCCESS;
 	}
 
+	@Override
 	public String execute() throws Exception {
 		return SUCCESS;
 	}
 
+	@Override
 	public Object getModel() {
 		return new Gangster();
 	}

--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/modelDriven/ModelDrivenAction.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/modelDriven/ModelDrivenAction.java
@@ -22,6 +22,7 @@ package org.apache.struts2.showcase.modelDriven;
 
 import com.opensymphony.xwork2.ActionSupport;
 import com.opensymphony.xwork2.ModelDriven;
+import org.apache.struts2.showcase.modelDriven.model.Gangster;
 
 /**
  * Action to demonstrate simple model-driven feature of the framework.

--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/modelDriven/model/Gangster.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/modelDriven/model/Gangster.java
@@ -18,7 +18,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.struts2.showcase.modelDriven;
+package org.apache.struts2.showcase.modelDriven.model;
 
 import java.io.Serializable;
 

--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/person/EditPersonAction.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/person/EditPersonAction.java
@@ -23,10 +23,10 @@ package org.apache.struts2.showcase.person;
 import com.opensymphony.xwork2.ActionSupport;
 import org.apache.struts2.convention.annotation.Result;
 import org.apache.struts2.convention.annotation.Results;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -42,13 +42,14 @@ public class EditPersonAction extends ActionSupport {
 
 	@Autowired
 	private PersonManager personManager;
-	private List<Person> persons = new ArrayList<Person>();
+	private List<Person> persons = new ArrayList<>();
 
 	/**
 	 * A default implementation that does nothing an returns "success".
 	 *
 	 * @return {@link #INPUT}
 	 */
+	@Override
 	public String execute() throws Exception {
 		persons.addAll(personManager.getPeople());
 		return INPUT;
@@ -68,6 +69,7 @@ public class EditPersonAction extends ActionSupport {
 		return "list";
 	}
 
+	@StrutsParameter(depth = 2)
 	public List<Person> getPersons() {
 		return persons;
 	}

--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/person/ListPeopleAction.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/person/ListPeopleAction.java
@@ -35,8 +35,9 @@ public class ListPeopleAction extends ActionSupport {
 	@Autowired
 	private PersonManager personManager;
 
-	private List<Person> people = new ArrayList<Person>();
+	private final List<Person> people = new ArrayList<>();
 
+	@Override
 	public String execute() {
 		people.addAll(personManager.getPeople());
 

--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/person/NewPersonAction.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/person/NewPersonAction.java
@@ -23,6 +23,7 @@ package org.apache.struts2.showcase.person;
 import com.opensymphony.xwork2.ActionSupport;
 import org.apache.struts2.convention.annotation.Result;
 import org.apache.struts2.convention.annotation.Results;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 import org.springframework.beans.factory.annotation.Autowired;
 
 
@@ -38,12 +39,14 @@ public class NewPersonAction extends ActionSupport {
 	private PersonManager personManager;
 	private Person person;
 
+	@Override
 	public String execute() {
 		personManager.createPerson(person);
 
 		return "list";
 	}
 
+	@StrutsParameter(depth = 1)
 	public Person getPerson() {
 		return person;
 	}

--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/source/ViewSourceAction.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/source/ViewSourceAction.java
@@ -23,6 +23,7 @@ package org.apache.struts2.showcase.source;
 import com.opensymphony.xwork2.ActionSupport;
 import com.opensymphony.xwork2.util.ClassLoaderUtil;
 import org.apache.struts2.action.ServletContextAware;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
 import javax.servlet.ServletContext;
 import java.io.BufferedReader;
@@ -98,8 +99,9 @@ public class ViewSourceAction extends ActionSupport implements ServletContextAwa
     /**
      * @param className the className to set
      */
+    @StrutsParameter
     public void setClassName(String className) {
-        if (className != null && className.trim().length() > 0) {
+        if (className != null && !className.trim().isEmpty()) {
             this.className = className;
         }
     }
@@ -107,8 +109,9 @@ public class ViewSourceAction extends ActionSupport implements ServletContextAwa
     /**
      * @param config the config to set
      */
+    @StrutsParameter
     public void setConfig(String config) {
-        if (config != null && config.trim().length() > 0) {
+        if (config != null && !config.trim().isEmpty()) {
             this.config = config;
         }
     }
@@ -116,8 +119,9 @@ public class ViewSourceAction extends ActionSupport implements ServletContextAwa
     /**
      * @param page the page to set
      */
+    @StrutsParameter
     public void setPage(String page) {
-        if (page != null && page.trim().length() > 0) {
+        if (page != null && !page.trim().isEmpty()) {
             this.page = page;
         }
     }
@@ -125,6 +129,7 @@ public class ViewSourceAction extends ActionSupport implements ServletContextAwa
     /**
      * @param padding the padding to set
      */
+    @StrutsParameter
     public void setPadding(int padding) {
         this.padding = padding;
     }
@@ -222,6 +227,7 @@ public class ViewSourceAction extends ActionSupport implements ServletContextAwa
         return snippet;
     }
 
+    @Override
     public void withServletContext(ServletContext arg0) {
         this.servletContext = arg0;
     }

--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/tag/nonui/actionPrefix/SubmitAction.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/tag/nonui/actionPrefix/SubmitAction.java
@@ -21,6 +21,7 @@
 package org.apache.struts2.showcase.tag.nonui.actionPrefix;
 
 import com.opensymphony.xwork2.ActionSupport;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
 public class SubmitAction extends ActionSupport {
 
@@ -32,10 +33,12 @@ public class SubmitAction extends ActionSupport {
 		return text;
 	}
 
+	@StrutsParameter
 	public void setText(String text) {
 		this.text = text;
 	}
 
+	@Override
 	public String execute() throws Exception {
 		return SUCCESS;
 	}

--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/tag/nonui/debugtag/DebugTagAction.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/tag/nonui/debugtag/DebugTagAction.java
@@ -23,6 +23,7 @@ import org.apache.struts2.dispatcher.PrepareOperations;
 
 public class DebugTagAction extends ActionSupport {
 
+    @Override
     public String execute() throws Exception {
         PrepareOperations.overrideDevMode(true); // Just for Showcase, explicitly switch on for this action only
         return SUCCESS;

--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/tag/nonui/iteratortag/AppendIteratorTagDemo.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/tag/nonui/iteratortag/AppendIteratorTagDemo.java
@@ -22,6 +22,7 @@ package org.apache.struts2.showcase.tag.nonui.iteratortag;
 
 import com.opensymphony.xwork2.ActionSupport;
 import com.opensymphony.xwork2.Validateable;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
 /**
  *
@@ -47,25 +48,25 @@ public class AppendIteratorTagDemo extends ActionSupport implements Validateable
 		}
 	}
 
-
 	public String getIteratorValue1() {
 		return iteratorValue1;
 	}
 
+	@StrutsParameter
 	public void setIteratorValue1(String iteratorValue1) {
 		this.iteratorValue1 = iteratorValue1;
 	}
-
 
 	public String getIteratorValue2() {
 		return iteratorValue2;
 	}
 
+	@StrutsParameter
 	public void setIteratorValue2(String iteratorValue2) {
 		this.iteratorValue2 = iteratorValue2;
 	}
 
-
+	@Override
 	public String input() throws Exception {
 		return SUCCESS;
 	}

--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/tag/nonui/iteratortag/IteratorGeneratorTagDemo.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/tag/nonui/iteratortag/IteratorGeneratorTagDemo.java
@@ -21,6 +21,7 @@
 package org.apache.struts2.showcase.tag.nonui.iteratortag;
 
 import com.opensymphony.xwork2.ActionSupport;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
 /**
  */
@@ -37,34 +38,34 @@ public class IteratorGeneratorTagDemo extends ActionSupport {
 		return value;
 	}
 
+	@StrutsParameter
 	public void setValue(String value) {
 		this.value = value;
 	}
-
 
 	public Integer getCount() {
 		return count;
 	}
 
+	@StrutsParameter
 	public void setCount(Integer count) {
 		this.count = count;
 	}
-
 
 	public String getSeparator() {
 		return this.separator;
 	}
 
+	@StrutsParameter
 	public void setSeparator(String separator) {
 		this.separator = separator;
 	}
-
 
 	public String submit() throws Exception {
 		return SUCCESS;
 	}
 
-
+	@Override
 	public String input() throws Exception {
 		return SUCCESS;
 	}

--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/tag/nonui/iteratortag/MergeIteratorTagDemo.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/tag/nonui/iteratortag/MergeIteratorTagDemo.java
@@ -22,6 +22,7 @@ package org.apache.struts2.showcase.tag.nonui.iteratortag;
 
 import com.opensymphony.xwork2.ActionSupport;
 import com.opensymphony.xwork2.Validateable;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
 
 /**
@@ -33,7 +34,7 @@ public class MergeIteratorTagDemo extends ActionSupport implements Validateable 
 	private String iteratorValue1;
 	private String iteratorValue2;
 
-
+	@Override
 	public void validate() {
 		if (iteratorValue1 == null || iteratorValue1.trim().length() <= 0) {
 			addFieldError("iteratorValue1", "iterator value 1 cannot be empty");
@@ -47,25 +48,25 @@ public class MergeIteratorTagDemo extends ActionSupport implements Validateable 
 		}
 	}
 
-
 	public String getIteratorValue1() {
 		return this.iteratorValue1;
 	}
 
+	@StrutsParameter
 	public void setIteratorValue1(String iteratorValue1) {
 		this.iteratorValue1 = iteratorValue1;
 	}
-
 
 	public String getIteratorValue2() {
 		return this.iteratorValue2;
 	}
 
+	@StrutsParameter
 	public void setIteratorValue2(String iteratorValue2) {
 		this.iteratorValue2 = iteratorValue2;
 	}
 
-
+	@Override
 	public String input() throws Exception {
 		return SUCCESS;
 	}

--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/tag/nonui/iteratortag/SubsetIteratorTagDemo.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/tag/nonui/iteratortag/SubsetIteratorTagDemo.java
@@ -22,6 +22,7 @@ package org.apache.struts2.showcase.tag.nonui.iteratortag;
 
 import com.opensymphony.xwork2.ActionSupport;
 import com.opensymphony.xwork2.Validateable;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
 /**
  *
@@ -34,7 +35,7 @@ public class SubsetIteratorTagDemo extends ActionSupport implements Validateable
 	private Integer count;
 	private Integer start;
 
-
+	@Override
 	public void validate() {
 		if (iteratorValue == null || iteratorValue.trim().length() <= 0) {
 			addFieldError("iteratorValue1", "iterator value 1 cannot be empty");
@@ -43,34 +44,34 @@ public class SubsetIteratorTagDemo extends ActionSupport implements Validateable
 		}
 	}
 
-
 	public String getIteratorValue() {
 		return this.iteratorValue;
 	}
 
+	@StrutsParameter
 	public void setIteratorValue(String iteratorValue) {
 		this.iteratorValue = iteratorValue;
 	}
-
 
 	public Integer getCount() {
 		return this.count;
 	}
 
+	@StrutsParameter
 	public void setCount(Integer count) {
 		this.count = count;
 	}
-
 
 	public Integer getStart() {
 		return this.start;
 	}
 
+	@StrutsParameter
 	public void setStart(Integer start) {
 		this.start = start;
 	}
 
-
+	@Override
 	public String input() throws Exception {
 		return SUCCESS;
 	}
@@ -78,6 +79,4 @@ public class SubsetIteratorTagDemo extends ActionSupport implements Validateable
 	public String submit() throws Exception {
 		return SUCCESS;
 	}
-
-
 }

--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/token/TokenAction.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/token/TokenAction.java
@@ -22,6 +22,7 @@ package org.apache.struts2.showcase.token;
 
 import com.opensymphony.xwork2.ActionContext;
 import com.opensymphony.xwork2.ActionSupport;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
 import java.util.Date;
 
@@ -76,6 +77,7 @@ public class TokenAction extends ActionSupport {
 		return amount;
 	}
 
+	@StrutsParameter
 	public void setAmount(int amount) {
 		this.amount = amount;
 	}

--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/validation/AbstractValidationActionSupport.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/validation/AbstractValidationActionSupport.java
@@ -30,6 +30,7 @@ public abstract class AbstractValidationActionSupport extends ActionSupport {
 		return "success";
 	}
 
+	@Override
 	public String input() throws Exception {
 		return "input";
 	}

--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/validation/AjaxFormSubmitAction.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/validation/AjaxFormSubmitAction.java
@@ -18,8 +18,6 @@
  */
 package org.apache.struts2.showcase.validation;
 
-import java.sql.Date;
-
 import com.opensymphony.xwork2.validator.annotations.DateRangeFieldValidator;
 import com.opensymphony.xwork2.validator.annotations.EmailValidator;
 import com.opensymphony.xwork2.validator.annotations.FieldExpressionValidator;
@@ -29,6 +27,9 @@ import com.opensymphony.xwork2.validator.annotations.RequiredFieldValidator;
 import com.opensymphony.xwork2.validator.annotations.RequiredStringValidator;
 import com.opensymphony.xwork2.validator.annotations.StringLengthFieldValidator;
 import com.opensymphony.xwork2.validator.annotations.UrlValidator;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
+
+import java.sql.Date;
 
 /**
  * <!-- START SNIPPET: ajaxFormSubmit -->
@@ -72,9 +73,10 @@ public class AjaxFormSubmitAction extends AbstractValidationActionSupport {
     }
 
     @DateRangeFieldValidator(
-        min="01/01/1990", 
-        max="01/01/2000", 
+        min="01/01/1990",
+        max="01/01/2000",
         message="must be a min 01-01-1990 max 01-01-2000 if supplied")
+    @StrutsParameter
     public void setDateValidatorField(Date dateValidatorField) {
         this.dateValidatorField = dateValidatorField;
     }
@@ -84,6 +86,7 @@ public class AjaxFormSubmitAction extends AbstractValidationActionSupport {
     }
 
     @EmailValidator(message="must be a valid email if supplied")
+    @StrutsParameter
     public void setEmailValidatorField(String emailValidatorField) {
         this.emailValidatorField = emailValidatorField;
     }
@@ -93,6 +96,7 @@ public class AjaxFormSubmitAction extends AbstractValidationActionSupport {
     }
 
     @IntRangeFieldValidator(min="1", max="10", message="must be integer min 1 max 10 if supplied")
+    @StrutsParameter
     public void setIntegerValidatorField(Integer integerValidatorField) {
         this.integerValidatorField = integerValidatorField;
     }
@@ -102,8 +106,9 @@ public class AjaxFormSubmitAction extends AbstractValidationActionSupport {
     }
 
     @RegexFieldValidator(
-        regex="[^<>]+", 
+        regex="[^<>]+",
         message="regexValidatorField must match a regexp (.*\\.txt) if specified")
+    @StrutsParameter
     public void setRegexValidatorField(String regexValidatorField) {
         this.regexValidatorField = regexValidatorField;
     }
@@ -113,6 +118,7 @@ public class AjaxFormSubmitAction extends AbstractValidationActionSupport {
     }
 
     @RequiredStringValidator(trim=true, message="required and must be string")
+    @StrutsParameter
     public void setRequiredStringValidatorField(String requiredStringValidatorField) {
         this.requiredStringValidatorField = requiredStringValidatorField;
     }
@@ -122,6 +128,7 @@ public class AjaxFormSubmitAction extends AbstractValidationActionSupport {
     }
 
     @RequiredFieldValidator(message="required")
+    @StrutsParameter
     public void setRequiredValidatorField(String requiredValidatorField) {
         this.requiredValidatorField = requiredValidatorField;
     }
@@ -131,10 +138,11 @@ public class AjaxFormSubmitAction extends AbstractValidationActionSupport {
     }
 
     @StringLengthFieldValidator(
-        minLength="2", 
-        maxLength="4", 
-        trim=true, 
+        minLength="2",
+        maxLength="4",
+        trim=true,
         message="must be a String of a specific greater than 1 less than 5 if specified")
+    @StrutsParameter
     public void setStringLengthValidatorField(String stringLengthValidatorField) {
         this.stringLengthValidatorField = stringLengthValidatorField;
     }
@@ -144,10 +152,10 @@ public class AjaxFormSubmitAction extends AbstractValidationActionSupport {
     }
 
 	@FieldExpressionValidator(
-        expression = "(fieldExpressionValidatorField == requiredValidatorField)", 
+        expression = "(fieldExpressionValidatorField == requiredValidatorField)",
         message = "must be the same as the Required Validator Field if specified")
-    public void setFieldExpressionValidatorField(
-            String fieldExpressionValidatorField) {
+    @StrutsParameter
+    public void setFieldExpressionValidatorField(String fieldExpressionValidatorField) {
         this.fieldExpressionValidatorField = fieldExpressionValidatorField;
     }
 
@@ -156,6 +164,7 @@ public class AjaxFormSubmitAction extends AbstractValidationActionSupport {
     }
 
     @UrlValidator(message="must be a valid url if supplied")
+    @StrutsParameter
     public void setUrlValidatorField(String urlValidatorField) {
         this.urlValidatorField = urlValidatorField;
     }

--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/validation/BeanValidationExampleAction.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/validation/BeanValidationExampleAction.java
@@ -26,6 +26,7 @@ import org.apache.struts2.convention.annotation.Action;
 import org.apache.struts2.convention.annotation.Namespace;
 import org.apache.struts2.convention.annotation.ParentPackage;
 import org.apache.struts2.convention.annotation.Result;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 import org.apache.struts2.interceptor.validation.SkipValidation;
 import org.hibernate.validator.constraints.ScriptAssert;
 import org.hibernate.validator.constraints.URL;
@@ -95,6 +96,7 @@ public class BeanValidationExampleAction extends ActionSupport {
         return dateValidatorField;
     }
 
+    @StrutsParameter
     public void setDateValidatorField(Date dateValidatorField) {
         this.dateValidatorField = dateValidatorField;
     }
@@ -103,6 +105,7 @@ public class BeanValidationExampleAction extends ActionSupport {
         return emailValidatorField;
     }
 
+    @StrutsParameter
     public void setEmailValidatorField(String emailValidatorField) {
         this.emailValidatorField = emailValidatorField;
     }
@@ -111,6 +114,7 @@ public class BeanValidationExampleAction extends ActionSupport {
         return integerValidatorField;
     }
 
+    @StrutsParameter
     public void setIntegerValidatorField(Integer integerValidatorField) {
         this.integerValidatorField = integerValidatorField;
     }
@@ -119,6 +123,7 @@ public class BeanValidationExampleAction extends ActionSupport {
         return regexValidatorField;
     }
 
+    @StrutsParameter
     public void setRegexValidatorField(String regexValidatorField) {
         this.regexValidatorField = regexValidatorField;
     }
@@ -127,6 +132,7 @@ public class BeanValidationExampleAction extends ActionSupport {
         return requiredStringValidatorField;
     }
 
+    @StrutsParameter
     public void setRequiredStringValidatorField(String requiredStringValidatorField) {
         this.requiredStringValidatorField = requiredStringValidatorField;
     }
@@ -135,6 +141,7 @@ public class BeanValidationExampleAction extends ActionSupport {
         return requiredValidatorField;
     }
 
+    @StrutsParameter
     public void setRequiredValidatorField(String requiredValidatorField) {
         this.requiredValidatorField = requiredValidatorField;
     }
@@ -143,6 +150,7 @@ public class BeanValidationExampleAction extends ActionSupport {
         return stringLengthValidatorField;
     }
 
+    @StrutsParameter
     public void setStringLengthValidatorField(String stringLengthValidatorField) {
         this.stringLengthValidatorField = stringLengthValidatorField;
     }
@@ -151,8 +159,8 @@ public class BeanValidationExampleAction extends ActionSupport {
         return fieldExpressionValidatorField;
     }
 
-    public void setFieldExpressionValidatorField(
-        String fieldExpressionValidatorField) {
+    @StrutsParameter
+    public void setFieldExpressionValidatorField(String fieldExpressionValidatorField) {
         this.fieldExpressionValidatorField = fieldExpressionValidatorField;
     }
 
@@ -160,6 +168,7 @@ public class BeanValidationExampleAction extends ActionSupport {
         return urlValidatorField;
     }
 
+    @StrutsParameter
     public void setUrlValidatorField(String urlValidatorField) {
         this.urlValidatorField = urlValidatorField;
     }

--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/validation/NonFieldValidatorsExampleAction.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/validation/NonFieldValidatorsExampleAction.java
@@ -20,6 +20,8 @@
  */
 package org.apache.struts2.showcase.validation;
 
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
+
 /**
  */
 
@@ -37,6 +39,7 @@ public class NonFieldValidatorsExampleAction extends AbstractValidationActionSup
 		return someText;
 	}
 
+	@StrutsParameter
 	public void setSomeText(String someText) {
 		this.someText = someText;
 	}
@@ -45,6 +48,7 @@ public class NonFieldValidatorsExampleAction extends AbstractValidationActionSup
 		return someTextRetype;
 	}
 
+	@StrutsParameter
 	public void setSomeTextRetype(String someTextRetype) {
 		this.someTextRetype = someTextRetype;
 	}
@@ -53,6 +57,7 @@ public class NonFieldValidatorsExampleAction extends AbstractValidationActionSup
 		return someTextRetypeAgain;
 	}
 
+	@StrutsParameter
 	public void setSomeTextRetypeAgain(String someTextRetypeAgain) {
 		this.someTextRetypeAgain = someTextRetypeAgain;
 	}

--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/validation/QuizAction.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/validation/QuizAction.java
@@ -21,6 +21,7 @@
 package org.apache.struts2.showcase.validation;
 
 import com.opensymphony.xwork2.ActionSupport;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
 /**
  */
@@ -39,6 +40,7 @@ public class QuizAction extends ActionSupport {
 		return name;
 	}
 
+	@StrutsParameter
 	public void setName(String name) {
 		this.name = name;
 	}
@@ -47,6 +49,7 @@ public class QuizAction extends ActionSupport {
 		return age;
 	}
 
+	@StrutsParameter
 	public void setAge(int age) {
 		this.age = age;
 	}
@@ -55,6 +58,7 @@ public class QuizAction extends ActionSupport {
 		return answer;
 	}
 
+	@StrutsParameter
 	public void setAnswer(String answer) {
 		this.answer = answer;
 	}

--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/validation/SubmitApplication.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/validation/SubmitApplication.java
@@ -21,6 +21,7 @@
 package org.apache.struts2.showcase.validation;
 
 import com.opensymphony.xwork2.ActionSupport;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
 /**
  * @version $Date$ $Id$
@@ -30,6 +31,7 @@ public class SubmitApplication extends ActionSupport {
 	private String name;
 	private Integer age;
 
+	@StrutsParameter
 	public void setName(String name) {
 		this.name = name;
 	}
@@ -38,6 +40,7 @@ public class SubmitApplication extends ActionSupport {
 		return this.name;
 	}
 
+	@StrutsParameter
 	public void setAge(Integer age) {
 		this.age = age;
 	}

--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/validation/VisitorValidatorsExampleAction.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/validation/VisitorValidatorsExampleAction.java
@@ -23,12 +23,15 @@ package org.apache.struts2.showcase.validation;
 
 // START SNIPPET: visitorValidatorsExample
 
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
+
 public class VisitorValidatorsExampleAction extends AbstractValidationActionSupport {
 
 	private static final long serialVersionUID = 4375454086939598216L;
 
 	private User user;
 
+	@StrutsParameter(depth = 1)
 	public User getUser() {
 		return user;
 	}

--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/xslt/JVMAction.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/xslt/JVMAction.java
@@ -21,11 +21,9 @@
 package org.apache.struts2.showcase.xslt;
 
 import com.opensymphony.xwork2.ActionSupport;
-
-import javax.servlet.http.HttpServletRequest;
-
 import org.apache.struts2.action.ServletRequestAware;
 
+import javax.servlet.http.HttpServletRequest;
 import java.util.Map;
 import java.util.Properties;
 
@@ -72,7 +70,7 @@ public class JVMAction implements ServletRequestAware {
 		this.info = info;
 	}
 
-	public class ImportantInfo {
+	public static class ImportantInfo {
 		private String classpath;
 		private Properties systemProperties;
 

--- a/apps/showcase/src/main/resources/struts-fileupload.xml
+++ b/apps/showcase/src/main/resources/struts-fileupload.xml
@@ -40,7 +40,7 @@
 		</action>
 
 		<action name="doMultipleUploadUsingList" class="org.apache.struts2.showcase.fileupload.MultipleFileUploadUsingListAction" method="upload">
-                        <result name="input">/WEB-INF/fileupload/multipleUploadUsingList.jsp</result>
+			<result name="input">/WEB-INF/fileupload/multipleUploadUsingList.jsp</result>
 			<result>/WEB-INF/fileupload/multiple-success.jsp</result>
 		</action>
 
@@ -50,7 +50,7 @@
 		</action>
 
 		<action name="doMultipleUploadUsingArray" class="org.apache.struts2.showcase.fileupload.MultipleFileUploadUsingArrayAction" method="upload">
-                        <result name="input">/WEB-INF/fileupload/multipleUploadUsingArray.jsp</result>
+			<result name="input">/WEB-INF/fileupload/multipleUploadUsingArray.jsp</result>
 			<result>/WEB-INF/fileupload/multiple-success.jsp</result>
 		</action>
 

--- a/apps/showcase/src/main/resources/struts.xml
+++ b/apps/showcase/src/main/resources/struts.xml
@@ -36,6 +36,15 @@
 
     <constant name="struts.allowlist.enable" value="true" />
     <constant name="struts.parameters.requireAnnotations" value="true" />
+    <constant name="struts.allowlist.packageNames" value="
+            org.apache.struts2.showcase.model,
+            org.apache.struts2.showcase.modelDriven.model
+    "/>
+    <constant name="struts.allowlist.classes" value="
+            org.apache.struts2.showcase.hangman.Hangman,
+            org.apache.struts2.showcase.hangman.HangmanConstants,
+            org.apache.struts2.showcase.hangman.Vocab
+    "/>
 
     <constant name="struts.convention.package.locators.basePackage" value="org.apache.struts2.showcase" />
     <constant name="struts.convention.result.path" value="/WEB-INF" />

--- a/apps/showcase/src/test/java/it/org/apache/struts2/showcase/ConventionTest.java
+++ b/apps/showcase/src/test/java/it/org/apache/struts2/showcase/ConventionTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package it.org.apache.struts2.showcase;
+
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.html.HtmlForm;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import com.gargoylesoftware.htmlunit.html.HtmlSubmitInput;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ConventionTest {
+
+    private WebClient webClient;
+
+    @Before
+    public void setUp() throws Exception {
+        webClient = new WebClient();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        webClient.close();
+    }
+
+    @Test
+    public void listPeople() throws Exception {
+        HtmlPage page = webClient.getPage(ParameterUtils.getBaseUrl() + "/person/list-people.action");
+
+        assertThat(page.asNormalizedText()).contains(
+                "3\tAlexandru\tPapesco\n" +
+                "4\tJay\tBoss\n" +
+                "5\tRainer\tHermanos\n"
+        );
+    }
+
+    @Test
+    public void editPeople() throws Exception {
+        HtmlPage page = webClient.getPage(ParameterUtils.getBaseUrl() + "/person/edit-person.action");
+        HtmlForm form = page.getForms().get(0);
+
+        form.getInputByName("persons(1).name").setValue("Lukasz");
+        form.getInputByName("persons(1).lastName").setValue("Lenart");
+        form.getInputByName("persons(2).name").setValue("Kusal");
+        form.getInputByName("persons(2).lastName").setValue("Kithul-Godage");
+
+        HtmlSubmitInput button = form.getInputByValue("Save all persons");
+        page = button.click();
+
+        assertThat(page.asNormalizedText()).contains(
+                "1\tLukasz\tLenart\n" +
+                "2\tKusal\tKithul-Godage\n"
+        );
+    }
+
+    @Test
+    public void createPerson() throws Exception {
+        HtmlPage page = webClient.getPage(ParameterUtils.getBaseUrl() + "/person/new-person!input.action");
+        HtmlForm form = page.getForms().get(0);
+
+        form.getInputByName("person.name").type("Lukasz");
+        form.getInputByName("person.lastName").type("Lenart");
+
+        HtmlSubmitInput button = form.getInputByValue("Create person");
+        page = button.click();
+
+        assertThat(page.asNormalizedText()).contains("6\tLukasz\tLenart\n");
+    }
+}

--- a/bundles/admin/src/main/java/org/apache/struts2/osgi/admin/actions/BundlesAction.java
+++ b/bundles/admin/src/main/java/org/apache/struts2/osgi/admin/actions/BundlesAction.java
@@ -25,10 +25,11 @@ import com.opensymphony.xwork2.ActionSupport;
 import com.opensymphony.xwork2.config.Configuration;
 import com.opensymphony.xwork2.config.entities.PackageConfig;
 import com.opensymphony.xwork2.inject.Inject;
-import org.apache.struts2.osgi.BundleAccessor;
-import org.apache.struts2.osgi.host.OsgiHost;
-import org.apache.struts2.osgi.StrutsOsgiListener;
 import org.apache.struts2.action.ServletContextAware;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
+import org.apache.struts2.osgi.BundleAccessor;
+import org.apache.struts2.osgi.StrutsOsgiListener;
+import org.apache.struts2.osgi.host.OsgiHost;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleException;
 
@@ -36,9 +37,8 @@ import javax.servlet.ServletContext;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.List;
 import java.util.Collections;
-import java.util.Comparator;
+import java.util.List;
 
 public class BundlesAction extends ActionSupport implements ServletContextAware {
 
@@ -114,6 +114,7 @@ public class BundlesAction extends ActionSupport implements ServletContextAware 
         return id;
     }
 
+    @StrutsParameter
     public void setId(String id) {
         this.id = id;
     }

--- a/bundles/admin/src/main/java/org/apache/struts2/osgi/admin/actions/ShellAction.java
+++ b/bundles/admin/src/main/java/org/apache/struts2/osgi/admin/actions/ShellAction.java
@@ -21,25 +21,25 @@
 
 package org.apache.struts2.osgi.admin.actions;
 
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
-
+import com.opensymphony.xwork2.Action;
+import com.opensymphony.xwork2.ActionSupport;
 import org.apache.felix.shell.ShellService;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 import org.apache.struts2.osgi.DefaultBundleAccessor;
 import org.apache.struts2.osgi.interceptor.BundleContextAware;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
 
-import com.opensymphony.xwork2.Action;
-import com.opensymphony.xwork2.ActionSupport;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
 
 /**
  * This action executes commands on the Felix Shell.
- * 
+ *
  * The action is BundleContextAware so that if the OSGi interceptor is used the BundleContext
  * can be provided for configurations where the DefaultBundleAccessor is insufficient.
- * 
+ *
  */
 public class ShellAction extends ActionSupport implements BundleContextAware {
     private String command;
@@ -77,6 +77,7 @@ public class ShellAction extends ActionSupport implements BundleContextAware {
         return command;
     }
 
+    @StrutsParameter
     public void setCommand(String command) {
         this.command = command;
     }

--- a/bundles/demo/src/main/java/actions/osgi/BundlesAction.java
+++ b/bundles/demo/src/main/java/actions/osgi/BundlesAction.java
@@ -33,6 +33,7 @@ import org.osgi.framework.BundleContext;
 public class BundlesAction extends ActionSupport implements BundleContextAware {
     private BundleContext bundleContext;
 
+    @Override
     public void withBundleContext(BundleContext bundleContext) {
         this.bundleContext = bundleContext;
     }

--- a/bundles/demo/src/main/java/actions/osgi/HelloWorldAction.java
+++ b/bundles/demo/src/main/java/actions/osgi/HelloWorldAction.java
@@ -26,6 +26,7 @@ import org.apache.struts2.convention.annotation.Actions;
 import org.apache.struts2.convention.annotation.Namespace;
 import org.apache.struts2.convention.annotation.Result;
 import org.apache.struts2.convention.annotation.ResultPath;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
 @Namespace("/osgi")
 @ResultPath("/content/osgi")
@@ -41,6 +42,7 @@ public class HelloWorldAction extends ActionSupport {
         return SUCCESS;
     }
 
+    @StrutsParameter(depth = 1)
     public Message getMessage() {
         return message;
     }

--- a/core/src/main/java/com/opensymphony/xwork2/ValidationAwareSupport.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ValidationAwareSupport.java
@@ -21,7 +21,12 @@ package com.opensymphony.xwork2;
 import com.opensymphony.xwork2.interceptor.ValidationAware;
 
 import java.io.Serializable;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Provides a default implementation of ValidationAware. Returns new collections for
@@ -72,13 +77,7 @@ public class ValidationAwareSupport implements ValidationAware, Serializable {
 
     public synchronized void addFieldError(String fieldName, String errorMessage) {
         final Map<String, List<String>> errors = internalGetFieldErrors();
-        List<String> thisFieldErrors = errors.get(fieldName);
-
-        if (thisFieldErrors == null) {
-            thisFieldErrors = new ArrayList<>();
-            errors.put(fieldName, thisFieldErrors);
-        }
-
+        List<String> thisFieldErrors = errors.computeIfAbsent(fieldName, k -> new ArrayList<>());
         thisFieldErrors.add(errorMessage);
     }
 

--- a/core/src/main/java/com/opensymphony/xwork2/config/ConfigurationUtil.java
+++ b/core/src/main/java/com/opensymphony/xwork2/config/ConfigurationUtil.java
@@ -19,18 +19,21 @@
 package com.opensymphony.xwork2.config;
 
 import com.opensymphony.xwork2.config.entities.PackageConfig;
+import org.apache.commons.lang3.ClassUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.StringTokenizer;
 
 /**
  * ConfigurationUtil
- * 
+ *
  * @author Jason Carreira Created May 23, 2003 11:22:49 PM
  */
 public class ConfigurationUtil {
@@ -82,5 +85,13 @@ public class ConfigurationUtil {
         }
 
         return parents;
+    }
+
+    public static Set<Class<?>> getAllClassTypes(Class<?> clazz) {
+        HashSet<Class<?>> classes = new HashSet<>();
+        classes.add(clazz);
+        classes.addAll(ClassUtils.getAllSuperclasses(clazz));
+        classes.addAll(ClassUtils.getAllInterfaces(clazz));
+        return classes;
     }
 }

--- a/core/src/main/java/com/opensymphony/xwork2/config/providers/XmlDocConfigurationProvider.java
+++ b/core/src/main/java/com/opensymphony/xwork2/config/providers/XmlDocConfigurationProvider.java
@@ -45,7 +45,6 @@ import com.opensymphony.xwork2.util.location.LocatableProperties;
 import com.opensymphony.xwork2.util.location.Location;
 import com.opensymphony.xwork2.util.location.LocationUtils;
 import org.apache.commons.lang3.BooleanUtils;
-import org.apache.commons.lang3.ClassUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -149,9 +148,7 @@ public abstract class XmlDocConfigurationProvider implements ConfigurationProvid
 
     protected Class<?> allowAndLoadClass(String className) throws ClassNotFoundException {
         Class<?> clazz = loadClass(className);
-        allowlistClasses.add(clazz);
-        allowlistClasses.addAll(ClassUtils.getAllSuperclasses(clazz));
-        allowlistClasses.addAll(ClassUtils.getAllInterfaces(clazz));
+        allowlistClasses.addAll(ConfigurationUtil.getAllClassTypes(clazz));
         return clazz;
     }
 

--- a/core/src/main/java/com/opensymphony/xwork2/interceptor/annotations/Allowed.java
+++ b/core/src/main/java/com/opensymphony/xwork2/interceptor/annotations/Allowed.java
@@ -28,9 +28,11 @@ import java.lang.annotation.Target;
  * a HttpRequest parameter.
  *
  * @author martin.gilday
+ * @deprecated since 6.6.0, use {@link org.apache.struts2.interceptor.parameter.StrutsParameter}.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)
+@Deprecated
 public @interface Allowed {
 
 }

--- a/core/src/main/java/com/opensymphony/xwork2/interceptor/annotations/AnnotationParameterFilterInterceptor.java
+++ b/core/src/main/java/com/opensymphony/xwork2/interceptor/annotations/AnnotationParameterFilterInterceptor.java
@@ -23,13 +23,13 @@ import com.opensymphony.xwork2.ActionInvocation;
 import com.opensymphony.xwork2.interceptor.AbstractInterceptor;
 import com.opensymphony.xwork2.interceptor.Interceptor;
 import com.opensymphony.xwork2.interceptor.ParameterFilterInterceptor;
-import com.opensymphony.xwork2.interceptor.ParametersInterceptor;
 import com.opensymphony.xwork2.util.AnnotationUtils;
 import org.apache.struts2.dispatcher.HttpParameters;
+import org.apache.struts2.interceptor.parameter.ParametersInterceptor;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
 import java.lang.reflect.Field;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 
 /**
@@ -46,7 +46,10 @@ import java.util.List;
  * </p>
  *
  * @author martin.gilday
+ * @deprecated since 6.6.0, integrated into {@link ParametersInterceptor} with {@link StrutsParameter} using
+ * {@code struts.parameters.requireAnnotations=true}
  */
+@Deprecated
 public class AnnotationParameterFilterInterceptor extends AbstractInterceptor {
 
     /* (non-Javadoc)

--- a/core/src/main/java/com/opensymphony/xwork2/interceptor/annotations/BlockByDefault.java
+++ b/core/src/main/java/com/opensymphony/xwork2/interceptor/annotations/BlockByDefault.java
@@ -31,9 +31,11 @@ import java.lang.annotation.Target;
  * To allow access to a field it must be annotated with {@link Allowed}
  *
  * @author martin.gilday
+ * @deprecated since 6.6.0, use {@code struts.parameters.requireAnnotations=true} to block all parameters globally.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
+@Deprecated
 public @interface BlockByDefault {
 
 }

--- a/core/src/main/java/com/opensymphony/xwork2/interceptor/annotations/Blocked.java
+++ b/core/src/main/java/com/opensymphony/xwork2/interceptor/annotations/Blocked.java
@@ -28,9 +28,11 @@ import java.lang.annotation.Target;
  * a HttpRequest parameter.
  *
  * @author martin.gilday
+ * @deprecated since 6.6.0, use {@code struts.parameters.requireAnnotations=true} to block all parameters globally.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)
+@Deprecated
 public @interface Blocked {
 
 }

--- a/core/src/main/java/org/apache/struts2/dispatcher/DefaultActionSupport.java
+++ b/core/src/main/java/org/apache/struts2/dispatcher/DefaultActionSupport.java
@@ -18,11 +18,11 @@
  */
 package org.apache.struts2.dispatcher;
 
-import javax.servlet.http.HttpServletRequest;
-
-import org.apache.struts2.ServletActionContext;
-
 import com.opensymphony.xwork2.ActionSupport;
+import org.apache.struts2.ServletActionContext;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
+
+import javax.servlet.http.HttpServletRequest;
 
 /**
  * A simple action support class that sets properties to be able to serve
@@ -44,6 +44,7 @@ public class DefaultActionSupport extends ActionSupport {
     /* (non-Javadoc)
      * @see com.opensymphony.xwork2.ActionSupport#execute()
      */
+    @Override
     public String execute() throws Exception {
         HttpServletRequest request = ServletActionContext.getRequest();
         String requestedUrl = request.getPathInfo();
@@ -61,9 +62,8 @@ public class DefaultActionSupport extends ActionSupport {
     /**
      * @param successResultValue The successResultValue to set.
      */
+    @StrutsParameter
     public void setSuccessResultValue(String successResultValue) {
         this.successResultValue = successResultValue;
     }
-
-
 }

--- a/core/src/main/java/org/apache/struts2/ognl/ProviderAllowlist.java
+++ b/core/src/main/java/org/apache/struts2/ognl/ProviderAllowlist.java
@@ -28,13 +28,14 @@ import java.util.Set;
 import static java.util.Collections.unmodifiableSet;
 
 /**
- * Allows {@link ConfigurationProvider}s to register classes that should be allowed to be used in OGNL expressions.
+ * Allows registration of classes that should be allowed to be used in OGNL expressions, using a key to identify the
+ * source of the allowlist.
  *
  * @since 6.4.0
  */
 public class ProviderAllowlist {
 
-    private final Map<ConfigurationProvider, Set<Class<?>>> allowlistMap;
+    private final Map<Object, Set<Class<?>>> allowlistMap;
     private Set<Class<?>> allowlistClasses;
 
     public ProviderAllowlist() {
@@ -42,22 +43,38 @@ public class ProviderAllowlist {
         reconstructAllowlist();
     }
 
-    public synchronized void registerAllowlist(ConfigurationProvider configurationProvider, Set<Class<?>> allowlist) {
-        Set<Class<?>> existingAllowlist = allowlistMap.get(configurationProvider);
+    public synchronized void registerAllowlist(Object key, Set<Class<?>> allowlist) {
+        Set<Class<?>> existingAllowlist = allowlistMap.get(key);
         if (existingAllowlist != null) {
-            clearAllowlist(configurationProvider);
+            clearAllowlist(key);
         }
-        this.allowlistMap.put(configurationProvider, new HashSet<>(allowlist));
+        this.allowlistMap.put(key, new HashSet<>(allowlist));
         this.allowlistClasses.addAll(allowlist);
     }
 
-    public synchronized void clearAllowlist(ConfigurationProvider configurationProvider) {
-        Set<Class<?>> allowlist = allowlistMap.get(configurationProvider);
+    /**
+     * @deprecated since 6.6.0, use {@link #registerAllowlist(Object, Set)}
+     */
+    @Deprecated
+    public synchronized void registerAllowlist(ConfigurationProvider configurationProvider, Set<Class<?>> allowlist) {
+        registerAllowlist((Object) configurationProvider, allowlist);
+    }
+
+    public synchronized void clearAllowlist(Object key) {
+        Set<Class<?>> allowlist = allowlistMap.get(key);
         if (allowlist == null) {
             return;
         }
-        this.allowlistMap.remove(configurationProvider);
+        this.allowlistMap.remove(key);
         reconstructAllowlist();
+    }
+
+    /**
+     * @deprecated since 6.6.0, use {@link #clearAllowlist(Object)}
+     */
+    @Deprecated
+    public synchronized void clearAllowlist(ConfigurationProvider configurationProvider) {
+        clearAllowlist((Object) configurationProvider);
     }
 
     public Set<Class<?>> getProviderAllowlist() {

--- a/core/src/test/java/com/opensymphony/xwork2/ActionSupportTest.java
+++ b/core/src/test/java/com/opensymphony/xwork2/ActionSupportTest.java
@@ -20,8 +20,12 @@ package com.opensymphony.xwork2;
 
 import com.opensymphony.xwork2.conversion.impl.ConversionData;
 import com.opensymphony.xwork2.util.ValueStack;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.ResourceBundle;
 
 /**
  * Unit test for {@link ActionSupport}.
@@ -334,6 +338,7 @@ public class ActionSupportTest extends XWorkTestCase {
             return val;
         }
 
+        @StrutsParameter
         public void setVal(Double val) {
             this.val = val;
         }

--- a/core/src/test/java/com/opensymphony/xwork2/ModelDrivenAction.java
+++ b/core/src/test/java/com/opensymphony/xwork2/ModelDrivenAction.java
@@ -19,6 +19,8 @@
 package com.opensymphony.xwork2;
 
 
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
+
 /**
  * ModelDrivenAction
  *
@@ -28,9 +30,9 @@ package com.opensymphony.xwork2;
 public class ModelDrivenAction extends ActionSupport implements ModelDriven {
 
     private String foo;
-    private TestBean model = new TestBean();
+    private final TestBean model = new TestBean();
 
-
+    @StrutsParameter
     public void setFoo(String foo) {
         this.foo = foo;
     }
@@ -42,6 +44,8 @@ public class ModelDrivenAction extends ActionSupport implements ModelDriven {
     /**
      * @return the model to be pushed onto the ValueStack after the Action itself
      */
+    @StrutsParameter(depth = 2)
+    @Override
     public Object getModel() {
         return model;
     }

--- a/core/src/test/java/com/opensymphony/xwork2/ModelDrivenAnnotationAction.java
+++ b/core/src/test/java/com/opensymphony/xwork2/ModelDrivenAnnotationAction.java
@@ -18,6 +18,8 @@
  */
 package com.opensymphony.xwork2;
 
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
+
 /**
  * ModelDrivenAnnotationAction
  *
@@ -28,9 +30,9 @@ package com.opensymphony.xwork2;
 public class ModelDrivenAnnotationAction extends ActionSupport implements ModelDriven {
 
     private String foo;
-    private AnnotatedTestBean model = new AnnotatedTestBean();
+    private final AnnotatedTestBean model = new AnnotatedTestBean();
 
-
+    @StrutsParameter
     public void setFoo(String foo) {
         this.foo = foo;
     }
@@ -42,6 +44,8 @@ public class ModelDrivenAnnotationAction extends ActionSupport implements ModelD
     /**
      * @return the model to be pushed onto the ValueStack after the Action itself
      */
+    @StrutsParameter(depth = 2)
+    @Override
     public Object getModel() {
         return model;
     }

--- a/core/src/test/java/com/opensymphony/xwork2/ProxyInvocationAction.java
+++ b/core/src/test/java/com/opensymphony/xwork2/ProxyInvocationAction.java
@@ -22,6 +22,8 @@ package com.opensymphony.xwork2;
  * Need by the ProxyInvocationTest
  */
 public class ProxyInvocationAction extends ActionSupport implements ProxyInvocationInterface {
+
+    @Override
     public String show() {
         return "proxyResult";
     }

--- a/core/src/test/java/com/opensymphony/xwork2/SimpleAction.java
+++ b/core/src/test/java/com/opensymphony/xwork2/SimpleAction.java
@@ -21,7 +21,12 @@ package com.opensymphony.xwork2;
 import com.opensymphony.xwork2.config.Configuration;
 import com.opensymphony.xwork2.inject.Inject;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
 
 
 /**
@@ -56,7 +61,7 @@ public class SimpleAction extends ActionSupport {
     private Map<String, String> existingMap = new HashMap<>();
 
     private List<TestBean> beanList;
-    
+
     public static boolean resultCalled;
 
 
@@ -64,11 +69,11 @@ public class SimpleAction extends ActionSupport {
         resultCalled = false;
         existingMap.put("existingKey", "value");
     }
-    
+
     public Map<String,String> getTheProtectedMap() {
         return protectedMap;
     }
-    
+
     protected Map<String,String> getTheSemiProtectedMap() {
         return protectedMap;
     }
@@ -80,7 +85,6 @@ public class SimpleAction extends ActionSupport {
     public Map<String,String> getTheExistingMap() {
         return existingMap;
     }
-
 
     public void setBar(int bar) {
         this.bar = bar;
@@ -187,15 +191,15 @@ public class SimpleAction extends ActionSupport {
     public ArrayList<String> getSomeList() {
         return someList;
     }
-    
+
     public String getIndexedProp(int index) {
     	return indexedProps.get(index);
     }
-    
+
     public void setIndexedProp(int index, String val) {
     	indexedProps.put(index, val);
     }
-    
+
 
     public void setThrowException(boolean   throwException) {
         this.throwException = throwException;
@@ -204,7 +208,7 @@ public class SimpleAction extends ActionSupport {
     public String commandMethod() throws Exception {
         return COMMAND_RETURN_CODE;
     }
-    
+
     public Result resultAction() throws Exception {
     	return new Result() {
             public Configuration configuration;
@@ -217,7 +221,7 @@ public class SimpleAction extends ActionSupport {
                 if (configuration != null)
                     resultCalled = true;
             }
-    	    
+
     	};
     }
 
@@ -251,7 +255,7 @@ public class SimpleAction extends ActionSupport {
 
         return SUCCESS;
     }
-    
+
     public long getLongFoo() {
         return longFoo;
     }

--- a/core/src/test/java/com/opensymphony/xwork2/SimpleAnnotationAction.java
+++ b/core/src/test/java/com/opensymphony/xwork2/SimpleAnnotationAction.java
@@ -18,7 +18,18 @@
  */
 package com.opensymphony.xwork2;
 
-import com.opensymphony.xwork2.validator.annotations.*;
+import com.opensymphony.xwork2.validator.annotations.DateRangeFieldValidator;
+import com.opensymphony.xwork2.validator.annotations.DoubleRangeFieldValidator;
+import com.opensymphony.xwork2.validator.annotations.EmailValidator;
+import com.opensymphony.xwork2.validator.annotations.ExpressionValidator;
+import com.opensymphony.xwork2.validator.annotations.IntRangeFieldValidator;
+import com.opensymphony.xwork2.validator.annotations.RequiredFieldValidator;
+import com.opensymphony.xwork2.validator.annotations.RequiredStringValidator;
+import com.opensymphony.xwork2.validator.annotations.StringLengthFieldValidator;
+import com.opensymphony.xwork2.validator.annotations.UrlValidator;
+import com.opensymphony.xwork2.validator.annotations.Validations;
+import com.opensymphony.xwork2.validator.annotations.ValidatorType;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
 import java.util.ArrayList;
 import java.util.Date;
@@ -49,8 +60,6 @@ public class SimpleAnnotationAction extends ActionSupport {
 
     private String aliasSource;
     private String aliasDest;
-    
-    
 
     //~ Constructors ///////////////////////////////////////////////////////////
 
@@ -61,6 +70,7 @@ public class SimpleAnnotationAction extends ActionSupport {
 
     @RequiredFieldValidator(type = ValidatorType.FIELD, message = "You must enter a value for bar.")
     @IntRangeFieldValidator(type = ValidatorType.FIELD, min = "6", max = "10", message = "bar must be between ${min} and ${max}, current value is ${bar}.")
+    @StrutsParameter
     public void setBar(int bar) {
         this.bar = bar;
     }
@@ -70,6 +80,7 @@ public class SimpleAnnotationAction extends ActionSupport {
     }
 
     @IntRangeFieldValidator(min = "0", key = "baz.range", message = "Could not find baz.range!")
+    @StrutsParameter
     public void setBaz(int baz) {
         this.baz = baz;
     }
@@ -83,6 +94,7 @@ public class SimpleAnnotationAction extends ActionSupport {
     }
 
     @DoubleRangeFieldValidator(minInclusive = "0.123", key = "baz.range", message = "Could not find percentage.range!")
+    @StrutsParameter
     public void setPercentage(double percentage) {
         this.percentage = percentage;
     }
@@ -91,10 +103,12 @@ public class SimpleAnnotationAction extends ActionSupport {
         this.bean = bean;
     }
 
+    @StrutsParameter(depth = 2)
     public AnnotatedTestBean getBean() {
         return bean;
     }
 
+    @StrutsParameter
     public void setBlah(String blah) {
         this.blah = blah;
     }
@@ -112,6 +126,7 @@ public class SimpleAnnotationAction extends ActionSupport {
     }
 
     @DateRangeFieldValidator(min = "12/22/2002", max = "12/25/2002", message = "The date must be between 12-22-2002 and 12-25-2002.")
+    @StrutsParameter
     public void setDate(Date date) {
         this.date = date;
     }
@@ -120,6 +135,7 @@ public class SimpleAnnotationAction extends ActionSupport {
         return date;
     }
 
+    @StrutsParameter
     public void setFoo(int foo) {
         this.foo = foo;
     }
@@ -128,6 +144,7 @@ public class SimpleAnnotationAction extends ActionSupport {
         return foo;
     }
 
+    @StrutsParameter
     public void setName(String name) {
         this.name = name;
     }
@@ -140,15 +157,16 @@ public class SimpleAnnotationAction extends ActionSupport {
         this.settings = settings;
     }
 
+    @StrutsParameter(depth = 1)
     public Properties getSettings() {
         return settings;
     }
-
 
     public String getAliasDest() {
         return aliasDest;
     }
 
+    @StrutsParameter
     public void setAliasDest(String aliasDest) {
         this.aliasDest = aliasDest;
     }
@@ -157,11 +175,12 @@ public class SimpleAnnotationAction extends ActionSupport {
         return aliasSource;
     }
 
+    @StrutsParameter
     public void setAliasSource(String aliasSource) {
         this.aliasSource = aliasSource;
     }
 
-    
+    @StrutsParameter
     public void setSomeList(ArrayList<String> someList) {
         this.someList = someList;
     }
@@ -170,6 +189,7 @@ public class SimpleAnnotationAction extends ActionSupport {
         return someList;
     }
 
+    @StrutsParameter
     public void setThrowException(boolean throwException) {
         this.throwException = throwException;
     }
@@ -186,7 +206,6 @@ public class SimpleAnnotationAction extends ActionSupport {
         return "OK";
     }
 
-    @Override
     @Validations(
             requiredFields =
                     {@RequiredFieldValidator(type = ValidatorType.SIMPLE, fieldName = "customfield", message = "You must enter a value for field.")},
@@ -210,6 +229,7 @@ public class SimpleAnnotationAction extends ActionSupport {
                 @ExpressionValidator(expression = "foo &gt; 5", message = "Foo must be greater than Bar 5. Foo = ${foo}, Bar = ${bar}.")
     }
     )
+    @Override
     public String execute() throws Exception {
         if (foo == bar) {
             return ERROR;

--- a/core/src/test/java/com/opensymphony/xwork2/ValidationOrderAction.java
+++ b/core/src/test/java/com/opensymphony/xwork2/ValidationOrderAction.java
@@ -18,14 +18,16 @@
  */
 package com.opensymphony.xwork2;
 
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
+
 /**
  * A sample action to test validation order.
- * 
+ *
  * @author tm_jee
  * @version $Date$ $Id$
  */
 public class ValidationOrderAction extends ActionSupport {
-	
+
 	private String username;
 	private String password;
 	private String confirmPassword;
@@ -38,9 +40,9 @@ public class ValidationOrderAction extends ActionSupport {
 	private String email;
 	private String website;
 	private String passwordHint;
-	
-	
-	
+
+
+
 	@Override
     public String execute() throws Exception {
 		return SUCCESS;
@@ -53,7 +55,7 @@ public class ValidationOrderAction extends ActionSupport {
 	}
 
 
-
+	@StrutsParameter
 	public void setCity(String city) {
 		this.city = city;
 	}
@@ -65,7 +67,7 @@ public class ValidationOrderAction extends ActionSupport {
 	}
 
 
-
+	@StrutsParameter
 	public void setConfirmPassword(String confirmPassword) {
 		this.confirmPassword = confirmPassword;
 	}
@@ -77,7 +79,7 @@ public class ValidationOrderAction extends ActionSupport {
 	}
 
 
-
+	@StrutsParameter
 	public void setCountry(String country) {
 		this.country = country;
 	}
@@ -89,7 +91,7 @@ public class ValidationOrderAction extends ActionSupport {
 	}
 
 
-
+	@StrutsParameter
 	public void setEmail(String email) {
 		this.email = email;
 	}
@@ -101,7 +103,7 @@ public class ValidationOrderAction extends ActionSupport {
 	}
 
 
-
+	@StrutsParameter
 	public void setFirstName(String firstName) {
 		this.firstName = firstName;
 	}
@@ -113,7 +115,7 @@ public class ValidationOrderAction extends ActionSupport {
 	}
 
 
-
+	@StrutsParameter
 	public void setLastName(String lastName) {
 		this.lastName = lastName;
 	}
@@ -125,7 +127,7 @@ public class ValidationOrderAction extends ActionSupport {
 	}
 
 
-
+	@StrutsParameter
 	public void setPassword(String password) {
 		this.password = password;
 	}
@@ -137,7 +139,7 @@ public class ValidationOrderAction extends ActionSupport {
 	}
 
 
-
+	@StrutsParameter
 	public void setPasswordHint(String passwordHint) {
 		this.passwordHint = passwordHint;
 	}
@@ -149,7 +151,7 @@ public class ValidationOrderAction extends ActionSupport {
 	}
 
 
-
+	@StrutsParameter
 	public void setPostalCode(String postalCode) {
 		this.postalCode = postalCode;
 	}
@@ -161,7 +163,7 @@ public class ValidationOrderAction extends ActionSupport {
 	}
 
 
-
+	@StrutsParameter
 	public void setProvince(String province) {
 		this.province = province;
 	}
@@ -173,7 +175,7 @@ public class ValidationOrderAction extends ActionSupport {
 	}
 
 
-
+	@StrutsParameter
 	public void setUsername(String username) {
 		this.username = username;
 	}
@@ -185,7 +187,7 @@ public class ValidationOrderAction extends ActionSupport {
 	}
 
 
-
+	@StrutsParameter
 	public void setWebsite(String website) {
 		this.website = website;
 	}

--- a/core/src/test/java/com/opensymphony/xwork2/interceptor/ModelDrivenInterceptorTest.java
+++ b/core/src/test/java/com/opensymphony/xwork2/interceptor/ModelDrivenInterceptorTest.java
@@ -20,7 +20,12 @@ package com.opensymphony.xwork2.interceptor;
 
 import com.mockobjects.dynamic.ConstraintMatcher;
 import com.mockobjects.dynamic.Mock;
-import com.opensymphony.xwork2.*;
+import com.opensymphony.xwork2.Action;
+import com.opensymphony.xwork2.ActionContext;
+import com.opensymphony.xwork2.ActionInvocation;
+import com.opensymphony.xwork2.ActionSupport;
+import com.opensymphony.xwork2.ModelDriven;
+import com.opensymphony.xwork2.XWorkTestCase;
 import com.opensymphony.xwork2.util.ValueStack;
 
 import java.util.Date;
@@ -175,6 +180,7 @@ public class ModelDrivenInterceptorTest extends XWorkTestCase {
 
     public class ModelDrivenAction extends ActionSupport implements ModelDriven {
 
+        @Override
         public Object getModel() {
             return model;
         }

--- a/core/src/test/java/com/opensymphony/xwork2/interceptor/ScopedModelDrivenInterceptorTest.java
+++ b/core/src/test/java/com/opensymphony/xwork2/interceptor/ScopedModelDrivenInterceptorTest.java
@@ -190,22 +190,27 @@ public class ScopedModelDrivenInterceptorTest extends XWorkTestCase {
         private String key;
         private User model;
 
+        @Override
         public void setModel(Object model) {
             this.model = (User) model;
         }
 
+        @Override
         public void setScopeKey(String key) {
             this.key = key;
         }
 
+        @Override
         public String getScopeKey() {
             return key;
         }
 
+        @Override
         public User getModel() {
             return model;
         }
 
+        @Override
         public String execute() throws Exception {
             return SUCCESS;
         }
@@ -217,22 +222,27 @@ public class ScopedModelDrivenInterceptorTest extends XWorkTestCase {
         private String key;
         private Equidae model;
 
+        @Override
         public void setModel(Object model) {
             this.model = (Equidae) model;
         }
 
+        @Override
         public void setScopeKey(String key) {
             this.key = key;
         }
 
+        @Override
         public String getScopeKey() {
             return key;
         }
 
+        @Override
         public Equidae getModel() {
             return model;
         }
 
+        @Override
         public String execute() throws Exception {
             return SUCCESS;
         }

--- a/core/src/test/java/com/opensymphony/xwork2/interceptor/annotations/AllowingByDefaultAction.java
+++ b/core/src/test/java/com/opensymphony/xwork2/interceptor/annotations/AllowingByDefaultAction.java
@@ -19,21 +19,24 @@
 package com.opensymphony.xwork2.interceptor.annotations;
 
 import com.opensymphony.xwork2.ActionSupport;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
 /**
  * @author martin.gilday
  *
  */
 public class AllowingByDefaultAction extends ActionSupport {
-	
+
 	@Blocked
 	private String name;
 	private String job;
-	
+
+	@StrutsParameter
 	public void setName(String name) {
 		this.name = name;
 	}
-	
+
+	@StrutsParameter
 	public void setJob(String job) {
 		this.job = job;
 	}

--- a/core/src/test/java/com/opensymphony/xwork2/interceptor/annotations/BlockingByDefaultAction.java
+++ b/core/src/test/java/com/opensymphony/xwork2/interceptor/annotations/BlockingByDefaultAction.java
@@ -19,6 +19,7 @@
 package com.opensymphony.xwork2.interceptor.annotations;
 
 import com.opensymphony.xwork2.ActionSupport;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
 /**
  * @author martin.gilday
@@ -26,15 +27,17 @@ import com.opensymphony.xwork2.ActionSupport;
  */
 @BlockByDefault
 public class BlockingByDefaultAction extends ActionSupport {
-	
+
 	@Allowed
 	private String name;
 	private String job;
-	
+
+	@StrutsParameter
 	public void setName(String name) {
 		this.name = name;
 	}
-	
+
+	@StrutsParameter
 	public void setJob(String job) {
 		this.job = job;
 	}

--- a/core/src/test/java/com/opensymphony/xwork2/test/ModelDrivenAction2.java
+++ b/core/src/test/java/com/opensymphony/xwork2/test/ModelDrivenAction2.java
@@ -19,6 +19,7 @@
 package com.opensymphony.xwork2.test;
 
 import com.opensymphony.xwork2.ModelDrivenAction;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
 
 /**
@@ -28,12 +29,13 @@ import com.opensymphony.xwork2.ModelDrivenAction;
  */
 public class ModelDrivenAction2 extends ModelDrivenAction {
 
-    private TestBean2 model = new TestBean2();
+    private final TestBean2 model = new TestBean2();
 
 
     /**
      * @return the model to be pushed onto the ValueStack after the Action itself
      */
+    @StrutsParameter(depth = 3)
     @Override
     public Object getModel() {
         return model;

--- a/core/src/test/java/com/opensymphony/xwork2/test/ModelDrivenAnnotationAction2.java
+++ b/core/src/test/java/com/opensymphony/xwork2/test/ModelDrivenAnnotationAction2.java
@@ -19,6 +19,7 @@
 package com.opensymphony.xwork2.test;
 
 import com.opensymphony.xwork2.ModelDrivenAnnotationAction;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
 
 /**
@@ -29,12 +30,13 @@ import com.opensymphony.xwork2.ModelDrivenAnnotationAction;
  */
 public class ModelDrivenAnnotationAction2 extends ModelDrivenAnnotationAction {
 
-    private AnnotationTestBean2 model = new AnnotationTestBean2();
+    private final AnnotationTestBean2 model = new AnnotationTestBean2();
 
 
     /**
      * @return the model to be pushed onto the ValueStack after the Action itself
      */
+    @StrutsParameter(depth = 3)
     @Override
     public Object getModel() {
         return model;

--- a/core/src/test/java/com/opensymphony/xwork2/test/SimpleAction2.java
+++ b/core/src/test/java/com/opensymphony/xwork2/test/SimpleAction2.java
@@ -19,6 +19,7 @@
 package com.opensymphony.xwork2.test;
 
 import com.opensymphony.xwork2.SimpleAction;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
 
 /**
@@ -31,7 +32,7 @@ public class SimpleAction2 extends SimpleAction {
 
     private int count;
 
-
+    @StrutsParameter
     public void setCount(int count) {
         this.count = count;
     }

--- a/core/src/test/java/com/opensymphony/xwork2/test/SimpleAction3.java
+++ b/core/src/test/java/com/opensymphony/xwork2/test/SimpleAction3.java
@@ -20,6 +20,7 @@ package com.opensymphony.xwork2.test;
 
 import com.opensymphony.xwork2.SimpleAction;
 import com.opensymphony.xwork2.util.Bar;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
 
 /**
@@ -32,19 +33,24 @@ public class SimpleAction3 extends SimpleAction implements DataAware {
     private Bar bar;
     private String data;
 
-
+    @Override
     public void setBarObj(Bar b) {
         bar = b;
     }
 
+    @StrutsParameter(depth = 1)
+    @Override
     public Bar getBarObj() {
         return bar;
     }
 
+    @StrutsParameter
+    @Override
     public void setData(String data) {
         this.data = data;
     }
 
+    @Override
     public String getData() {
         return data;
     }

--- a/core/src/test/java/com/opensymphony/xwork2/test/SimpleAnnotationAction2.java
+++ b/core/src/test/java/com/opensymphony/xwork2/test/SimpleAnnotationAction2.java
@@ -21,6 +21,7 @@ package com.opensymphony.xwork2.test;
 import com.opensymphony.xwork2.SimpleAnnotationAction;
 import com.opensymphony.xwork2.validator.annotations.IntRangeFieldValidator;
 import com.opensymphony.xwork2.validator.annotations.RequiredFieldValidator;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
 /**
  * SimpleAction2
@@ -35,6 +36,7 @@ public class SimpleAnnotationAction2 extends SimpleAnnotationAction {
 
     @RequiredFieldValidator(message = "You must enter a value for count.")
     @IntRangeFieldValidator(min = "0", max = "5", message = "count must be between ${min} and ${max}, current value is ${count}.")
+    @StrutsParameter
     public void setCount(int count) {
         this.count = count;
     }

--- a/core/src/test/java/com/opensymphony/xwork2/test/SimpleAnnotationAction3.java
+++ b/core/src/test/java/com/opensymphony/xwork2/test/SimpleAnnotationAction3.java
@@ -20,6 +20,7 @@ package com.opensymphony.xwork2.test;
 
 import com.opensymphony.xwork2.SimpleAnnotationAction;
 import com.opensymphony.xwork2.util.Bar;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
 
 /**
@@ -33,19 +34,24 @@ public class SimpleAnnotationAction3 extends SimpleAnnotationAction implements A
     private Bar bar;
     private String data;
 
-
+    @Override
     public void setBarObj(Bar b) {
         bar = b;
     }
 
+    @StrutsParameter(depth = 1)
+    @Override
     public Bar getBarObj() {
         return bar;
     }
 
+    @StrutsParameter
+    @Override
     public void setData(String data) {
         this.data = data;
     }
 
+    @Override
     public String getData() {
         return data;
     }

--- a/core/src/test/java/com/opensymphony/xwork2/test/annotations/ValidateAnnotatedMethodOnlyAction.java
+++ b/core/src/test/java/com/opensymphony/xwork2/test/annotations/ValidateAnnotatedMethodOnlyAction.java
@@ -20,6 +20,7 @@ package com.opensymphony.xwork2.test.annotations;
 
 import com.opensymphony.xwork2.ActionSupport;
 import com.opensymphony.xwork2.validator.annotations.ExpressionValidator;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
 /**
  * <code>ValidateAnnotatedMethodOnlyAction</code>
@@ -34,6 +35,7 @@ public class ValidateAnnotatedMethodOnlyAction extends ActionSupport {
         return param1;
     }
 
+    @StrutsParameter
     public void setParam1(String param1) {
         this.param1 = param1;
     }
@@ -42,6 +44,7 @@ public class ValidateAnnotatedMethodOnlyAction extends ActionSupport {
         return param2;
     }
 
+    @StrutsParameter
     public void setParam2(String param2) {
         this.param2 = param2;
     }

--- a/core/src/test/java/com/opensymphony/xwork2/util/Bar.java
+++ b/core/src/test/java/com/opensymphony/xwork2/util/Bar.java
@@ -19,6 +19,7 @@
 package com.opensymphony.xwork2.util;
 
 import com.opensymphony.xwork2.ActionSupport;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
 
 /**
@@ -32,7 +33,7 @@ public class Bar extends ActionSupport {
     String title;
     int somethingElse;
 
-
+    @StrutsParameter
     public void setId(Long id) {
         this.id = id;
     }
@@ -41,6 +42,7 @@ public class Bar extends ActionSupport {
         return this.id;
     }
 
+    @StrutsParameter
     public void setSomethingElse(int somethingElse) {
         this.somethingElse = somethingElse;
     }
@@ -49,6 +51,7 @@ public class Bar extends ActionSupport {
         return somethingElse;
     }
 
+    @StrutsParameter
     public void setTitle(String title) {
         this.title = title;
     }

--- a/core/src/test/java/com/opensymphony/xwork2/util/StrutsLocalizedTextProviderTest.java
+++ b/core/src/test/java/com/opensymphony/xwork2/util/StrutsLocalizedTextProviderTest.java
@@ -32,6 +32,7 @@ import com.opensymphony.xwork2.config.providers.XmlConfigurationProvider;
 import com.opensymphony.xwork2.test.ModelDrivenAction2;
 import com.opensymphony.xwork2.test.TestBean2;
 import org.apache.struts2.config.StrutsXmlConfigurationProvider;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
 import java.text.DateFormat;
 import java.text.ParseException;
@@ -83,6 +84,7 @@ public class StrutsLocalizedTextProviderTest extends XWorkTestCase {
     public static class MyAction extends ActionSupport {
         private Bar testBean2;
 
+        @StrutsParameter(depth = 1)
         public Bar getBarObj() {
             return testBean2;
         }
@@ -460,7 +462,7 @@ public class StrutsLocalizedTextProviderTest extends XWorkTestCase {
     /**
      * Test the {@link StrutsLocalizedTextProvider#findText(java.lang.Class, java.lang.String, java.util.Locale, java.lang.String, java.lang.Object[], com.opensymphony.xwork2.util.ValueStack) }
      * method for basic correctness.
-     * 
+     *
      * It is the version of the method that will search the class hierarchy resource bundles first, unless {@link StrutsLocalizedTextProvider#searchDefaultBundlesFirst}
      * is true (in which case it will search the default resource bundles first).  No matter the flag setting, it should search until it finds a match, or fails to find
      * a match and returns the default message parameter that was passed.
@@ -611,7 +613,7 @@ public class StrutsLocalizedTextProviderTest extends XWorkTestCase {
 
         /**
          * Attempt to force the resource bundles to be reloaded, even if configuration would otherwise prevent it.
-         * It will preserve the current reloadBundles state, attempt to force a reload and then restore the 
+         * It will preserve the current reloadBundles state, attempt to force a reload and then restore the
          * original reloadBundles value.
          */
         public void callReloadBundlesForceReload() {
@@ -625,9 +627,9 @@ public class StrutsLocalizedTextProviderTest extends XWorkTestCase {
         }
 
         /**
-         * Returns the value of the resource bundles reloaded state from the context, provided that one was 
+         * Returns the value of the resource bundles reloaded state from the context, provided that one was
          * previously set.  If no value is found, the result will be false (same as if bundles had not been reloaded).
-         * 
+         *
          * @return true if resource bundles reloaded indicator is true, false otherwise (including if value was never set).
          */
         public boolean getBundlesReloadedIndicatorValue() {

--- a/core/src/test/java/com/opensymphony/xwork2/validator/ActionValidatorManagerTest.java
+++ b/core/src/test/java/com/opensymphony/xwork2/validator/ActionValidatorManagerTest.java
@@ -25,6 +25,7 @@ import com.opensymphony.xwork2.util.ValueStackFactory;
 import com.opensymphony.xwork2.validator.validators.RequiredFieldValidator;
 import com.opensymphony.xwork2.validator.validators.RequiredStringValidator;
 import com.opensymphony.xwork2.validator.validators.VisitorFieldValidator;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -201,8 +202,10 @@ public class ActionValidatorManagerTest extends XWorkTestCase {
         public void setReferenceNumber(String referenceNumber) { this.referenceNumber = referenceNumber; }
 
         public Integer getOrder() { return order; }
+        @StrutsParameter
         public void setOrder(Integer order) { this.order = order; }
 
+        @StrutsParameter(depth = 2)
         public Customer getCustomer() { return customer; }
         public void setCustomer(Customer customer) { this.customer = customer; }
     }

--- a/core/src/test/java/com/opensymphony/xwork2/validator/AnnotationValidationAction.java
+++ b/core/src/test/java/com/opensymphony/xwork2/validator/AnnotationValidationAction.java
@@ -87,6 +87,7 @@ public class AnnotationValidationAction extends ActionSupport {
             messageParams = {"one", "two", "three"})
     @VisitorFieldValidator(message = "Foo isn't valid!", key = "visitorfield.key", fieldName = "foo", appendPrefix = false,
             shortCircuit = true, messageParams = {"one", "two", "three"})
+    @Override
     public String execute() {
         return SUCCESS;
     }

--- a/core/src/test/java/com/opensymphony/xwork2/validator/AnnotationValidationExpAction.java
+++ b/core/src/test/java/com/opensymphony/xwork2/validator/AnnotationValidationExpAction.java
@@ -89,6 +89,7 @@ public class AnnotationValidationExpAction extends ActionSupport {
             messageParams = {"one", "two", "three"})
     @VisitorFieldValidator(message = "Foo isn't valid!", key = "visitorfield.key", fieldName = "foo", appendPrefix = false,
             shortCircuit = true, messageParams = {"one", "two", "three"})
+    @Override
     public String execute() {
         return SUCCESS;
     }

--- a/core/src/test/java/com/opensymphony/xwork2/validator/StringLengthFieldValidatorTest.java
+++ b/core/src/test/java/com/opensymphony/xwork2/validator/StringLengthFieldValidatorTest.java
@@ -24,6 +24,7 @@ import com.opensymphony.xwork2.TextProviderFactory;
 import com.opensymphony.xwork2.XWorkTestCase;
 import com.opensymphony.xwork2.util.ValueStack;
 import com.opensymphony.xwork2.validator.validators.StringLengthFieldValidator;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -220,6 +221,7 @@ public class StringLengthFieldValidatorTest extends XWorkTestCase {
             return this.myField;
         }
 
+        @StrutsParameter
         public void setMyField(String myField) {
             this.myField = myField;
         }
@@ -228,6 +230,7 @@ public class StringLengthFieldValidatorTest extends XWorkTestCase {
             return trimValue;
         }
 
+        @StrutsParameter
         public void setTrimValue(boolean trimValue) {
             this.trimValue = trimValue;
         }
@@ -236,6 +239,7 @@ public class StringLengthFieldValidatorTest extends XWorkTestCase {
             return minLengthValue;
         }
 
+        @StrutsParameter
         public void setMinLengthValue(int minLengthValue) {
             this.minLengthValue = minLengthValue;
         }
@@ -244,6 +248,7 @@ public class StringLengthFieldValidatorTest extends XWorkTestCase {
             return maxLengthValue;
         }
 
+        @StrutsParameter
         public void setMaxLengthValue(int maxLengthValue) {
             this.maxLengthValue = maxLengthValue;
         }
@@ -252,6 +257,7 @@ public class StringLengthFieldValidatorTest extends XWorkTestCase {
             return strings;
         }
 
+        @StrutsParameter
         public void setStrings(String[] strings) {
             this.strings = strings;
         }
@@ -260,6 +266,7 @@ public class StringLengthFieldValidatorTest extends XWorkTestCase {
             return stringCollection;
         }
 
+        @StrutsParameter
         public void setStringCollection(Collection<String> stringCollection) {
             this.stringCollection = stringCollection;
         }

--- a/core/src/test/java/com/opensymphony/xwork2/validator/VisitorValidatorModelAction.java
+++ b/core/src/test/java/com/opensymphony/xwork2/validator/VisitorValidatorModelAction.java
@@ -19,6 +19,7 @@
 package com.opensymphony.xwork2.validator;
 
 import com.opensymphony.xwork2.ModelDriven;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
 
 /**
@@ -32,6 +33,8 @@ public class VisitorValidatorModelAction extends VisitorValidatorTestAction impl
     /**
      * @return the model to be pushed onto the ValueStack instead of the Action itself
      */
+    @StrutsParameter(depth = 2)
+    @Override
     public Object getModel() {
         return getBean();
     }

--- a/core/src/test/java/com/opensymphony/xwork2/validator/VisitorValidatorTestAction.java
+++ b/core/src/test/java/com/opensymphony/xwork2/validator/VisitorValidatorTestAction.java
@@ -20,6 +20,7 @@ package com.opensymphony.xwork2.validator;
 
 import com.opensymphony.xwork2.ActionSupport;
 import com.opensymphony.xwork2.TestBean;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
 import java.util.ArrayList;
 import java.util.Date;
@@ -49,15 +50,16 @@ public class VisitorValidatorTestAction extends ActionSupport {
         }
     }
 
-
     public void setBean(TestBean bean) {
         this.bean = bean;
     }
 
+    @StrutsParameter(depth = 2)
     public TestBean getBean() {
         return bean;
     }
 
+    @StrutsParameter
     public void setContext(String context) {
         this.context = context;
     }
@@ -70,6 +72,7 @@ public class VisitorValidatorTestAction extends ActionSupport {
         this.testBeanArray = testBeanArray;
     }
 
+    @StrutsParameter(depth = 3)
     public TestBean[] getTestBeanArray() {
         return testBeanArray;
     }
@@ -78,6 +81,7 @@ public class VisitorValidatorTestAction extends ActionSupport {
         this.testBeanList = testBeanList;
     }
 
+    @StrutsParameter(depth = 3)
     public List<TestBean> getTestBeanList() {
         return testBeanList;
     }
@@ -86,6 +90,7 @@ public class VisitorValidatorTestAction extends ActionSupport {
         return birthday;
     }
 
+    @StrutsParameter
     public void setBirthday(Date birthday) {
         this.birthday = birthday;
     }

--- a/core/src/test/java/org/apache/struts2/ExecutionCountTestAction.java
+++ b/core/src/test/java/org/apache/struts2/ExecutionCountTestAction.java
@@ -41,9 +41,10 @@ public class ExecutionCountTestAction extends ActionSupport {
         return executionCount;
     }
 
+    @Override
     public String execute() throws Exception {
         executionCount++;
-        LOG.info("executing ExecutionCountTestAction. Current count is " + executionCount);
+        LOG.info("executing ExecutionCountTestAction. Current count is {}", executionCount);
 
         return SUCCESS;
     }

--- a/core/src/test/java/org/apache/struts2/HttpMethodsTestAction.java
+++ b/core/src/test/java/org/apache/struts2/HttpMethodsTestAction.java
@@ -68,6 +68,7 @@ public class HttpMethodsTestAction extends ActionSupport implements HttpMethodAw
         return "onDelete";
     }
 
+    @Override
     public void setMethod(HttpMethod httpMethod) {
         this.httpMethod = httpMethod;
     }
@@ -76,6 +77,7 @@ public class HttpMethodsTestAction extends ActionSupport implements HttpMethodAw
         return httpMethod;
     }
 
+    @Override
     public String getBadRequestResultName() {
         return resultName;
     }

--- a/core/src/test/java/org/apache/struts2/TestAction.java
+++ b/core/src/test/java/org/apache/struts2/TestAction.java
@@ -184,6 +184,7 @@ public class TestAction extends ActionSupport {
         this.fooInt = fooInt;
     }
 
+    @Override
     public String execute() throws Exception {
         if (result == null) {
             result = Action.SUCCESS;

--- a/core/src/test/java/org/apache/struts2/interceptor/CookieInterceptorTest.java
+++ b/core/src/test/java/org/apache/struts2/interceptor/CookieInterceptorTest.java
@@ -27,6 +27,7 @@ import com.opensymphony.xwork2.security.DefaultAcceptedPatternsChecker;
 import com.opensymphony.xwork2.security.DefaultExcludedPatternsChecker;
 import org.apache.struts2.ServletActionContext;
 import org.apache.struts2.StrutsInternalTestCase;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 import org.springframework.mock.web.MockHttpServletRequest;
 
 import javax.servlet.http.Cookie;
@@ -503,6 +504,7 @@ public class CookieInterceptorTest extends StrutsInternalTestCase {
         private String cookie2;
         private String cookie3;
 
+        @Override
         public void setCookiesMap(Map<String, String> cookies) {
             this.cookies = cookies;
         }
@@ -515,6 +517,7 @@ public class CookieInterceptorTest extends StrutsInternalTestCase {
             return cookie1;
         }
 
+        @StrutsParameter
         public void setCookie1(String cookie1) {
             this.cookie1 = cookie1;
         }
@@ -523,6 +526,7 @@ public class CookieInterceptorTest extends StrutsInternalTestCase {
             return cookie2;
         }
 
+        @StrutsParameter
         public void setCookie2(String cookie2) {
             this.cookie2 = cookie2;
         }
@@ -531,6 +535,7 @@ public class CookieInterceptorTest extends StrutsInternalTestCase {
             return cookie3;
         }
 
+        @StrutsParameter
         public void setCookie3(String cookie3) {
             this.cookie3 = cookie3;
         }
@@ -543,6 +548,7 @@ public class CookieInterceptorTest extends StrutsInternalTestCase {
         private String cookie2;
         private String cookie3;
 
+        @Override
         public void withCookies(Map<String, String> cookies) {
             this.cookies = cookies;
         }
@@ -555,6 +561,7 @@ public class CookieInterceptorTest extends StrutsInternalTestCase {
             return cookie1;
         }
 
+        @StrutsParameter
         public void setCookie1(String cookie1) {
             this.cookie1 = cookie1;
         }
@@ -563,6 +570,7 @@ public class CookieInterceptorTest extends StrutsInternalTestCase {
             return cookie2;
         }
 
+        @StrutsParameter
         public void setCookie2(String cookie2) {
             this.cookie2 = cookie2;
         }
@@ -571,6 +579,7 @@ public class CookieInterceptorTest extends StrutsInternalTestCase {
             return cookie3;
         }
 
+        @StrutsParameter
         public void setCookie3(String cookie3) {
             this.cookie3 = cookie3;
         }

--- a/core/src/test/java/org/apache/struts2/interceptor/FileUploadInterceptorTest.java
+++ b/core/src/test/java/org/apache/struts2/interceptor/FileUploadInterceptorTest.java
@@ -27,7 +27,6 @@ import com.opensymphony.xwork2.util.ClassLoaderUtil;
 import org.apache.commons.fileupload.servlet.ServletFileUpload;
 import org.apache.struts2.ServletActionContext;
 import org.apache.struts2.StrutsInternalTestCase;
-import org.apache.struts2.TestAction;
 import org.apache.struts2.dispatcher.HttpParameters;
 import org.apache.struts2.dispatcher.multipart.JakartaMultiPartRequest;
 import org.apache.struts2.dispatcher.multipart.MultiPartRequestWrapper;
@@ -37,7 +36,6 @@ import org.springframework.mock.web.MockHttpServletRequest;
 
 import javax.servlet.http.HttpServletRequest;
 import java.io.File;
-import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
@@ -595,6 +593,7 @@ public class FileUploadInterceptorTest extends StrutsInternalTestCase {
         return new MultiPartRequestWrapper(jak, req, tempDir.getAbsolutePath(), new DefaultLocaleProvider());
     }
 
+    @Override
     protected void setUp() throws Exception {
         super.setUp();
 
@@ -605,6 +604,7 @@ public class FileUploadInterceptorTest extends StrutsInternalTestCase {
         tempDir.mkdirs();
     }
 
+    @Override
     protected void tearDown() throws Exception {
         tempDir.delete();
         interceptor.destroy();

--- a/core/src/test/java/org/apache/struts2/ognl/ProviderAllowlistTest.java
+++ b/core/src/test/java/org/apache/struts2/ognl/ProviderAllowlistTest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.struts2.ognl;
 
-import com.opensymphony.xwork2.config.ConfigurationProvider;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -39,10 +38,10 @@ public class ProviderAllowlistTest {
     private ProviderAllowlist providerAllowlist;
 
     @Mock
-    private ConfigurationProvider provider1;
+    private Object key1;
 
     @Mock
-    private ConfigurationProvider provider2;
+    private Object key2;
 
     @Before
     public void setUp() throws Exception {
@@ -51,37 +50,37 @@ public class ProviderAllowlistTest {
 
     @Test
     public void registerAllowlist() {
-        providerAllowlist.registerAllowlist(provider1, new HashSet<>(asList(String.class, Integer.class)));
-        providerAllowlist.registerAllowlist(provider2, new HashSet<>(asList(Double.class, Integer.class)));
+        providerAllowlist.registerAllowlist(key1, new HashSet<>(asList(String.class, Integer.class)));
+        providerAllowlist.registerAllowlist(key2, new HashSet<>(asList(Double.class, Integer.class)));
 
         assertThat(providerAllowlist.getProviderAllowlist()).containsExactlyInAnyOrder(String.class, Integer.class, Double.class);
     }
 
     @Test
     public void registerAllowlist_twice() {
-        providerAllowlist.registerAllowlist(provider1, new HashSet<>(asList(String.class, Integer.class)));
-        providerAllowlist.registerAllowlist(provider1, new HashSet<>(asList(Double.class, Integer.class)));
+        providerAllowlist.registerAllowlist(key1, new HashSet<>(asList(String.class, Integer.class)));
+        providerAllowlist.registerAllowlist(key1, new HashSet<>(asList(Double.class, Integer.class)));
 
         assertThat(providerAllowlist.getProviderAllowlist()).containsExactlyInAnyOrder(Integer.class, Double.class);
     }
 
     @Test
     public void clearAllowlist() {
-        providerAllowlist.registerAllowlist(provider1, new HashSet<>(asList(String.class, Integer.class)));
-        providerAllowlist.registerAllowlist(provider2, new HashSet<>(asList(Double.class, Integer.class)));
+        providerAllowlist.registerAllowlist(key1, new HashSet<>(asList(String.class, Integer.class)));
+        providerAllowlist.registerAllowlist(key2, new HashSet<>(asList(Double.class, Integer.class)));
 
-        providerAllowlist.clearAllowlist(provider1);
+        providerAllowlist.clearAllowlist(key1);
 
         assertThat(providerAllowlist.getProviderAllowlist()).containsExactlyInAnyOrder(Integer.class, Double.class);
     }
 
     @Test
     public void clearAllowlist_both() {
-        providerAllowlist.registerAllowlist(provider1, new HashSet<>(asList(String.class, Integer.class)));
-        providerAllowlist.registerAllowlist(provider2, new HashSet<>(asList(Double.class, Integer.class)));
+        providerAllowlist.registerAllowlist(key1, new HashSet<>(asList(String.class, Integer.class)));
+        providerAllowlist.registerAllowlist(key2, new HashSet<>(asList(Double.class, Integer.class)));
 
-        providerAllowlist.clearAllowlist(provider1);
-        providerAllowlist.clearAllowlist(provider2);
+        providerAllowlist.clearAllowlist(key1);
+        providerAllowlist.clearAllowlist(key2);
 
         assertThat(providerAllowlist.getProviderAllowlist()).isEmpty();
     }

--- a/core/src/test/java/org/apache/struts2/views/jsp/IteratorGeneratorTagTest.java
+++ b/core/src/test/java/org/apache/struts2/views/jsp/IteratorGeneratorTagTest.java
@@ -18,13 +18,12 @@
  */
 package org.apache.struts2.views.jsp;
 
-import java.util.Iterator;
-
+import com.opensymphony.xwork2.Action;
+import com.opensymphony.xwork2.ActionSupport;
 import org.apache.struts2.util.IteratorGenerator.Converter;
 import org.apache.struts2.views.jsp.iterator.IteratorGeneratorTag;
 
-import com.opensymphony.xwork2.Action;
-import com.opensymphony.xwork2.ActionSupport;
+import java.util.Iterator;
 
 /**
  * Test case for IteratorGeneratorTag.
@@ -428,11 +427,7 @@ public class IteratorGeneratorTagTest extends AbstractTagTest {
     public Action getAction() {
         return new ActionSupport() {
             public Converter getMyConverter() {
-                return new Converter() {
-                    public Object convert(String value) throws Exception {
-                        return "myConverter-"+value;
-                    }
-                };
+                return value -> "myConverter-"+value;
             }
 
             public int getMyCount() {

--- a/core/src/test/java/org/apache/struts2/views/jsp/SortIteratorTagTest.java
+++ b/core/src/test/java/org/apache/struts2/views/jsp/SortIteratorTagTest.java
@@ -18,17 +18,15 @@
  */
 package org.apache.struts2.views.jsp;
 
+import com.opensymphony.xwork2.Action;
+import com.opensymphony.xwork2.ActionSupport;
+import org.apache.struts2.views.jsp.iterator.SortIteratorTag;
+
+import javax.servlet.jsp.JspException;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
-
-import javax.servlet.jsp.JspException;
-
-import org.apache.struts2.views.jsp.iterator.SortIteratorTag;
-
-import com.opensymphony.xwork2.Action;
-import com.opensymphony.xwork2.ActionSupport;
 
 /**
  * Test case to test SortIteratorTag.
@@ -338,13 +336,11 @@ public class SortIteratorTagTest extends AbstractTagTest {
     public Action getAction() {
         return new ActionSupport() {
             public Comparator getComparator() {
-                return new Comparator() {
-                    public int compare(Object o1, Object o2) {
-                        Integer i1 = (Integer) o1;
-                        Integer i2 = (Integer) o2;
+                return (o1, o2) -> {
+                    Integer i1 = (Integer) o1;
+                    Integer i2 = (Integer) o2;
 
-                        return (i1.intValue() - i2.intValue());
-                    }
+                    return (i1 - i2);
                 };
             }
 

--- a/core/src/test/java/org/apache/struts2/views/jsp/SubsetIteratorTagTest.java
+++ b/core/src/test/java/org/apache/struts2/views/jsp/SubsetIteratorTagTest.java
@@ -18,15 +18,14 @@
  */
 package org.apache.struts2.views.jsp;
 
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-
+import com.opensymphony.xwork2.Action;
+import com.opensymphony.xwork2.ActionSupport;
 import org.apache.struts2.util.SubsetIteratorFilter.Decider;
 import org.apache.struts2.views.jsp.iterator.SubsetIteratorTag;
 
-import com.opensymphony.xwork2.Action;
-import com.opensymphony.xwork2.ActionSupport;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
 
 
 /**
@@ -641,11 +640,11 @@ public class SubsetIteratorTagTest extends AbstractTagTest {
         return new ActionSupport() {
             public List getMyList() {
                 List l = new ArrayList();
-                l.add(new Integer(1));
-                l.add(new Integer(2));
-                l.add(new Integer(3));
-                l.add(new Integer(4));
-                l.add(new Integer(5));
+                l.add(1);
+                l.add(2);
+                l.add(3);
+                l.add(4);
+                l.add(5);
                 return l;
             }
 
@@ -660,11 +659,9 @@ public class SubsetIteratorTagTest extends AbstractTagTest {
             }
 
             public Decider getMyDecider() {
-                return new Decider() {
-                    public boolean decide(Object element) throws Exception {
-                        int integer = ((Integer)element).intValue();
-                        return (((integer % 2) == 0)?true:false);
-                    }
+                return element -> {
+                    int integer = (Integer) element;
+                    return integer % 2 == 0;
                 };
             }
         };

--- a/core/src/test/java/org/apache/struts2/views/jsp/ui/DoubleValidationAction.java
+++ b/core/src/test/java/org/apache/struts2/views/jsp/ui/DoubleValidationAction.java
@@ -19,6 +19,7 @@
 package org.apache.struts2.views.jsp.ui;
 
 import com.opensymphony.xwork2.ActionSupport;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
 /**
  *
@@ -30,6 +31,7 @@ public class DoubleValidationAction extends ActionSupport {
         return longint;
     }
 
+    @StrutsParameter
     public void setLongint(double longint) {
         this.longint = longint;
     }

--- a/core/src/test/java/org/apache/struts2/views/jsp/ui/FieldErrorTagTest.java
+++ b/core/src/test/java/org/apache/struts2/views/jsp/ui/FieldErrorTagTest.java
@@ -18,18 +18,17 @@
  */
 package org.apache.struts2.views.jsp.ui;
 
+import com.opensymphony.xwork2.Action;
+import com.opensymphony.xwork2.ActionSupport;
+import org.apache.struts2.TestAction;
+import org.apache.struts2.views.jsp.AbstractUITagTest;
+import org.apache.struts2.views.jsp.ParamTag;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-
-import org.apache.struts2.views.jsp.AbstractUITagTest;
-import org.apache.struts2.views.jsp.ParamTag;
-import org.apache.struts2.TestAction;
-
-import com.opensymphony.xwork2.Action;
-import com.opensymphony.xwork2.ActionSupport;
 
 /**
  * FieldError Tag Test Case.

--- a/core/src/test/java/org/apache/struts2/views/jsp/ui/IntValidationAction.java
+++ b/core/src/test/java/org/apache/struts2/views/jsp/ui/IntValidationAction.java
@@ -19,6 +19,7 @@
 package org.apache.struts2.views.jsp.ui;
 
 import com.opensymphony.xwork2.ActionSupport;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
 /**
  *
@@ -30,6 +31,7 @@ public class IntValidationAction extends ActionSupport {
         return longint;
     }
 
+    @StrutsParameter
     public void setLongint(int longint) {
         this.longint = longint;
     }

--- a/plugins/bean-validation/src/test/java/org/apache/struts/beanvalidation/actions/FieldAction.java
+++ b/plugins/bean-validation/src/test/java/org/apache/struts/beanvalidation/actions/FieldAction.java
@@ -19,6 +19,7 @@
 package org.apache.struts.beanvalidation.actions;
 
 import com.opensymphony.xwork2.ActionSupport;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 import org.hibernate.validator.constraints.NotBlank;
 
 public class FieldAction extends ActionSupport {
@@ -30,6 +31,7 @@ public class FieldAction extends ActionSupport {
         return test;
     }
 
+    @StrutsParameter
     public void setTest(String test) {
         this.test = test;
     }

--- a/plugins/bean-validation/src/test/java/org/apache/struts/beanvalidation/actions/FieldMatchAction.java
+++ b/plugins/bean-validation/src/test/java/org/apache/struts/beanvalidation/actions/FieldMatchAction.java
@@ -20,6 +20,7 @@ package org.apache.struts.beanvalidation.actions;
 
 import com.opensymphony.xwork2.ActionSupport;
 import org.apache.struts.beanvalidation.constraints.FieldMatch;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 import org.hibernate.validator.constraints.Email;
 import org.hibernate.validator.constraints.NotBlank;
 
@@ -48,6 +49,7 @@ public class FieldMatchAction extends ActionSupport {
         return password;
     }
 
+    @StrutsParameter
     public void setPassword(String password) {
         this.password = password;
     }
@@ -56,6 +58,7 @@ public class FieldMatchAction extends ActionSupport {
         return confirmPassword;
     }
 
+    @StrutsParameter
     public void setConfirmPassword(String confirmPassword) {
         this.confirmPassword = confirmPassword;
     }
@@ -64,6 +67,7 @@ public class FieldMatchAction extends ActionSupport {
         return email;
     }
 
+    @StrutsParameter
     public void setEmail(String email) {
         this.email = email;
     }
@@ -72,6 +76,7 @@ public class FieldMatchAction extends ActionSupport {
         return confirmEmail;
     }
 
+    @StrutsParameter
     public void setConfirmEmail(String confirmEmail) {
         this.confirmEmail = confirmEmail;
     }

--- a/plugins/bean-validation/src/test/java/org/apache/struts/beanvalidation/actions/ModelDrivenAction.java
+++ b/plugins/bean-validation/src/test/java/org/apache/struts/beanvalidation/actions/ModelDrivenAction.java
@@ -21,14 +21,17 @@ package org.apache.struts.beanvalidation.actions;
 import com.opensymphony.xwork2.ActionSupport;
 import com.opensymphony.xwork2.ModelDriven;
 import org.apache.struts.beanvalidation.models.Person;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
 import javax.validation.Valid;
 
 public class ModelDrivenAction extends ActionSupport implements ModelDriven<Person>, ModelDrivenActionInterface {
 
     @Valid
-    private Person model = new Person();
+    private final Person model = new Person();
 
+    @StrutsParameter(depth = 2)
+    @Override
     public Person getModel() {
         return model;
     }

--- a/plugins/bean-validation/src/test/java/org/apache/struts/beanvalidation/actions/ValidateGroupAction.java
+++ b/plugins/bean-validation/src/test/java/org/apache/struts/beanvalidation/actions/ValidateGroupAction.java
@@ -22,14 +22,17 @@ import com.opensymphony.xwork2.ActionSupport;
 import com.opensymphony.xwork2.ModelDriven;
 import org.apache.struts.beanvalidation.constraints.ValidationGroup;
 import org.apache.struts.beanvalidation.models.Person;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
 import javax.validation.Valid;
 
 public class ValidateGroupAction extends ActionSupport implements ModelDriven<Person> {
 
     @Valid
-    private Person model = new Person();
+    private final Person model = new Person();
 
+    @StrutsParameter(depth = 2)
+    @Override
     public Person getModel() {
         return model;
     }

--- a/plugins/config-browser/src/main/java/org/apache/struts2/config_browser/ActionNamesAction.java
+++ b/plugins/config-browser/src/main/java/org/apache/struts2/config_browser/ActionNamesAction.java
@@ -23,6 +23,7 @@ import com.opensymphony.xwork2.config.entities.ActionConfig;
 import com.opensymphony.xwork2.inject.Inject;
 import org.apache.commons.text.StringEscapeUtils;
 import org.apache.struts2.StrutsConstants;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
 import java.util.Set;
 import java.util.TreeSet;
@@ -54,6 +55,7 @@ public class ActionNamesAction extends ActionSupport {
         return StringEscapeUtils.escapeHtml4(namespace);
     }
 
+    @StrutsParameter
     public void setNamespace(String namespace) {
         this.namespace = namespace;
     }
@@ -81,9 +83,10 @@ public class ActionNamesAction extends ActionSupport {
         return extension;
     }
 
+    @Override
     public String execute() throws Exception {
         namespaces = configHelper.getNamespaces();
-        if (namespaces.size() == 0) {
+        if (namespaces.isEmpty()) {
             addActionError("There are no namespaces in this configuration");
             return ERROR;
         }

--- a/plugins/config-browser/src/main/java/org/apache/struts2/config_browser/ListValidatorsAction.java
+++ b/plugins/config-browser/src/main/java/org/apache/struts2/config_browser/ListValidatorsAction.java
@@ -26,6 +26,7 @@ import com.opensymphony.xwork2.validator.ActionValidatorManager;
 import com.opensymphony.xwork2.validator.Validator;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
 import java.util.Collections;
 import java.util.List;
@@ -43,16 +44,17 @@ public class ListValidatorsAction extends ActionSupport {
     List<Validator> validators = Collections.emptyList();
     private ActionValidatorManager actionValidatorManager;
 
-    
+
     @Inject
     public void setActionValidatorManager(ActionValidatorManager mgr) {
         this.actionValidatorManager = mgr;
     }
-    
+
     public String getClazz() {
         return clazz;
     }
 
+    @StrutsParameter
     public void setClazz(String clazz) {
         this.clazz = clazz;
     }
@@ -69,6 +71,7 @@ public class ListValidatorsAction extends ActionSupport {
         return context;
     }
 
+    @StrutsParameter
     public void setContext(String context) {
         this.context = context;
     }
@@ -77,6 +80,7 @@ public class ListValidatorsAction extends ActionSupport {
         return validators;
     }
 
+    @Override
     public String execute() throws Exception {
         loadValidators();
         return super.execute();

--- a/plugins/config-browser/src/main/java/org/apache/struts2/config_browser/ShowBeansAction.java
+++ b/plugins/config-browser/src/main/java/org/apache/struts2/config_browser/ShowBeansAction.java
@@ -46,6 +46,7 @@ public class ShowBeansAction extends ActionNamesAction {
     Map<String, Set<Binding>> bindings;
 
     @Inject
+    @Override
     public void setContainer(Container container) {
         super.setContainer(container);
         bindings = new TreeMap<>();
@@ -123,6 +124,7 @@ public class ShowBeansAction extends ActionNamesAction {
             return isDefault;
         }
 
+        @Override
         public int compareTo(Binding b2) {
             int ret;
             if (isDefault) {

--- a/plugins/config-browser/src/main/java/org/apache/struts2/config_browser/ShowConfigAction.java
+++ b/plugins/config-browser/src/main/java/org/apache/struts2/config_browser/ShowConfigAction.java
@@ -21,10 +21,11 @@ package org.apache.struts2.config_browser;
 import com.opensymphony.xwork2.ObjectFactory;
 import com.opensymphony.xwork2.config.entities.ActionConfig;
 import com.opensymphony.xwork2.inject.Inject;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import com.opensymphony.xwork2.util.reflection.ReflectionProvider;
 import org.apache.commons.text.StringEscapeUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
 import java.beans.PropertyDescriptor;
 import java.util.Set;
@@ -43,8 +44,8 @@ public class ShowConfigAction extends ActionNamesAction {
     private Set<String> actionNames;
     private String detailView = "results";
     private PropertyDescriptor[] properties;
-    private static Logger LOG = LogManager.getLogger(ShowConfigAction.class);
-    
+    private static final Logger LOG = LogManager.getLogger(ShowConfigAction.class);
+
     private ObjectFactory objectFactory;
     private ReflectionProvider reflectionProvider;
 
@@ -52,23 +53,26 @@ public class ShowConfigAction extends ActionNamesAction {
         return detailView;
     }
 
+    @StrutsParameter
     public void setDetailView(String detailView) {
         this.detailView = detailView;
     }
 
+    @Override
     public Set<String> getActionNames() {
         return actionNames;
     }
 
+    @Override
     public String getNamespace() {
         return StringEscapeUtils.escapeHtml4(namespace);
     }
-    
+
     @Inject
     public void setObjectFactory(ObjectFactory fac) {
         this.objectFactory = fac;
     }
-    
+
     @Inject
     public void setReflectionProvider(ReflectionProvider prov) {
         this.reflectionProvider = prov;
@@ -78,6 +82,7 @@ public class ShowConfigAction extends ActionNamesAction {
         return clazz.getName().substring(clazz.getName().lastIndexOf('.') + 1);
     }
 
+    @StrutsParameter
     public void setNamespace(String namespace) {
         this.namespace = namespace;
     }
@@ -86,6 +91,7 @@ public class ShowConfigAction extends ActionNamesAction {
         return actionName;
     }
 
+    @StrutsParameter
     public void setActionName(String actionName) {
         this.actionName = actionName;
     }
@@ -98,16 +104,17 @@ public class ShowConfigAction extends ActionNamesAction {
         return properties;
     }
 
+    @Override
     public String execute() throws Exception {
         super.execute();
         config = configHelper.getActionConfig(namespace, actionName);
-        actionNames = new TreeSet<String>(configHelper.getActionNames(namespace));
+        actionNames = new TreeSet<>(configHelper.getActionNames(namespace));
         try {
             Object action = objectFactory.buildAction(actionName, namespace, config, null);
             properties = reflectionProvider.getPropertyDescriptors(action);
         } catch (Exception e) {
-            LOG.error("Unable to get properties for action " + actionName, e);
-            addActionError("Unable to retrieve action properties: " + e.toString());
+            LOG.error("Unable to get properties for action {}", actionName, e);
+            addActionError("Unable to retrieve action properties: " + e);
         }
 
         if (hasErrors()) //super might have set some :)

--- a/plugins/config-browser/src/main/java/org/apache/struts2/config_browser/ShowValidatorAction.java
+++ b/plugins/config-browser/src/main/java/org/apache/struts2/config_browser/ShowValidatorAction.java
@@ -19,12 +19,13 @@
 package org.apache.struts2.config_browser;
 
 import com.opensymphony.xwork2.inject.Inject;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import com.opensymphony.xwork2.util.reflection.ReflectionContextFactory;
 import com.opensymphony.xwork2.util.reflection.ReflectionException;
 import com.opensymphony.xwork2.util.reflection.ReflectionProvider;
 import com.opensymphony.xwork2.validator.Validator;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
 import java.beans.BeanInfo;
 import java.beans.IntrospectionException;
@@ -32,6 +33,7 @@ import java.beans.Introspector;
 import java.beans.PropertyDescriptor;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
 
@@ -42,11 +44,11 @@ import java.util.TreeSet;
 public class ShowValidatorAction extends ListValidatorsAction {
     private static final long serialVersionUID = 4061534149317835177L;
 
-    private static Logger LOG = LogManager.getLogger(ShowValidatorAction.class);
+    private static final Logger LOG = LogManager.getLogger(ShowValidatorAction.class);
 
     private Set<PropertyInfo> properties = Collections.emptySet();
     private int selected = 0;
-    
+
     ReflectionProvider reflectionProvider;
     ReflectionContextFactory reflectionContextFactory;
 
@@ -54,16 +56,17 @@ public class ShowValidatorAction extends ListValidatorsAction {
     public void setReflectionProvider(ReflectionProvider prov) {
         this.reflectionProvider = prov;
     }
-    
+
     @Inject
     public void setReflectionContextFactory(ReflectionContextFactory fac) {
         this.reflectionContextFactory = fac;
     }
-    
+
     public int getSelected() {
         return selected;
     }
 
+    @StrutsParameter
     public void setSelected(int selected) {
         this.selected = selected;
     }
@@ -76,10 +79,11 @@ public class ShowValidatorAction extends ListValidatorsAction {
         return validators.get(selected);
     }
 
+    @Override
     public String execute() throws Exception {
         loadValidators();
         Validator validator = getSelectedValidator();
-        properties = new TreeSet<PropertyInfo>();
+        properties = new TreeSet<>();
         try {
             Map<String, Object> context = reflectionContextFactory.createDefaultContext(validator);
             BeanInfo beanInfoFrom;
@@ -162,6 +166,7 @@ public class ShowValidatorAction extends ListValidatorsAction {
             this.name = name;
         }
 
+        @Override
         public boolean equals(Object o) {
             if (this == o) return true;
             if (!(o instanceof PropertyInfo)) return false;
@@ -170,11 +175,11 @@ public class ShowValidatorAction extends ListValidatorsAction {
 
             if (!name.equals(propertyInfo.name)) return false;
             if (!type.equals(propertyInfo.type)) return false;
-            if (value != null ? !value.equals(propertyInfo.value) : propertyInfo.value != null) return false;
 
-            return true;
+            return Objects.equals(value, propertyInfo.value);
         }
 
+        @Override
         public int hashCode() {
             int result;
             result = name.hashCode();
@@ -183,6 +188,7 @@ public class ShowValidatorAction extends ListValidatorsAction {
             return result;
         }
 
+        @Override
         public int compareTo(Object o) {
             PropertyInfo other = (PropertyInfo) o;
             return this.name.compareTo(other.name);

--- a/plugins/convention/src/main/java/org/apache/struts2/convention/ClasspathConfigurationProvider.java
+++ b/plugins/convention/src/main/java/org/apache/struts2/convention/ClasspathConfigurationProvider.java
@@ -36,7 +36,7 @@ import org.apache.struts2.dispatcher.DispatcherListener;
  * </p>
  */
 public class ClasspathConfigurationProvider implements ConfigurationProvider, DispatcherListener {
-    private ActionConfigBuilder actionConfigBuilder;
+    private final ActionConfigBuilder actionConfigBuilder;
     private boolean devMode;
     private boolean reload;
     private boolean listeningToDispatcher;
@@ -59,6 +59,7 @@ public class ClasspathConfigurationProvider implements ConfigurationProvider, Di
     /**
      * Not used.
      */
+    @Override
     public void destroy() {
         if (this.listeningToDispatcher) {
             Dispatcher.removeDispatcherListener(this);
@@ -71,6 +72,7 @@ public class ClasspathConfigurationProvider implements ConfigurationProvider, Di
      *
      * @param configuration configuration
      */
+    @Override
     public void init(Configuration configuration) {
         if (devMode && reload && !listeningToDispatcher) {
             //this is the only way I found to be able to get added to to ConfigurationProvider list
@@ -88,6 +90,7 @@ public class ClasspathConfigurationProvider implements ConfigurationProvider, Di
      *
      * @throws ConfigurationException in case of configuration errors
      */
+    @Override
     public void register(ContainerBuilder containerBuilder, LocatableProperties locatableProperties)
             throws ConfigurationException {
     }
@@ -97,20 +100,24 @@ public class ClasspathConfigurationProvider implements ConfigurationProvider, Di
      *
      * @throws ConfigurationException in case of configuration errors
      */
+    @Override
     public void loadPackages() throws ConfigurationException {
     }
 
     /**
      * @return true if devMode, reload and actionConfigBuilder.needsReload()
      */
+    @Override
     public boolean needsReload() {
         return devMode && reload && actionConfigBuilder.needsReload();
     }
 
+    @Override
     public void dispatcherInitialized(Dispatcher du) {
         du.getConfigurationManager().addContainerProvider(this);
     }
 
+    @Override
     public void dispatcherDestroyed(Dispatcher du) {
     }
 }

--- a/plugins/convention/src/main/java/org/apache/struts2/convention/ClasspathPackageProvider.java
+++ b/plugins/convention/src/main/java/org/apache/struts2/convention/ClasspathPackageProvider.java
@@ -18,11 +18,11 @@
  */
 package org.apache.struts2.convention;
 
-import com.opensymphony.xwork2.config.PackageProvider;
 import com.opensymphony.xwork2.config.Configuration;
 import com.opensymphony.xwork2.config.ConfigurationException;
-import com.opensymphony.xwork2.inject.Inject;
+import com.opensymphony.xwork2.config.PackageProvider;
 import com.opensymphony.xwork2.inject.Container;
+import com.opensymphony.xwork2.inject.Inject;
 
 /**
  * <p>
@@ -34,20 +34,23 @@ import com.opensymphony.xwork2.inject.Container;
  * </p>
  */
 public class ClasspathPackageProvider implements PackageProvider {
-     private ActionConfigBuilder actionConfigBuilder;
+    private final ActionConfigBuilder actionConfigBuilder;
 
     @Inject
     public ClasspathPackageProvider(Container container) {
         this.actionConfigBuilder = container.getInstance(ActionConfigBuilder.class, container.getInstance(String.class, ConventionConstants.CONVENTION_ACTION_CONFIG_BUILDER));
     }
 
+    @Override
     public void init(Configuration configuration) throws ConfigurationException {
     }
 
+    @Override
     public boolean needsReload() {
-        return actionConfigBuilder.needsReload(); 
+        return actionConfigBuilder.needsReload();
     }
 
+    @Override
     public void loadPackages() throws ConfigurationException {
         actionConfigBuilder.buildActionConfigs();
     }

--- a/plugins/convention/src/test/java/actions/MessageAction.java
+++ b/plugins/convention/src/test/java/actions/MessageAction.java
@@ -31,7 +31,7 @@ public class MessageAction extends ActionSupport {
         return message;
     }
 
-
+    @Override
     public String execute() {
         message = "Hello World";
         return SUCCESS;

--- a/plugins/convention/src/test/java/org/apache/struts2/convention/PackageBasedActionConfigBuilderTest.java
+++ b/plugins/convention/src/test/java/org/apache/struts2/convention/PackageBasedActionConfigBuilderTest.java
@@ -18,9 +18,21 @@
  */
 package org.apache.struts2.convention;
 
-import com.opensymphony.xwork2.*;
+import com.opensymphony.xwork2.ActionChainResult;
+import com.opensymphony.xwork2.ActionContext;
+import com.opensymphony.xwork2.FileManager;
+import com.opensymphony.xwork2.FileManagerFactory;
+import com.opensymphony.xwork2.ObjectFactory;
+import com.opensymphony.xwork2.Result;
 import com.opensymphony.xwork2.config.Configuration;
-import com.opensymphony.xwork2.config.entities.*;
+import com.opensymphony.xwork2.config.entities.ActionConfig;
+import com.opensymphony.xwork2.config.entities.ExceptionMappingConfig;
+import com.opensymphony.xwork2.config.entities.InterceptorConfig;
+import com.opensymphony.xwork2.config.entities.InterceptorMapping;
+import com.opensymphony.xwork2.config.entities.InterceptorStackConfig;
+import com.opensymphony.xwork2.config.entities.PackageConfig;
+import com.opensymphony.xwork2.config.entities.ResultConfig;
+import com.opensymphony.xwork2.config.entities.ResultTypeConfig;
 import com.opensymphony.xwork2.config.impl.DefaultConfiguration;
 import com.opensymphony.xwork2.factory.DefaultInterceptorFactory;
 import com.opensymphony.xwork2.factory.DefaultResultFactory;
@@ -32,12 +44,20 @@ import com.opensymphony.xwork2.util.fs.DefaultFileManager;
 import com.opensymphony.xwork2.util.fs.DefaultFileManagerFactory;
 import com.opensymphony.xwork2.util.reflection.ReflectionException;
 import junit.framework.TestCase;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.struts2.convention.actions.DefaultResultPathAction;
 import org.apache.struts2.convention.actions.NoAnnotationAction;
 import org.apache.struts2.convention.actions.Skip;
-import org.apache.struts2.convention.actions.action.*;
+import org.apache.struts2.convention.actions.action.ActionNameAction;
+import org.apache.struts2.convention.actions.action.ActionNamesAction;
+import org.apache.struts2.convention.actions.action.ClassLevelAnnotationAction;
+import org.apache.struts2.convention.actions.action.ClassLevelAnnotationDefaultMethodAction;
+import org.apache.struts2.convention.actions.action.ClassLevelAnnotationsAction;
+import org.apache.struts2.convention.actions.action.ClassLevelAnnotationsDefaultMethodAction;
+import org.apache.struts2.convention.actions.action.ClassNameAction;
+import org.apache.struts2.convention.actions.action.SingleActionNameAction;
+import org.apache.struts2.convention.actions.action.TestAction;
+import org.apache.struts2.convention.actions.action.TestExtends;
 import org.apache.struts2.convention.actions.allowedmethods.ClassLevelAllowedMethodsAction;
 import org.apache.struts2.convention.actions.allowedmethods.PackageLevelAllowedMethodsAction;
 import org.apache.struts2.convention.actions.allowedmethods.sub.PackageLevelAllowedMethodsChildAction;
@@ -61,7 +81,15 @@ import org.apache.struts2.convention.actions.parentpackage.ClassLevelParentPacka
 import org.apache.struts2.convention.actions.parentpackage.PackageLevelParentPackageAction;
 import org.apache.struts2.convention.actions.parentpackage.sub.ClassLevelParentPackageChildAction;
 import org.apache.struts2.convention.actions.parentpackage.sub.PackageLevelParentPackageChildAction;
-import org.apache.struts2.convention.actions.result.*;
+import org.apache.struts2.convention.actions.result.ActionLevelResultAction;
+import org.apache.struts2.convention.actions.result.ActionLevelResultsAction;
+import org.apache.struts2.convention.actions.result.ActionLevelResultsNamesAction;
+import org.apache.struts2.convention.actions.result.ClassLevelResultAction;
+import org.apache.struts2.convention.actions.result.ClassLevelResultsAction;
+import org.apache.struts2.convention.actions.result.GlobalResultAction;
+import org.apache.struts2.convention.actions.result.GlobalResultOverrideAction;
+import org.apache.struts2.convention.actions.result.InheritedResultExtends;
+import org.apache.struts2.convention.actions.result.OverrideResultAction;
 import org.apache.struts2.convention.actions.resultpath.ClassLevelResultPathAction;
 import org.apache.struts2.convention.actions.resultpath.PackageLevelResultPathAction;
 import org.apache.struts2.convention.actions.skip.Index;
@@ -69,15 +97,24 @@ import org.apache.struts2.convention.actions.transactions.TransNameAction;
 import org.apache.struts2.convention.annotation.Action;
 import org.apache.struts2.convention.annotation.Actions;
 import org.apache.struts2.convention.dontfind.DontFindMeAction;
+import org.apache.struts2.ognl.ProviderAllowlist;
 import org.apache.struts2.result.ServletDispatcherResult;
 import org.easymock.EasyMock;
 
 import javax.servlet.ServletContext;
 import java.net.MalformedURLException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static org.apache.struts2.convention.ReflectionTools.getAnnotation;
-import static org.easymock.EasyMock.*;
+import static org.easymock.EasyMock.checkOrder;
+import static org.easymock.EasyMock.createStrictMock;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.verify;
 
 /**
  * <p>
@@ -388,6 +425,7 @@ public class PackageBasedActionConfigBuilderTest extends TestCase {
         fileManagerFactory.setFileManager(new DefaultFileManager());
         builder.setFileManagerFactory(fileManagerFactory);
         builder.setPackageLocatorsBase("org.apache.struts2.convention.actions");
+        builder.setProviderAllowlist(new ProviderAllowlist());
         builder.buildActionConfigs();
         verify(resultMapBuilder);
 

--- a/plugins/json/src/test/java/org/apache/struts2/json/JSONValidationInterceptorTest.java
+++ b/plugins/json/src/test/java/org/apache/struts2/json/JSONValidationInterceptorTest.java
@@ -29,6 +29,7 @@ import com.opensymphony.xwork2.validator.annotations.IntRangeFieldValidator;
 import com.opensymphony.xwork2.validator.annotations.RequiredStringValidator;
 import com.opensymphony.xwork2.validator.annotations.StringLengthFieldValidator;
 import org.apache.struts2.StrutsStatics;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 import org.apache.struts2.interceptor.validation.AnnotationValidationInterceptor;
 import org.apache.struts2.interceptor.validation.SkipValidation;
 import org.apache.struts2.junit.StrutsTestCase;
@@ -214,6 +215,7 @@ public class JSONValidationInterceptorTest extends StrutsTestCase {
         private boolean executed = false;
         private String password;
 
+        @Override
         public String execute() {
             executed = true;
             return Action.SUCCESS;
@@ -230,11 +232,13 @@ public class JSONValidationInterceptorTest extends StrutsTestCase {
 
         @StringLengthFieldValidator(minLength = "2", message = "Too short")
         @EmailValidator(message = "This is no email")
+        @StrutsParameter
         public void setText(String text) {
             this.text = text;
         }
 
         @RequiredStringValidator(message = "Password isn't correct")
+        @StrutsParameter
         public void setPassword(String password) {
             this.password = password;
         }
@@ -248,6 +252,7 @@ public class JSONValidationInterceptorTest extends StrutsTestCase {
         }
 
         @IntRangeFieldValidator(min = "-1", message = "Min value is -1")
+        @StrutsParameter
         public void setValue(int value) {
             this.value = value;
         }

--- a/plugins/junit/src/test/java/org/apache/struts2/junit/JUnitTestAction.java
+++ b/plugins/junit/src/test/java/org/apache/struts2/junit/JUnitTestAction.java
@@ -19,6 +19,7 @@
 package org.apache.struts2.junit;
 
 import com.opensymphony.xwork2.ActionSupport;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 import org.springframework.beans.factory.annotation.Autowired;
 
 public class JUnitTestAction extends ActionSupport {
@@ -33,6 +34,7 @@ public class JUnitTestAction extends ActionSupport {
         return name;
     }
 
+    @StrutsParameter
     public void setName(String name) {
         this.name = name;
     }

--- a/plugins/junit/src/test/java/org/apache/struts2/junit/session/SessionGetAction.java
+++ b/plugins/junit/src/test/java/org/apache/struts2/junit/session/SessionGetAction.java
@@ -27,6 +27,7 @@ import com.opensymphony.xwork2.ActionSupport;
 public class SessionGetAction extends ActionSupport {
     private static final long serialVersionUID = 8366502863472148631L;
 
+    @Override
     public String execute() {
         return ActionSupport.SUCCESS;
     }

--- a/plugins/junit/src/test/java/org/apache/struts2/junit/session/SessionSetAction.java
+++ b/plugins/junit/src/test/java/org/apache/struts2/junit/session/SessionSetAction.java
@@ -30,6 +30,7 @@ public class SessionSetAction extends ActionSupport {
     public String SESSION_KEY = "sessionKey";
     public String SESSION_VALUE = "sessionValue";
 
+    @Override
     public String execute() {
         ActionContext.getContext().getSession().put(SESSION_KEY, SESSION_VALUE);
         return ActionSupport.SUCCESS;

--- a/plugins/oval/src/test/java/org/apache/struts2/oval/interceptor/FieldsWithProfiles.java
+++ b/plugins/oval/src/test/java/org/apache/struts2/oval/interceptor/FieldsWithProfiles.java
@@ -20,6 +20,7 @@ package org.apache.struts2.oval.interceptor;
 
 import com.opensymphony.xwork2.ActionSupport;
 import net.sf.oval.constraint.NotNull;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 import org.apache.struts2.oval.annotation.Profiles;
 
 public class FieldsWithProfiles extends ActionSupport {
@@ -46,6 +47,7 @@ public class FieldsWithProfiles extends ActionSupport {
         return firstName;
     }
 
+    @StrutsParameter
     public void setFirstName(String firstName) {
         this.firstName = firstName;
     }
@@ -54,6 +56,7 @@ public class FieldsWithProfiles extends ActionSupport {
         return lastName;
     }
 
+    @StrutsParameter
     public void setLastName(String lastName) {
         this.lastName = lastName;
     }
@@ -62,6 +65,7 @@ public class FieldsWithProfiles extends ActionSupport {
         return middleName;
     }
 
+    @StrutsParameter
     public void setMiddleName(String middleName) {
         this.middleName = middleName;
     }

--- a/plugins/oval/src/test/java/org/apache/struts2/oval/interceptor/MemberObject.java
+++ b/plugins/oval/src/test/java/org/apache/struts2/oval/interceptor/MemberObject.java
@@ -18,17 +18,17 @@
  */
 package org.apache.struts2.oval.interceptor;
 
-import net.sf.oval.constraint.AssertValid;
-
-import org.apache.struts2.oval.interceptor.domain.Person;
-
 import com.opensymphony.xwork2.ActionSupport;
+import net.sf.oval.constraint.AssertValid;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
+import org.apache.struts2.oval.interceptor.domain.Person;
 
 public class MemberObject extends ActionSupport {
 
 	@AssertValid
-	private Person person = new Person();
+	private final Person person = new Person();
 
+	@StrutsParameter(depth = 2)
 	public Person getPerson() {
 		return person;
 	}

--- a/plugins/oval/src/test/java/org/apache/struts2/oval/interceptor/ModelDrivenAction.java
+++ b/plugins/oval/src/test/java/org/apache/struts2/oval/interceptor/ModelDrivenAction.java
@@ -18,18 +18,19 @@
  */
 package org.apache.struts2.oval.interceptor;
 
-import net.sf.oval.constraint.AssertValid;
-
-import org.apache.struts2.oval.interceptor.domain.Person;
-
 import com.opensymphony.xwork2.ActionSupport;
 import com.opensymphony.xwork2.ModelDriven;
+import net.sf.oval.constraint.AssertValid;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
+import org.apache.struts2.oval.interceptor.domain.Person;
 
 public class ModelDrivenAction extends ActionSupport implements ModelDriven<Person> {
 
 	@AssertValid
-	private Person person = new Person();
+	private final Person person = new Person();
 
+	@StrutsParameter(depth = 2)
+	@Override
 	public Person getModel() {
 		return person;
 	}

--- a/plugins/oval/src/test/java/org/apache/struts2/oval/interceptor/SimpleField.java
+++ b/plugins/oval/src/test/java/org/apache/struts2/oval/interceptor/SimpleField.java
@@ -18,10 +18,11 @@
  */
 package org.apache.struts2.oval.interceptor;
 
+import com.opensymphony.xwork2.ActionSupport;
 import net.sf.oval.constraint.Length;
 import net.sf.oval.constraint.NotEmpty;
 import net.sf.oval.constraint.NotNull;
-import com.opensymphony.xwork2.ActionSupport;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
 public class SimpleField extends ActionSupport{
     @NotNull()
@@ -35,10 +36,12 @@ public class SimpleField extends ActionSupport{
         return name;
     }
 
+    @StrutsParameter
     public void setName(String name) {
         this.name = name;
     }
 
+    @Override
     public void validate() {
         this.validateCalled = true;
     }

--- a/plugins/oval/src/test/java/org/apache/struts2/oval/interceptor/SimpleFieldI18n.java
+++ b/plugins/oval/src/test/java/org/apache/struts2/oval/interceptor/SimpleFieldI18n.java
@@ -21,6 +21,7 @@ package org.apache.struts2.oval.interceptor;
 import com.opensymphony.xwork2.ActionSupport;
 import net.sf.oval.constraint.Length;
 import net.sf.oval.constraint.NotNull;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
 public class SimpleFieldI18n  extends ActionSupport {
     @NotNull(message = "notnull.field")
@@ -31,6 +32,7 @@ public class SimpleFieldI18n  extends ActionSupport {
         return name;
     }
 
+    @StrutsParameter
     public void setName(String name) {
         this.name = name;
     }

--- a/plugins/oval/src/test/java/org/apache/struts2/oval/interceptor/SimpleFieldI18nDefaultKey.java
+++ b/plugins/oval/src/test/java/org/apache/struts2/oval/interceptor/SimpleFieldI18nDefaultKey.java
@@ -20,8 +20,7 @@ package org.apache.struts2.oval.interceptor;
 
 import com.opensymphony.xwork2.ActionSupport;
 import net.sf.oval.constraint.NotNull;
-import net.sf.oval.constraint.NotEmpty;
-import net.sf.oval.constraint.Length;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
 public class SimpleFieldI18nDefaultKey extends ActionSupport {
     @NotNull(message = "notnull.field")
@@ -31,6 +30,7 @@ public class SimpleFieldI18nDefaultKey extends ActionSupport {
         return name;
     }
 
+    @StrutsParameter
     public void setName(String name) {
         this.name = name;
     }

--- a/plugins/oval/src/test/java/org/apache/struts2/oval/interceptor/SimpleFieldJPAAnnotations.java
+++ b/plugins/oval/src/test/java/org/apache/struts2/oval/interceptor/SimpleFieldJPAAnnotations.java
@@ -19,6 +19,7 @@
 package org.apache.struts2.oval.interceptor;
 
 import com.opensymphony.xwork2.ActionSupport;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
 import javax.persistence.Basic;
 
@@ -30,6 +31,7 @@ public class SimpleFieldJPAAnnotations extends ActionSupport {
         return firstName;
     }
 
+    @StrutsParameter
     public void setFirstName(String firstName) {
         this.firstName = firstName;
     }

--- a/plugins/oval/src/test/java/org/apache/struts2/oval/interceptor/SimpleFieldOGNLExpression.java
+++ b/plugins/oval/src/test/java/org/apache/struts2/oval/interceptor/SimpleFieldOGNLExpression.java
@@ -18,8 +18,9 @@
  */
 package org.apache.struts2.oval.interceptor;
 
-import net.sf.oval.constraint.Assert;
 import com.opensymphony.xwork2.ActionSupport;
+import net.sf.oval.constraint.Assert;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
 public class SimpleFieldOGNLExpression extends ActionSupport {
 
@@ -30,6 +31,7 @@ public class SimpleFieldOGNLExpression extends ActionSupport {
         return name;
     }
 
+    @StrutsParameter
     public void setName(String name) {
         this.name = name;
     }

--- a/plugins/oval/src/test/java/org/apache/struts2/oval/interceptor/SimpleFieldsXML.java
+++ b/plugins/oval/src/test/java/org/apache/struts2/oval/interceptor/SimpleFieldsXML.java
@@ -19,8 +19,8 @@
 package org.apache.struts2.oval.interceptor;
 
 import com.opensymphony.xwork2.ActionSupport;
-import net.sf.oval.constraint.NotEmpty;
 import net.sf.oval.constraint.NotNull;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
 public class SimpleFieldsXML extends ActionSupport {
     private String firstName;
@@ -32,6 +32,7 @@ public class SimpleFieldsXML extends ActionSupport {
         return firstName;
     }
 
+    @StrutsParameter
     public void setFirstName(String firstName) {
         this.firstName = firstName;
     }
@@ -40,6 +41,7 @@ public class SimpleFieldsXML extends ActionSupport {
         return lastName;
     }
 
+    @StrutsParameter
     public void setLastName(String lastName) {
         this.lastName = lastName;
     }

--- a/plugins/oval/src/test/java/org/apache/struts2/oval/interceptor/SimpleFieldsXMLChild.java
+++ b/plugins/oval/src/test/java/org/apache/struts2/oval/interceptor/SimpleFieldsXMLChild.java
@@ -18,6 +18,8 @@
  */
 package org.apache.struts2.oval.interceptor;
 
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
+
 public class SimpleFieldsXMLChild extends SimpleFieldsXML {
     private String middleName;
 
@@ -25,6 +27,7 @@ public class SimpleFieldsXMLChild extends SimpleFieldsXML {
         return middleName;
     }
 
+    @StrutsParameter
     public void setMiddleName(String middleName) {
         this.middleName = middleName;
     }

--- a/plugins/oval/src/test/java/org/apache/struts2/oval/interceptor/SimpleMethod.java
+++ b/plugins/oval/src/test/java/org/apache/struts2/oval/interceptor/SimpleMethod.java
@@ -19,9 +19,10 @@
 package org.apache.struts2.oval.interceptor;
 
 import com.opensymphony.xwork2.ActionSupport;
+import net.sf.oval.configuration.annotation.IsInvariant;
 import net.sf.oval.constraint.Length;
 import net.sf.oval.constraint.NotNull;
-import net.sf.oval.configuration.annotation.IsInvariant;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
 public class SimpleMethod extends ActionSupport {
     private String name;
@@ -33,6 +34,7 @@ public class SimpleMethod extends ActionSupport {
         return name;
     }
 
+    @StrutsParameter
     public void setSomeName(String name) {
         this.name = name;
     }

--- a/plugins/rest/src/test/java/org/apache/struts2/rest/RestActionInvocationTest.java
+++ b/plugins/rest/src/test/java/org/apache/struts2/rest/RestActionInvocationTest.java
@@ -32,6 +32,7 @@ import com.opensymphony.xwork2.ognl.OgnlUtil;
 import com.opensymphony.xwork2.util.XWorkTestCaseHelper;
 import junit.framework.TestCase;
 import org.apache.struts2.ServletActionContext;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 import org.apache.struts2.result.HttpHeaderResult;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -53,7 +54,7 @@ public class RestActionInvocationTest extends TestCase {
 	@Override
 	protected void setUp() throws Exception {
 		super.setUp();
-		
+
 		restActionInvocation = new RestActionInvocationTester();
 		request = new MockHttpServletRequest();
 		response = new MockHttpServletResponse();
@@ -61,7 +62,7 @@ public class RestActionInvocationTest extends TestCase {
 		ServletActionContext.setResponse(response);
 
 	}
-	
+
 	/**
 	 * Test the correct action results: null, String, HttpHeaders, Result
 	 * @throws Exception
@@ -71,12 +72,12 @@ public class RestActionInvocationTest extends TestCase {
 		Object methodResult = "index";
 		ActionConfig actionConfig = restActionInvocation.getProxy().getConfig();
 		assertEquals("index", restActionInvocation.saveResult(actionConfig, methodResult));
-    	
+
 		setUp();
     	methodResult = new DefaultHttpHeaders("show");
     	assertEquals("show", restActionInvocation.saveResult(actionConfig, methodResult));
     	assertEquals(methodResult, restActionInvocation.httpHeaders);
-    	
+
 		setUp();
     	methodResult = new HttpHeaderResult(HttpServletResponse.SC_ACCEPTED);
     	assertEquals(null, restActionInvocation.saveResult(actionConfig, methodResult));
@@ -89,18 +90,18 @@ public class RestActionInvocationTest extends TestCase {
 
     		// ko
     		assertFalse(true);
-    		
+
     	} catch (ConfigurationException c) {
     		// ok, object not allowed
     	}
 	}
-	
+
 	/**
 	 * Test the target selection: exception, error messages, model and null
 	 * @throws Exception
 	 */
 	public void testSelectTarget() throws Exception {
-		
+
 		// Exception
 		Exception e = new Exception();
 		restActionInvocation.getStack().set("exception", e);
@@ -118,7 +119,7 @@ public class RestActionInvocationTest extends TestCase {
     	errors.put("actionErrors", list);
     	restActionInvocation.selectTarget();
 		assertEquals(errors, restActionInvocation.target);
-		
+
     	// Model with get and no content in post, put, delete
     	setUp();
 		RestAction restAction = (RestAction)restActionInvocation.getAction();
@@ -168,18 +169,18 @@ public class RestActionInvocationTest extends TestCase {
 		};
 		model.add("Item");
 		restAction.model = model;
-		
+
 		restActionInvocation.processResult();
 		assertEquals(SC_NOT_MODIFIED, response.getStatus());
-        
+
     }
-	
+
 	/**
 	 * Test the default error result.
 	 * @throws Exception
 	 */
 	public void testDefaultErrorResult() throws Exception {
-		
+
 		// Exception
 		Exception e = new Exception();
 		restActionInvocation.getStack().set("exception", e);
@@ -189,24 +190,24 @@ public class RestActionInvocationTest extends TestCase {
 		List<String> model = new ArrayList<String>();
 		model.add("Item");
 		restAction.model = model;
-		
+
 		restActionInvocation.setDefaultErrorResultName("default-error");
-		ResultConfig resultConfig = new ResultConfig.Builder("default-error", 
+		ResultConfig resultConfig = new ResultConfig.Builder("default-error",
 			"org.apache.struts2.result.HttpHeaderResult")
 	    	.addParam("status", "123").build();
-	    ActionConfig actionConfig = new ActionConfig.Builder("org.apache.rest", 
+	    ActionConfig actionConfig = new ActionConfig.Builder("org.apache.rest",
 				"RestAction", "org.apache.rest.RestAction")
 	    	.addResultConfig(resultConfig)
 	    	.build();
 	    ((MockActionProxy)restActionInvocation.getProxy()).setConfig(actionConfig);
-		
+
 		restActionInvocation.processResult();
 		assertEquals(123, response.getStatus());
-		
+
 	}
-	
+
 	public void testNoResult() throws Exception {
-		
+
 		RestAction restAction = (RestAction)restActionInvocation.getAction();
 		List<String> model = new ArrayList<String>();
 		model.add("Item");
@@ -219,34 +220,34 @@ public class RestActionInvocationTest extends TestCase {
 
     		// ko
     		assertFalse(true);
-    		
+
     	} catch (ConfigurationException c) {
     		// ok, no result
     	}
 
 	}
-	
+
 	/**
 	 * Test the global execution
 	 * @throws Exception
 	 */
 	public void testInvoke() throws Exception {
-        
+
 	    // Default index method return 'success'
 	    ((MockActionProxy)restActionInvocation.getProxy()).setMethod("index");
 
 	    // Define result 'success'
-		ResultConfig resultConfig = new ResultConfig.Builder("success", 
+		ResultConfig resultConfig = new ResultConfig.Builder("success",
 			"org.apache.struts2.result.HttpHeaderResult")
 	    	.addParam("status", "123").build();
-	    ActionConfig actionConfig = new ActionConfig.Builder("org.apache.rest", 
+	    ActionConfig actionConfig = new ActionConfig.Builder("org.apache.rest",
 				"RestAction", "org.apache.rest.RestAction")
 	    	.addResultConfig(resultConfig)
 	    	.build();
 	    ((MockActionProxy)restActionInvocation.getProxy()).setConfig(actionConfig);
 
 		request.setMethod("GET");
-		
+
         restActionInvocation.setOgnlUtil(new OgnlUtil());
         restActionInvocation.invoke();
 
@@ -264,7 +265,7 @@ public class RestActionInvocationTest extends TestCase {
             interceptorMappings.add(new InterceptorMapping("interceptor", mockInterceptor));
             interceptors = interceptorMappings.iterator();
             MockActionProxy actionProxy = new MockActionProxy();
-            ActionConfig actionConfig = new ActionConfig.Builder("org.apache.rest", 
+            ActionConfig actionConfig = new ActionConfig.Builder("org.apache.rest",
     				"RestAction", "org.apache.rest.RestAction").build();
             actionProxy.setConfig(actionConfig);
             proxy = actionProxy;
@@ -280,18 +281,20 @@ public class RestActionInvocationTest extends TestCase {
 			container = ActionContext.getContext().getContainer();
 			stack = ActionContext.getContext().getValueStack();
 			objectFactory = container.getInstance(ObjectFactory.class);
-			
+
         }
-    	
+
     }
 
-    class RestAction extends RestActionSupport implements ModelDriven<List<String>> {
+    static class RestAction extends RestActionSupport implements ModelDriven<List<String>> {
 
     	List<String> model;
-		
+
+		@StrutsParameter(depth = 1)
+		@Override
     	public List<String> getModel() {
 			return model;
 		}
-    	
+
     }
 }

--- a/plugins/spring/src/test/java/com/opensymphony/xwork2/ModelDrivenAction.java
+++ b/plugins/spring/src/test/java/com/opensymphony/xwork2/ModelDrivenAction.java
@@ -19,6 +19,8 @@
 package com.opensymphony.xwork2;
 
 
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
+
 /**
  * ModelDrivenAction
  *
@@ -28,9 +30,9 @@ package com.opensymphony.xwork2;
 public class ModelDrivenAction extends ActionSupport implements ModelDriven {
 
     private String foo;
-    private TestBean model = new TestBean();
+    private final TestBean model = new TestBean();
 
-
+    @StrutsParameter
     public void setFoo(String foo) {
         this.foo = foo;
     }
@@ -42,6 +44,8 @@ public class ModelDrivenAction extends ActionSupport implements ModelDriven {
     /**
      * @return the model to be pushed onto the ValueStack after the Action itself
      */
+    @StrutsParameter(depth = 2)
+    @Override
     public Object getModel() {
         return model;
     }


### PR DESCRIPTION
WW-5440
--
* Fixed `struts2-convention-plugin` compatibility with OGNL allowlist, Actions are now auto-allowlisted as expected
* Fixed `struts2-config-browser-plugin` compatibility with `struts.parameters.requireAnnotations=true`
* Fixed Showcase App Hangman Action by adding appropriate classes to OGNL allowlist configuration
* Fixed a number of other Showcase App Actions which required further annotating/allowlisting
* Deprecated `AnnotationParameterFilterInterceptor` which is superseded by `@StrutsParameter` capability

I also went through and did a batch application of `@StrutsParameter` even in unit test Actions in which they may not be strictly required. Did this as a precautionary measure against any other regressions or unintended test behaviour.