### PR TITLE
Potential mitigation for WW-5466

### DIFF
--- a/core/src/main/java/org/apache/struts2/dispatcher/multipart/JakartaMultiPartRequest.java
+++ b/core/src/main/java/org/apache/struts2/dispatcher/multipart/JakartaMultiPartRequest.java
@@ -142,7 +142,7 @@ public class JakartaMultiPartRequest extends AbstractMultiPartRequest {
             }
 
             long size = item.getSize();
-            if (size > maxStringLength) {
+            if (maxStringLength != null && size > maxStringLength) {
                 LOG.debug("Form field {} of size {} bytes exceeds limit of {}.", sanitizeNewlines(item.getFieldName()), size, maxStringLength);
                 String errorKey = "struts.messages.upload.error.parameter.too.long";
                 LocalizedMessage localizedMessage = new LocalizedMessage(this.getClass(), errorKey, null,

--- a/core/src/test/java/org/apache/struts2/interceptor/ActionFileUploadInterceptorTest.java
+++ b/core/src/test/java/org/apache/struts2/interceptor/ActionFileUploadInterceptorTest.java
@@ -324,6 +324,148 @@ public class ActionFileUploadInterceptorTest extends StrutsInternalTestCase {
         assertNotNull("deleteme.txt", files.get(0).getOriginalName());
     }
 
+    public void testSuccessUploadOfATextFileMultipartRequestNoMaxParamsSet() throws Exception {
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        req.setMethod("post");
+        req.addHeader("Content-type", "multipart/form-data; boundary=---1234");
+
+        // inspired by the unit tests for jakarta commons fileupload
+        String content = ("-----1234\r\n" +
+            "Content-Disposition: form-data; name=\"file\"; filename=\"deleteme.txt\"\r\n" +
+            "Content-Type: text/html\r\n" +
+            "\r\n" +
+            "Unit test of ActionFileUploadInterceptor" +
+            "\r\n" +
+            "-----1234--\r\n");
+        req.setContent(content.getBytes(StandardCharsets.US_ASCII));
+
+        MyFileUploadAction action = new MyFileUploadAction();
+
+        MockActionInvocation mai = new MockActionInvocation();
+        mai.setAction(action);
+        mai.setResultCode("success");
+        mai.setInvocationContext(ActionContext.getContext());
+        ActionContext.getContext().withServletRequest(createMultipartRequestNoMaxParamsSet(req));
+
+        interceptor.intercept(mai);
+
+        assertFalse(action.hasErrors());
+
+        List<UploadedFile> files = action.getUploadFiles();
+
+        assertNotNull(files);
+        assertEquals(1, files.size());
+        assertEquals("text/html", files.get(0).getContentType());
+        assertNotNull("deleteme.txt", files.get(0).getOriginalName());
+    }
+
+    public void testSuccessUploadOfATextFileMultipartRequestWithNormalFieldsMaxParamsSet() throws Exception {
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        req.setMethod("post");
+        req.addHeader("Content-type", "multipart/form-data; boundary=---1234");
+
+        // inspired by the unit tests for jakarta commons fileupload
+        String content = ("-----1234\r\n" +
+            "Content-Disposition: form-data; name=\"file\"; filename=\"deleteme.txt\"\r\n" +
+            "Content-Type: text/html\r\n" +
+            "\r\n" +
+            "Unit test of ActionFileUploadInterceptor" +
+            "\r\n" +
+            "-----1234\r\n" +
+            "Content-Disposition: form-data; name=\"normalFormField1\"\r\n" +
+            "\r\n" +
+            "normal field 1" +
+            "\r\n" +
+            "-----1234\r\n" +
+            "Content-Disposition: form-data; name=\"normalFormField2\"\r\n" +
+            "\r\n" +
+            "normal field 2" +
+            "\r\n" +
+            "-----1234--\r\n");
+        req.setContent(content.getBytes(StandardCharsets.US_ASCII));
+
+        MyFileUploadAction action = new MyFileUploadAction();
+
+        MockActionInvocation mai = new MockActionInvocation();
+        mai.setAction(action);
+        mai.setResultCode("success");
+        mai.setInvocationContext(ActionContext.getContext());
+        ActionContext.getContext().withServletRequest(createMultipartRequest(req, 2000, 2000, 5, 100));
+
+        interceptor.intercept(mai);
+
+        assertFalse(action.hasErrors());
+
+        List<UploadedFile> files = action.getUploadFiles();
+
+        assertNotNull(files);
+        assertEquals(1, files.size());
+        assertEquals("text/html", files.get(0).getContentType());
+        assertNotNull("deleteme.txt", files.get(0).getOriginalName());
+
+        // Confirm normalFormField1, normalFormField2 were processed by the MultiPartRequestWrapper.
+        HttpServletRequest invocationServletRequest = mai.getInvocationContext().getServletRequest();
+        assertTrue("invocation servelt request is not a MultiPartRequestWrapper ?", invocationServletRequest instanceof MultiPartRequestWrapper);
+        MultiPartRequestWrapper multipartRequestWrapper = (MultiPartRequestWrapper) invocationServletRequest;
+        assertNotNull("normalFormField1 missing from MultiPartRequestWrapper parameters ?", multipartRequestWrapper.getParameter("normalFormField1"));
+        assertNotNull("normalFormField2 missing from MultiPartRequestWrapper parameters ?", multipartRequestWrapper.getParameter("normalFormField2"));
+    }
+
+    public void testSuccessUploadOfATextFileMultipartRequestWithNormalFieldsNoMaxParamsSet() throws Exception {
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        req.setMethod("post");
+        req.addHeader("Content-type", "multipart/form-data; boundary=---1234");
+
+        // inspired by the unit tests for jakarta commons fileupload
+        String content = ("-----1234\r\n" +
+            "Content-Disposition: form-data; name=\"file\"; filename=\"deleteme.txt\"\r\n" +
+            "Content-Type: text/html\r\n" +
+            "\r\n" +
+            "Unit test of ActionFileUploadInterceptor" +
+            "\r\n" +
+            "-----1234\r\n" +
+            "Content-Disposition: form-data; name=\"normalFormField1\"\r\n" +
+            "\r\n" +
+            "normal field 1" +
+            "\r\n" +
+            "-----1234\r\n" +
+            "Content-Disposition: form-data; name=\"normalFormField2\"\r\n" +
+            "\r\n" +
+            "normal field 2" +
+            "\r\n" +
+            "-----1234--\r\n");
+        req.setContent(content.getBytes(StandardCharsets.US_ASCII));
+
+        MyFileUploadAction action = new MyFileUploadAction();
+
+        MockActionInvocation mai = new MockActionInvocation();
+        mai.setAction(action);
+        mai.setResultCode("success");
+        mai.setInvocationContext(ActionContext.getContext());
+        ActionContext.getContext().withServletRequest(createMultipartRequestNoMaxParamsSet(req));
+
+        interceptor.intercept(mai);
+
+        assertFalse(action.hasErrors());
+
+        List<UploadedFile> files = action.getUploadFiles();
+
+        assertNotNull(files);
+        assertEquals(1, files.size());
+        assertEquals("text/html", files.get(0).getContentType());
+        assertNotNull("deleteme.txt", files.get(0).getOriginalName());
+
+        // Confirm normalFormField1, normalFormField2 were processed by the MultiPartRequestWrapper.
+        HttpServletRequest invocationServletRequest = mai.getInvocationContext().getServletRequest();
+        assertTrue("invocation servelt request is not a MultiPartRequestWrapper ?", invocationServletRequest instanceof MultiPartRequestWrapper);
+        MultiPartRequestWrapper multipartRequestWrapper = (MultiPartRequestWrapper) invocationServletRequest;
+        assertNotNull("normalFormField1 missing from MultiPartRequestWrapper parameters ?", multipartRequestWrapper.getParameter("normalFormField1"));
+        assertNotNull("normalFormField2 missing from MultiPartRequestWrapper parameters ?", multipartRequestWrapper.getParameter("normalFormField2"));
+    }
+
     /**
      * tests whether with multiple files sent with the same name, the ones with forbiddenTypes (see
      * ActionFileUploadInterceptor.setAllowedTypes(...) ) are sorted out.
@@ -564,6 +706,12 @@ public class ActionFileUploadInterceptorTest extends StrutsInternalTestCase {
         return new MultiPartRequestWrapper(jak, req, tempDir.getAbsolutePath(), new DefaultLocaleProvider());
     }
 
+    private MultiPartRequestWrapper createMultipartRequestNoMaxParamsSet(HttpServletRequest req) {
+
+        JakartaMultiPartRequest jak = new JakartaMultiPartRequest();
+        return new MultiPartRequestWrapper(jak, req, tempDir.getAbsolutePath(), new DefaultLocaleProvider());
+    }
+
     protected void setUp() throws Exception {
         super.setUp();
 
@@ -582,6 +730,9 @@ public class ActionFileUploadInterceptorTest extends StrutsInternalTestCase {
 
     public static class MyFileUploadAction extends ActionSupport implements UploadedFilesAware {
         private List<UploadedFile> uploadedFiles;
+
+        // Note: We do not currently need fields/getters/setters for normalFormField1, normalFormField2 since
+        //       the upload interceptor only prepares the normal field parameters.
 
         @Override
         public void withUploadedFiles(List<UploadedFile> uploadedFiles) {


### PR DESCRIPTION
Hello Apache Struts Team.

This is a proposed mitigation for WW-5466.  It is unlikely that many users will encounter it given the default configuration normally sets `struts.multipart.maxStringLength` .

The proposed change is a basic guard, combined with some additional unit tests to confirm that processing works both when the configuration values have not been set, as well as when they have been set.

Please advise if anyone thinks the change should be considered, or needs additional consideration.