### PR TITLE
WW-5468 Exempt ModelDriven Actions from @StrutsParameter requirement

### DIFF
--- a/apps/showcase/src/main/java/org/apache/struts2/showcase/modelDriven/ModelDrivenAction.java
+++ b/apps/showcase/src/main/java/org/apache/struts2/showcase/modelDriven/ModelDrivenAction.java
@@ -42,7 +42,7 @@ public class ModelDrivenAction extends ActionSupport implements ModelDriven {
 	}
 
 	@Override
-	public Object getModel() {
+	public Gangster getModel() {
 		return new Gangster();
 	}
 }

--- a/core/src/main/java/com/opensymphony/xwork2/ModelDriven.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ModelDriven.java
@@ -18,6 +18,8 @@
  */
 package com.opensymphony.xwork2;
 
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
+
 /**
  * ModelDriven Actions provide a model object to be pushed onto the ValueStack
  * in addition to the Action itself, allowing a FormBean type approach like Struts.
@@ -31,6 +33,7 @@ public interface ModelDriven<T> {
      *
      * @return the model
      */
+    @StrutsParameter
     T getModel();
 
 }

--- a/core/src/main/java/com/opensymphony/xwork2/ModelDriven.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ModelDriven.java
@@ -30,10 +30,13 @@ public interface ModelDriven<T> {
 
     /**
      * Gets the model to be pushed onto the ValueStack instead of the Action itself.
+     * <p>
+     * Please be aware that all setters and getters of every depth on the object returned by this method are available
+     * for user parameter injection!
      *
      * @return the model
      */
-    @StrutsParameter
+    @StrutsParameter(depth = Integer.MAX_VALUE)
     T getModel();
 
 }

