### PR TITLE
WW-5451 Fixes NPE when iterator starts with null

### DIFF
--- a/core/src/main/java/org/apache/struts2/components/IteratorComponent.java
+++ b/core/src/main/java/org/apache/struts2/components/IteratorComponent.java
@@ -306,7 +306,10 @@ public class IteratorComponent extends ContextBean {
         if ((iterator != null) && iterator.hasNext()) {
             Object currentValue = iterator.next();
             stack.push(currentValue);
-            threadAllowlist.allowClass(currentValue.getClass());
+
+            if (currentValue != null) {
+                threadAllowlist.allowClass(currentValue.getClass());
+            }
 
             String var = getVar();
 

--- a/core/src/test/java/org/apache/struts2/components/IteratorComponentTest.java
+++ b/core/src/test/java/org/apache/struts2/components/IteratorComponentTest.java
@@ -184,6 +184,42 @@ public class IteratorComponentTest extends StrutsInternalTestCase {
         assertEquals("1, 2, , 4, ", out.getBuffer().toString());
     }
 
+    public void testIteratorWithNullsOnly() {
+        // given
+        stack.push(new FooAction() {
+            private final List<String> items = Arrays.asList(null, null, null);
+
+            public List<String> getItems() {
+                return items;
+            }
+        });
+
+        StringWriter out = new StringWriter();
+
+        ic.setValue("items");
+        ic.setVar("val");
+        Property prop = new Property(stack);
+
+        ic.getComponentStack().push(prop);
+        ic.getComponentStack().push(prop);
+        ic.getComponentStack().push(prop);
+        ic.getComponentStack().push(prop);
+
+        String body = ", ";
+
+        // when
+        assertTrue(ic.start(out));
+
+        for (int i = 0; i < 3; i++) {
+            prop.start(out);
+            prop.end(out, body);
+            ic.end(out, null);
+        }
+
+        // then
+        assertEquals(", , , ", out.getBuffer().toString());
+    }
+
     public void testIteratorWithDifferentLocale() {
         // given
         ActionContext.getContext().withLocale(new Locale("fa_IR"));

--- a/core/src/test/java/org/apache/struts2/views/jsp/IteratorTagTest.java
+++ b/core/src/test/java/org/apache/struts2/views/jsp/IteratorTagTest.java
@@ -20,7 +20,6 @@ package org.apache.struts2.views.jsp;
 
 import com.mockobjects.servlet.MockBodyContent;
 import com.mockobjects.servlet.MockJspWriter;
-import com.opensymphony.xwork2.ActionContext;
 import org.apache.commons.collections.ListUtils;
 
 import javax.servlet.jsp.JspException;
@@ -720,6 +719,41 @@ public class IteratorTagTest extends AbstractUITagTest {
         tag.setBegin("0");
         tag.setEnd("2");
         validateCounter(new String[]{"a", "b", "c"});
+    }
+
+    public void testNullElements() throws JspException {
+        Foo foo = new Foo();
+        foo.setArray(new String[3]);
+
+        stack.push(foo);
+        tag.setValue("array");
+        tag.setVar("anId");
+
+        // one
+        int result = tag.doStartTag();
+        assertEquals(TagSupport.EVAL_BODY_INCLUDE, result);
+        assertNull(stack.peek());
+        assertNull(stack.getContext().get("anId"));
+
+        tag.doInitBody();
+
+        // two
+        result = tag.doAfterBody();
+        assertEquals(TagSupport.EVAL_BODY_AGAIN, result);
+        assertNull(stack.peek());
+        assertNull(stack.getContext().get("anId"));
+
+        // three
+        result = tag.doAfterBody();
+        assertEquals(TagSupport.EVAL_BODY_AGAIN, result);
+        assertNull(stack.peek());
+        assertNull(stack.getContext().get("anId"));
+
+        result = tag.doAfterBody();
+        assertEquals(TagSupport.SKIP_BODY, result);
+
+        result = tag.doEndTag();
+        assertEquals(TagSupport.EVAL_PAGE, result);
     }
 
     public void testCounterWithArray() throws JspException {


### PR DESCRIPTION
PR fixes NPE
```
ERROR org.apache.struts2.dispatcher.DefaultDispatcherErrorHandler - Exception occurred during processing request: null
java.lang.NullPointerException: null
    at org.apache.struts2.components.IteratorComponent.start(IteratorComponent.java:309) ~[struts2-core-6.4.0.jar:6.4.0]
...
```

Fixes [WW-5451](https://issues.apache.org/jira/browse/WW-5451)