### PR TITLE
WW-4062 Further optimisation of OgnlException caching

### DIFF
--- a/core/src/test/java/com/opensymphony/xwork2/ognl/OgnlUtilTest.java
+++ b/core/src/test/java/com/opensymphony/xwork2/ognl/OgnlUtilTest.java
@@ -1650,14 +1650,15 @@ public class OgnlUtilTest extends XWorkTestCase {
         StackTraceElement[] stackTrace = e.getStackTrace();
         assertThat(stackTrace).isEmpty();
         StackTraceElement[] causeStackTrace = e.getCause().getStackTrace();
+        assertThat(causeStackTrace).isNotEmpty();
 
         OgnlException e2 = assertThrows(OgnlException.class, () -> ognlUtil.compile(".literal.$something"));
-        StackTraceElement[] stackTrace2 = e.getStackTrace();
+        StackTraceElement[] stackTrace2 = e2.getStackTrace();
         assertThat(stackTrace2).isEmpty();
-        StackTraceElement[] causeStackTrace2 = e.getCause().getStackTrace();
+        StackTraceElement[] causeStackTrace2 = e2.getCause().getStackTrace();
 
+        assertThat(causeStackTrace2).isEmpty(); // Stack trace cleared before rethrow
         assertSame(e, e2); // Exception is cached
-        assertThat(causeStackTrace).isNotEqualTo(causeStackTrace2); // Stack trace refreshed
     }
 
     /**


### PR DESCRIPTION
WW-4062
--
Follow-up for #1013 - I was looking at the flame graph for this particular code flow (this is before the previous PR was merged) and observed that filling the stack trace is the largest contributor. Thus, we can gain more performance here by not refreshing the stack trace for cached exceptions. Given most of these exceptions are caught silently I don't expect the lack of stack trace to be an issue. If the stack trace is necessary for debugging purposes, then we can temporarily disable caching using `struts.ognl.enableExpressionCache=false`.

As the Jira issue suggests - this is primarily an issue for applications using the Velocity integration where the `null` fallback behaviour results in these invalid OGNL expressions attempting to be compiled repeatedly.

![image](https://github.com/user-attachments/assets/7c08053b-dd5e-4a02-9adc-dbd98e679031)
