### PR TITLE
WW-5442 Enforce allowlist for OgnlReflectionProvider

### DIFF
--- a/core/src/main/java/com/opensymphony/xwork2/config/providers/XmlDocConfigurationProvider.java
+++ b/core/src/main/java/com/opensymphony/xwork2/config/providers/XmlDocConfigurationProvider.java
@@ -109,6 +109,11 @@ public abstract class XmlDocConfigurationProvider implements ConfigurationProvid
         this.valueSubstitutor = valueSubstitutor;
     }
 
+    @Inject
+    public void setProviderAllowlist(ProviderAllowlist providerAllowlist) {
+        this.providerAllowlist = providerAllowlist;
+    }
+
     public XmlDocConfigurationProvider(Document... documents) {
         this.documents = Arrays.asList(documents);
     }
@@ -135,11 +140,6 @@ public abstract class XmlDocConfigurationProvider implements ConfigurationProvid
         this.configuration = configuration;
     }
 
-    private void registerAllowlist() {
-        providerAllowlist = configuration.getContainer().getInstance(ProviderAllowlist.class);
-        providerAllowlist.registerAllowlist(this, allowlistClasses);
-    }
-
     @Override
     public void destroy() {
         if (providerAllowlist != null) {
@@ -152,6 +152,7 @@ public abstract class XmlDocConfigurationProvider implements ConfigurationProvid
         allowlistClasses.add(clazz);
         allowlistClasses.addAll(ClassUtils.getAllSuperclasses(clazz));
         allowlistClasses.addAll(ClassUtils.getAllInterfaces(clazz));
+        providerAllowlist.registerAllowlist(this, allowlistClasses);
         return clazz;
     }
 
@@ -333,7 +334,6 @@ public abstract class XmlDocConfigurationProvider implements ConfigurationProvid
         }
 
         declaredPackages.clear();
-        registerAllowlist();
         configuration = null;
     }
 

--- a/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlUtil.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlUtil.java
@@ -859,11 +859,6 @@ public class OgnlUtil {
         return createDefaultContext(root, null);
     }
 
-    /**
-     * Note that the allowlist capability is not enforced by the {@link OgnlContext} returned by this method. Currently,
-     * this context is only leveraged by some public methods on {@link OgnlUtil} which are called by
-     * {@link OgnlReflectionProvider}.
-     */
     protected Map<String, Object> createDefaultContext(Object root, ClassResolver resolver) {
         if (resolver == null) {
             resolver = container.getInstance(RootAccessor.class);
@@ -871,11 +866,7 @@ public class OgnlUtil {
                 throw new IllegalStateException("Cannot find ClassResolver");
             }
         }
-
-        SecurityMemberAccess memberAccess = container.getInstance(SecurityMemberAccess.class);
-        memberAccess.useEnforceAllowlistEnabled(Boolean.FALSE.toString());
-
-        return Ognl.createDefaultContext(root, memberAccess, resolver, defaultConverter);
+        return Ognl.createDefaultContext(root, container.getInstance(SecurityMemberAccess.class), resolver, defaultConverter);
     }
 
     @FunctionalInterface


### PR DESCRIPTION
WW-5442
--
Previously, I had exempted the `OgnlReflectionProvider` from the allowlist due to some initialisation issues but I've fixed this now by updating the allowlist as each class is loaded when XML configuration is being read.