### PR TITLE
WW-5450 Sets RequestDispatcher#FORWARD_REQUEST_URI attribute when forwarding

### DIFF
--- a/core/src/main/java/org/apache/struts2/result/ServletDispatcherResult.java
+++ b/core/src/main/java/org/apache/struts2/result/ServletDispatcherResult.java
@@ -166,6 +166,9 @@ public class ServletDispatcherResult extends StrutsResultSupport {
                 request.setAttribute("struts.view_uri", finalLocation);
                 request.setAttribute("struts.request_uri", request.getRequestURI());
 
+                LOG.debug("Sets request attribute: {} to value: {}", RequestDispatcher.FORWARD_REQUEST_URI, finalLocation);
+                request.setAttribute(RequestDispatcher.FORWARD_REQUEST_URI, finalLocation);
+
                 dispatcher.forward(request, response);
             } else {
                 LOG.debug("Including location: {}", finalLocation);

--- a/core/src/test/java/org/apache/struts2/result/ServletDispatcherResultTest.java
+++ b/core/src/test/java/org/apache/struts2/result/ServletDispatcherResultTest.java
@@ -75,6 +75,7 @@ public class ServletDispatcherResultTest extends StrutsInternalTestCase implemen
         requestMock.expectAndReturn("getRequestDispatcher", C.args(C.eq("foo.jsp")), dispatcherMock.proxy());
         requestMock.expect("setAttribute", C.ANY_ARGS); // this is a bad mock, but it works
         requestMock.expect("setAttribute", C.ANY_ARGS); // this is a bad mock, but it works
+        requestMock.expect("setAttribute", C.args(C.eq(RequestDispatcher.FORWARD_REQUEST_URI), C.eq("foo.jsp")));
         requestMock.matchAndReturn("getRequestURI", "foo.jsp");
 
         Mock responseMock = new Mock(HttpServletResponse.class);
@@ -108,6 +109,7 @@ public class ServletDispatcherResultTest extends StrutsInternalTestCase implemen
         requestMock.expectAndReturn("getRequestDispatcher", C.args(C.eq("foo.jsp?bar=1")), dispatcherMock.proxy());
         requestMock.expect("setAttribute", C.ANY_ARGS); // this is a bad mock, but it works
         requestMock.expect("setAttribute", C.ANY_ARGS); // this is a bad mock, but it works
+        requestMock.expect("setAttribute", C.args(C.eq(RequestDispatcher.FORWARD_REQUEST_URI), C.eq("foo.jsp?bar=1")));
         requestMock.matchAndReturn("getRequestURI", "foo.jsp");
 
         Mock responseMock = new Mock(HttpServletResponse.class);


### PR DESCRIPTION
Closes [WW-5450](https://issues.apache.org/jira/browse/WW-5450)