--- a/core/src/test/java/com/opensymphony/xwork2/ModelDrivenAction.java
+++ b/core/src/test/java/com/opensymphony/xwork2/ModelDrivenAction.java
@@ -44,9 +44,8 @@ public class ModelDrivenAction extends ActionSupport implements ModelDriven {
     /**
      * @return the model to be pushed onto the ValueStack after the Action itself
      */
-    @StrutsParameter(depth = 2)
     @Override
-    public Object getModel() {
+    public TestBean getModel() {
         return model;
     }
 }

--- a/core/src/test/java/com/opensymphony/xwork2/ModelDrivenAnnotationAction.java
+++ b/core/src/test/java/com/opensymphony/xwork2/ModelDrivenAnnotationAction.java
@@ -44,9 +44,8 @@ public class ModelDrivenAnnotationAction extends ActionSupport implements ModelD
     /**
      * @return the model to be pushed onto the ValueStack after the Action itself
      */
-    @StrutsParameter(depth = 2)
     @Override
-    public Object getModel() {
+    public AnnotatedTestBean getModel() {
         return model;
     }
 }

--- a/core/src/test/java/com/opensymphony/xwork2/interceptor/ModelDrivenInterceptorTest.java
+++ b/core/src/test/java/com/opensymphony/xwork2/interceptor/ModelDrivenInterceptorTest.java
@@ -178,7 +178,7 @@ public class ModelDrivenInterceptorTest extends XWorkTestCase {
     }
 
 
-    public class ModelDrivenAction extends ActionSupport implements ModelDriven {
+    public class ModelDrivenAction extends ActionSupport implements ModelDriven<Object> {
 
         @Override
         public Object getModel() {

--- a/core/src/test/java/com/opensymphony/xwork2/test/ModelDrivenAction2.java
+++ b/core/src/test/java/com/opensymphony/xwork2/test/ModelDrivenAction2.java
@@ -19,7 +19,6 @@
 package com.opensymphony.xwork2.test;
 
 import com.opensymphony.xwork2.ModelDrivenAction;
-import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
 
 /**
@@ -35,9 +34,8 @@ public class ModelDrivenAction2 extends ModelDrivenAction {
     /**
      * @return the model to be pushed onto the ValueStack after the Action itself
      */
-    @StrutsParameter(depth = 3)
     @Override
-    public Object getModel() {
+    public TestBean2 getModel() {
         return model;
     }
 }

--- a/core/src/test/java/com/opensymphony/xwork2/test/ModelDrivenAnnotationAction2.java
+++ b/core/src/test/java/com/opensymphony/xwork2/test/ModelDrivenAnnotationAction2.java
@@ -19,7 +19,6 @@
 package com.opensymphony.xwork2.test;
 
 import com.opensymphony.xwork2.ModelDrivenAnnotationAction;
-import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
 
 /**
@@ -36,9 +35,8 @@ public class ModelDrivenAnnotationAction2 extends ModelDrivenAnnotationAction {
     /**
      * @return the model to be pushed onto the ValueStack after the Action itself
      */
-    @StrutsParameter(depth = 3)
     @Override
-    public Object getModel() {
+    public AnnotationTestBean2 getModel() {
         return model;
     }
 }

--- a/core/src/test/java/com/opensymphony/xwork2/test/subtest/NullModelDrivenAction.java
+++ b/core/src/test/java/com/opensymphony/xwork2/test/subtest/NullModelDrivenAction.java
@@ -19,6 +19,7 @@
 package com.opensymphony.xwork2.test.subtest;
 
 import com.opensymphony.xwork2.ModelDrivenAction;
+import com.opensymphony.xwork2.TestBean;
 
 /**
  * Extends ModelDrivenAction to return a null model.
@@ -31,7 +32,7 @@ public class NullModelDrivenAction extends ModelDrivenAction {
      * @return the model to be pushed onto the ValueStack instead of the Action itself
      */
     @Override
-    public Object getModel() {
+    public TestBean getModel() {
         return null;
     }
 }

--- a/core/src/test/java/com/opensymphony/xwork2/validator/VisitorValidatorModelAction.java
+++ b/core/src/test/java/com/opensymphony/xwork2/validator/VisitorValidatorModelAction.java
@@ -19,7 +19,7 @@
 package com.opensymphony.xwork2.validator;
 
 import com.opensymphony.xwork2.ModelDriven;
-import org.apache.struts2.interceptor.parameter.StrutsParameter;
+import com.opensymphony.xwork2.TestBean;
 
 
 /**
@@ -33,9 +33,8 @@ public class VisitorValidatorModelAction extends VisitorValidatorTestAction impl
     /**
      * @return the model to be pushed onto the ValueStack instead of the Action itself
      */
-    @StrutsParameter(depth = 2)
     @Override
-    public Object getModel() {
+    public TestBean getModel() {
         return getBean();
     }
 }

--- a/core/src/test/java/org/apache/struts2/interceptor/parameter/StrutsParameterAnnotationTest.java
+++ b/core/src/test/java/org/apache/struts2/interceptor/parameter/StrutsParameterAnnotationTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.struts2.interceptor.parameter;
 
+import com.opensymphony.xwork2.ModelDriven;
 import com.opensymphony.xwork2.security.AcceptedPatternsChecker;
 import com.opensymphony.xwork2.security.NotExcludedAcceptedPatternsChecker;
 import org.apache.commons.lang3.ClassUtils;
@@ -80,7 +81,7 @@ public class StrutsParameterAnnotationTest {
         }
     }
 
-    private Set<Class<?>> getParentClasses(Class<?> ...clazzes) {
+    private Set<Class<?>> getParentClasses(Class<?>... clazzes) {
         Set<Class<?>> set = new HashSet<>();
         for (Class<?> clazz : clazzes) {
             set.add(clazz);
@@ -258,8 +259,14 @@ public class StrutsParameterAnnotationTest {
         testParameter(new MethodAction(), "publicStrNotAnnotated", true);
     }
 
+    @Test
+    public void publicModelPojo() {
+        parametersInterceptor.setRequireAnnotationsTransitionMode(Boolean.TRUE.toString());
+        testParameter(new ModelAction(), "name", true);
+        assertThat(threadAllowlist.getAllowlist()).containsExactlyInAnyOrderElementsOf(getParentClasses(Object.class, Pojo.class));
+    }
 
-    class FieldAction {
+    static class FieldAction {
         @StrutsParameter
         private String privateStr;
 
@@ -275,7 +282,7 @@ public class StrutsParameterAnnotationTest {
         public Pojo publicPojoDepthZero;
 
         @StrutsParameter(depth = 1)
-        public Pojo publicPojoDepthOne ;
+        public Pojo publicPojoDepthOne;
 
         @StrutsParameter(depth = 2)
         public Pojo publicPojoDepthTwo;
@@ -290,7 +297,7 @@ public class StrutsParameterAnnotationTest {
         public Map<String, Pojo> publicPojoMapDepthTwo;
     }
 
-    class MethodAction {
+    static class MethodAction {
 
         @StrutsParameter
         private void setPrivateStr(String str) {
@@ -343,6 +350,23 @@ public class StrutsParameterAnnotationTest {
         }
     }
 
-    class Pojo {
+    static class ModelAction implements ModelDriven<Pojo> {
+
+        @StrutsParameter
+        public Pojo getModel() {
+            return new Pojo();
+        }
+    }
+
+    static class Pojo {
+        private String name;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
     }
 }

--- a/core/src/test/java/org/apache/struts2/result/StreamResultTest.java
+++ b/core/src/test/java/org/apache/struts2/result/StreamResultTest.java
@@ -37,7 +37,6 @@ import static com.opensymphony.xwork2.security.DefaultNotExcludedAcceptedPattern
 
 /**
  * Unit test for {@link StreamResult}.
- *
  */
 public class StreamResultTest extends StrutsInternalTestCase {
 
@@ -126,12 +125,12 @@ public class StreamResultTest extends StrutsInternalTestCase {
 
         result.doExecute("helloworld", mai);
 
-        //check that that headers are not set by default        
+        //check that that headers are not set by default
         assertNull(response.getHeader("Pragma"));
         assertNull(response.getHeader("Cache-Control"));
     }
 
-     public void testAllowCacheFalse() throws Exception {
+    public void testAllowCacheFalse() throws Exception {
         result.setInputName("streamForImage");
         result.setAllowCaching(false);
         result.doExecute("helloworld", mai);
@@ -264,7 +263,6 @@ public class StreamResultTest extends StrutsInternalTestCase {
 
         ActionContext.getContext().put(ServletActionContext.HTTP_RESPONSE, response);
     }
-
 
 
     protected void tearDown() throws Exception {

--- a/plugins/bean-validation/src/test/java/org/apache/struts/beanvalidation/actions/ModelDrivenAction.java
+++ b/plugins/bean-validation/src/test/java/org/apache/struts/beanvalidation/actions/ModelDrivenAction.java
@@ -20,17 +20,14 @@ package org.apache.struts.beanvalidation.actions;
 
 import com.opensymphony.xwork2.ActionSupport;
 import com.opensymphony.xwork2.ModelDriven;
-import org.apache.struts.beanvalidation.models.Person;
-import org.apache.struts2.interceptor.parameter.StrutsParameter;
-
 import jakarta.validation.Valid;
+import org.apache.struts.beanvalidation.models.Person;
 
 public class ModelDrivenAction extends ActionSupport implements ModelDriven<Person>, ModelDrivenActionInterface {
 
     @Valid
     private final Person model = new Person();
 
-    @StrutsParameter(depth = 2)
     @Override
     public Person getModel() {
         return model;

--- a/plugins/bean-validation/src/test/java/org/apache/struts/beanvalidation/actions/ValidateGroupAction.java
+++ b/plugins/bean-validation/src/test/java/org/apache/struts/beanvalidation/actions/ValidateGroupAction.java
@@ -20,18 +20,15 @@ package org.apache.struts.beanvalidation.actions;
 
 import com.opensymphony.xwork2.ActionSupport;
 import com.opensymphony.xwork2.ModelDriven;
+import jakarta.validation.Valid;
 import org.apache.struts.beanvalidation.constraints.ValidationGroup;
 import org.apache.struts.beanvalidation.models.Person;
-import org.apache.struts2.interceptor.parameter.StrutsParameter;
-
-import jakarta.validation.Valid;
 
 public class ValidateGroupAction extends ActionSupport implements ModelDriven<Person> {
 
     @Valid
     private final Person model = new Person();
 
-    @StrutsParameter(depth = 2)
     @Override
     public Person getModel() {
         return model;

--- a/plugins/junit/src/main/java/org/apache/struts2/junit/StrutsRestTestCase.java
+++ b/plugins/junit/src/main/java/org/apache/struts2/junit/StrutsRestTestCase.java
@@ -23,7 +23,6 @@ import com.opensymphony.xwork2.ActionProxy;
 import com.opensymphony.xwork2.ActionProxyFactory;
 import com.opensymphony.xwork2.config.Configuration;
 import org.apache.struts2.ServletActionContext;
-import org.apache.struts2.dispatcher.Dispatcher;
 import org.apache.struts2.dispatcher.HttpParameters;
 import org.apache.struts2.dispatcher.mapper.ActionMapping;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -75,7 +74,7 @@ public class StrutsRestTestCase<T> extends StrutsJUnit4TestCase<T> {
         ActionMapping mapping = getActionMapping(request);
 
         assertNotNull(mapping);
-        Dispatcher.getInstance().serviceAction(request, response, mapping);
+        dispatcher.serviceAction(request, response, mapping);
 
         if (response.getStatus() != HttpServletResponse.SC_OK)
             throw new ServletException("Error code [" + response.getStatus() + "], Error: ["

--- a/plugins/rest/src/test/java/org/apache/struts2/rest/RestActionInvocationTest.java
+++ b/plugins/rest/src/test/java/org/apache/struts2/rest/RestActionInvocationTest.java
@@ -50,97 +50,97 @@ import static jakarta.servlet.http.HttpServletResponse.SC_NOT_MODIFIED;
 
 public class RestActionInvocationTest extends TestCase {
 
-	RestActionInvocation restActionInvocation;
-	MockHttpServletRequest request;
-	MockHttpServletResponse response;
+    RestActionInvocation restActionInvocation;
+    MockHttpServletRequest request;
+    MockHttpServletResponse response;
 
-	@Override
-	protected void setUp() throws Exception {
-		super.setUp();
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
 
-		restActionInvocation = new RestActionInvocationTester();
-		request = new MockHttpServletRequest();
-		response = new MockHttpServletResponse();
-		ServletActionContext.setRequest(request);
-		ServletActionContext.setResponse(response);
+        restActionInvocation = new RestActionInvocationTester();
+        request = new MockHttpServletRequest();
+        response = new MockHttpServletResponse();
+        ServletActionContext.setRequest(request);
+        ServletActionContext.setResponse(response);
 
-	}
+    }
 
-	/**
-	 * Test the correct action results: null, String, HttpHeaders, Result
-	 * @throws Exception
-	 */
-	public void testSaveResult() throws Exception {
+    /**
+     * Test the correct action results: null, String, HttpHeaders, Result
+     * @throws Exception
+     */
+    public void testSaveResult() throws Exception {
 
-		Object methodResult = "index";
-		ActionConfig actionConfig = restActionInvocation.getProxy().getConfig();
-		assertEquals("index", restActionInvocation.saveResult(actionConfig, methodResult));
+        Object methodResult = "index";
+        ActionConfig actionConfig = restActionInvocation.getProxy().getConfig();
+        assertEquals("index", restActionInvocation.saveResult(actionConfig, methodResult));
 
-		setUp();
-    	methodResult = new DefaultHttpHeaders("show");
-    	assertEquals("show", restActionInvocation.saveResult(actionConfig, methodResult));
-    	assertEquals(methodResult, restActionInvocation.httpHeaders);
+        setUp();
+        methodResult = new DefaultHttpHeaders("show");
+        assertEquals("show", restActionInvocation.saveResult(actionConfig, methodResult));
+        assertEquals(methodResult, restActionInvocation.httpHeaders);
 
-		setUp();
-    	methodResult = new HttpHeaderResult(HttpServletResponse.SC_ACCEPTED);
-    	assertEquals(null, restActionInvocation.saveResult(actionConfig, methodResult));
-    	assertEquals(methodResult, restActionInvocation.createResult());
+        setUp();
+        methodResult = new HttpHeaderResult(HttpServletResponse.SC_ACCEPTED);
+        assertEquals(null, restActionInvocation.saveResult(actionConfig, methodResult));
+        assertEquals(methodResult, restActionInvocation.createResult());
 
-		setUp();
-    	try {
-    		methodResult = new Object();
-    		restActionInvocation.saveResult(actionConfig, methodResult);
+        setUp();
+        try {
+            methodResult = new Object();
+            restActionInvocation.saveResult(actionConfig, methodResult);
 
-    		// ko
-    		assertFalse(true);
+            // ko
+            assertFalse(true);
 
-    	} catch (ConfigurationException c) {
-    		// ok, object not allowed
-    	}
-	}
+        } catch (ConfigurationException c) {
+            // ok, object not allowed
+        }
+    }
 
-	/**
-	 * Test the target selection: exception, error messages, model and null
-	 * @throws Exception
-	 */
-	public void testSelectTarget() throws Exception {
+    /**
+     * Test the target selection: exception, error messages, model and null
+     * @throws Exception
+     */
+    public void testSelectTarget() throws Exception {
 
-		// Exception
-		Exception e = new Exception();
-		restActionInvocation.getStack().set("exception", e);
-		restActionInvocation.selectTarget();
-		assertEquals(e, restActionInvocation.target);
+        // Exception
+        Exception e = new Exception();
+        restActionInvocation.getStack().set("exception", e);
+        restActionInvocation.selectTarget();
+        assertEquals(e, restActionInvocation.target);
 
-		// Error messages
-		setUp();
-		String actionMessage = "Error!";
-		RestActionSupport action = (RestActionSupport)restActionInvocation.getAction();
-		action.addActionError(actionMessage);
-		Map<String, Object> errors = new HashMap<String, Object>();
-		List<String> list = new ArrayList<String>();
-		list.add(actionMessage);
-    	errors.put("actionErrors", list);
-    	restActionInvocation.selectTarget();
-		assertEquals(errors, restActionInvocation.target);
+        // Error messages
+        setUp();
+        String actionMessage = "Error!";
+        RestActionSupport action = (RestActionSupport)restActionInvocation.getAction();
+        action.addActionError(actionMessage);
+        Map<String, Object> errors = new HashMap<String, Object>();
+        List<String> list = new ArrayList<String>();
+        list.add(actionMessage);
+        errors.put("actionErrors", list);
+        restActionInvocation.selectTarget();
+        assertEquals(errors, restActionInvocation.target);
 
-    	// Model with get and no content in post, put, delete
-    	setUp();
-		RestAction restAction = (RestAction)restActionInvocation.getAction();
-		List<String> model = new ArrayList<String>();
-		model.add("Item");
-		restAction.model = model;
-		request.setMethod("GET");
-		restActionInvocation.selectTarget();
-		assertEquals(model, restActionInvocation.target);
-		request.setMethod("POST");
-		restActionInvocation.selectTarget();
-		assertEquals(null, restActionInvocation.target);
-		request.setMethod("PUT");
-		restActionInvocation.selectTarget();
-		assertEquals(null, restActionInvocation.target);
-		request.setMethod("DELETE");
-		restActionInvocation.selectTarget();
-		assertEquals(null, restActionInvocation.target);
+        // Model with get and no content in post, put, delete
+        setUp();
+        RestAction restAction = (RestAction)restActionInvocation.getAction();
+        List<String> model = new ArrayList<String>();
+        model.add("Item");
+        restAction.model = model;
+        request.setMethod("GET");
+        restActionInvocation.selectTarget();
+        assertEquals(model, restActionInvocation.target);
+        request.setMethod("POST");
+        restActionInvocation.selectTarget();
+        assertEquals(null, restActionInvocation.target);
+        request.setMethod("PUT");
+        restActionInvocation.selectTarget();
+        assertEquals(null, restActionInvocation.target);
+        request.setMethod("DELETE");
+        restActionInvocation.selectTarget();
+        assertEquals(null, restActionInvocation.target);
 
         // disable content restriction to GET only
         model = new ArrayList<String>();
@@ -154,108 +154,108 @@ public class RestActionInvocationTest extends TestCase {
         assertEquals(model.get(0), "Item1");
     }
 
-	/**
-	 * Test the not modified status code.
-	 * @throws Exception
-	 */
-	public void testResultNotModified() throws Exception {
+    /**
+     * Test the not modified status code.
+     * @throws Exception
+     */
+    public void testResultNotModified() throws Exception {
 
-		request.addHeader("If-None-Match", "123");
-		request.setMethod("GET");
+        request.addHeader("If-None-Match", "123");
+        request.setMethod("GET");
 
-		RestAction restAction = (RestAction)restActionInvocation.getAction();
-		List<String> model = new ArrayList<String>() {
-			@Override
-			public int hashCode() {
-				return 123;
-			}
-		};
-		model.add("Item");
-		restAction.model = model;
+        RestAction restAction = (RestAction)restActionInvocation.getAction();
+        List<String> model = new ArrayList<String>() {
+            @Override
+            public int hashCode() {
+                return 123;
+            }
+        };
+        model.add("Item");
+        restAction.model = model;
 
-		restActionInvocation.processResult();
-		assertEquals(SC_NOT_MODIFIED, response.getStatus());
+        restActionInvocation.processResult();
+        assertEquals(SC_NOT_MODIFIED, response.getStatus());
 
     }
 
-	/**
-	 * Test the default error result.
-	 * @throws Exception
-	 */
-	public void testDefaultErrorResult() throws Exception {
+    /**
+     * Test the default error result.
+     * @throws Exception
+     */
+    public void testDefaultErrorResult() throws Exception {
 
-		// Exception
-		Exception e = new Exception();
-		restActionInvocation.getStack().set("exception", e);
-		request.setMethod("GET");
+        // Exception
+        Exception e = new Exception();
+        restActionInvocation.getStack().set("exception", e);
+        request.setMethod("GET");
 
-		RestAction restAction = (RestAction)restActionInvocation.getAction();
-		List<String> model = new ArrayList<String>();
-		model.add("Item");
-		restAction.model = model;
+        RestAction restAction = (RestAction)restActionInvocation.getAction();
+        List<String> model = new ArrayList<String>();
+        model.add("Item");
+        restAction.model = model;
 
-		restActionInvocation.setDefaultErrorResultName("default-error");
-		ResultConfig resultConfig = new ResultConfig.Builder("default-error",
-			"org.apache.struts2.result.HttpHeaderResult")
-	    	.addParam("status", "123").build();
-	    ActionConfig actionConfig = new ActionConfig.Builder("org.apache.rest",
-				"RestAction", "org.apache.rest.RestAction")
-	    	.addResultConfig(resultConfig)
-	    	.build();
-	    ((MockActionProxy)restActionInvocation.getProxy()).setConfig(actionConfig);
+        restActionInvocation.setDefaultErrorResultName("default-error");
+        ResultConfig resultConfig = new ResultConfig.Builder("default-error",
+                "org.apache.struts2.result.HttpHeaderResult")
+                .addParam("status", "123").build();
+        ActionConfig actionConfig = new ActionConfig.Builder("org.apache.rest",
+                "RestAction", "org.apache.rest.RestAction")
+                .addResultConfig(resultConfig)
+                .build();
+        ((MockActionProxy)restActionInvocation.getProxy()).setConfig(actionConfig);
 
-		restActionInvocation.processResult();
-		assertEquals(123, response.getStatus());
+        restActionInvocation.processResult();
+        assertEquals(123, response.getStatus());
 
-	}
+    }
 
-	public void testNoResult() throws Exception {
+    public void testNoResult() throws Exception {
 
-		RestAction restAction = (RestAction)restActionInvocation.getAction();
-		List<String> model = new ArrayList<String>();
-		model.add("Item");
-		restAction.model = model;
-		request.setMethod("GET");
-		restActionInvocation.setResultCode("index");
+        RestAction restAction = (RestAction)restActionInvocation.getAction();
+        List<String> model = new ArrayList<String>();
+        model.add("Item");
+        restAction.model = model;
+        request.setMethod("GET");
+        restActionInvocation.setResultCode("index");
 
-		try {
-			restActionInvocation.processResult();
+        try {
+            restActionInvocation.processResult();
 
-    		// ko
-    		assertFalse(true);
+            // ko
+            assertFalse(true);
 
-    	} catch (ConfigurationException c) {
-    		// ok, no result
-    	}
+        } catch (ConfigurationException c) {
+            // ok, no result
+        }
 
-	}
+    }
 
-	/**
-	 * Test the global execution
-	 * @throws Exception
-	 */
-	public void testInvoke() throws Exception {
+    /**
+     * Test the global execution
+     * @throws Exception
+     */
+    public void testInvoke() throws Exception {
 
-	    // Default index method return 'success'
-	    ((MockActionProxy)restActionInvocation.getProxy()).setMethod("index");
+        // Default index method return 'success'
+        ((MockActionProxy)restActionInvocation.getProxy()).setMethod("index");
 
-	    // Define result 'success'
-		ResultConfig resultConfig = new ResultConfig.Builder("success",
-			"org.apache.struts2.result.HttpHeaderResult")
-	    	.addParam("status", "123").build();
-	    ActionConfig actionConfig = new ActionConfig.Builder("org.apache.rest",
-				"RestAction", "org.apache.rest.RestAction")
-	    	.addResultConfig(resultConfig)
-	    	.build();
-	    ((MockActionProxy)restActionInvocation.getProxy()).setConfig(actionConfig);
+        // Define result 'success'
+        ResultConfig resultConfig = new ResultConfig.Builder("success",
+                "org.apache.struts2.result.HttpHeaderResult")
+                .addParam("status", "123").build();
+        ActionConfig actionConfig = new ActionConfig.Builder("org.apache.rest",
+                "RestAction", "org.apache.rest.RestAction")
+                .addResultConfig(resultConfig)
+                .build();
+        ((MockActionProxy)restActionInvocation.getProxy()).setConfig(actionConfig);
 
-		request.setMethod("GET");
+        request.setMethod("GET");
 
         restActionInvocation.setOgnlUtil(new OgnlUtil(
-				new DefaultOgnlExpressionCacheFactory<>(String.valueOf(10_000), BASIC.toString()),
-				new DefaultOgnlBeanInfoCacheFactory<>(String.valueOf(10_000), BASIC.toString()),
-				new StrutsOgnlGuard()
-		));
+                new DefaultOgnlExpressionCacheFactory<>(String.valueOf(10_000), BASIC.toString()),
+                new DefaultOgnlBeanInfoCacheFactory<>(String.valueOf(10_000), BASIC.toString()),
+                new StrutsOgnlGuard()
+        ));
         restActionInvocation.invoke();
 
         assertEquals(123, response.getStatus());
@@ -263,7 +263,7 @@ public class RestActionInvocationTest extends TestCase {
 
 
     class RestActionInvocationTester extends RestActionInvocation {
-    	RestActionInvocationTester() {
+        RestActionInvocationTester() {
             super(new HashMap<String, Object>(), true);
             List<InterceptorMapping> interceptorMappings = new ArrayList<InterceptorMapping>();
             MockInterceptor mockInterceptor = new MockInterceptor();
@@ -273,21 +273,21 @@ public class RestActionInvocationTest extends TestCase {
             interceptors = interceptorMappings.iterator();
             MockActionProxy actionProxy = new MockActionProxy();
             ActionConfig actionConfig = new ActionConfig.Builder("org.apache.rest",
-    				"RestAction", "org.apache.rest.RestAction").build();
+                    "RestAction", "org.apache.rest.RestAction").build();
             actionProxy.setConfig(actionConfig);
             proxy = actionProxy;
             action = new RestAction();
             setMimeTypeHandlerSelector(new DefaultContentTypeHandlerManager());
             unknownHandlerManager = new DefaultUnknownHandlerManager();
-			try {
-				XWorkTestCaseHelper.setUp();
-			} catch (Exception e) {
-				throw new RuntimeException(e);
-			}
-			invocationContext = ActionContext.getContext();
-			container = ActionContext.getContext().getContainer();
-			stack = ActionContext.getContext().getValueStack();
-			objectFactory = container.getInstance(ObjectFactory.class);
+            try {
+                XWorkTestCaseHelper.setUp();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+            invocationContext = ActionContext.getContext();
+            container = ActionContext.getContext().getContainer();
+            stack = ActionContext.getContext().getValueStack();
+            objectFactory = container.getInstance(ObjectFactory.class);
 
         }
 
@@ -295,12 +295,12 @@ public class RestActionInvocationTest extends TestCase {
 
     static class RestAction extends RestActionSupport implements ModelDriven<List<String>> {
 
-    	List<String> model;
+        List<String> model;
 
-		@Override
-    	public List<String> getModel() {
-			return model;
-		}
+        @Override
+        public List<String> getModel() {
+            return model;
+        }
 
     }
 }

--- a/plugins/rest/src/test/java/org/apache/struts2/rest/RestActionInvocationTest.java
+++ b/plugins/rest/src/test/java/org/apache/struts2/rest/RestActionInvocationTest.java
@@ -35,7 +35,6 @@ import com.opensymphony.xwork2.util.XWorkTestCaseHelper;
 import jakarta.servlet.http.HttpServletResponse;
 import junit.framework.TestCase;
 import org.apache.struts2.ServletActionContext;
-import org.apache.struts2.interceptor.parameter.StrutsParameter;
 import org.apache.struts2.ognl.StrutsOgnlGuard;
 import org.apache.struts2.result.HttpHeaderResult;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -298,7 +297,6 @@ public class RestActionInvocationTest extends TestCase {
 
     	List<String> model;
 
-		@StrutsParameter(depth = 1)
 		@Override
     	public List<String> getModel() {
 			return model;

--- a/plugins/spring/src/test/java/com/opensymphony/xwork2/ModelDrivenAction.java
+++ b/plugins/spring/src/test/java/com/opensymphony/xwork2/ModelDrivenAction.java
@@ -44,9 +44,8 @@ public class ModelDrivenAction extends ActionSupport implements ModelDriven {
     /**
      * @return the model to be pushed onto the ValueStack after the Action itself
      */
-    @StrutsParameter(depth = 2)
     @Override
-    public Object getModel() {
+    public TestBean getModel() {
         return model;
     }
 }


### PR DESCRIPTION
WW-5468
--
The `@StrutsParameter` requirement was designed to protect against arbitrary getters and setters on the Action class from being invoked by users and/or attackers. However, if an Action is using a dedicated model object alongside the `ModelDrivenInterceptor`  (which ensures the Action is not on the root of the value stack) much of this risk is mitigated. I suggest we exempt this specific scenario from requiring the `@StrutsParameter` annotation.

Closes #1071 