### PR TITLE
WW-3714 Deprecate and repackage common APIs part 2

### DIFF
--- a/core/src/main/java/com/opensymphony/xwork2/ActionContext.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ActionContext.java
@@ -77,15 +77,19 @@ public class ActionContext extends org.apache.struts2.ActionContext {
         return this;
     }
 
-    @Override
     public ActionContext withActionInvocation(ActionInvocation actionInvocation) {
+        return withActionInvocation((org.apache.struts2.ActionInvocation) actionInvocation);
+    }
+
+    @Override
+    public ActionContext withActionInvocation(org.apache.struts2.ActionInvocation actionInvocation) {
         super.withActionInvocation(actionInvocation);
         return this;
     }
 
     @Override
     public ActionInvocation getActionInvocation() {
-        return super.getActionInvocation();
+        return ActionInvocation.adapt(super.getActionInvocation());
     }
 
     @Override

--- a/core/src/main/java/com/opensymphony/xwork2/ActionContext.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ActionContext.java
@@ -43,7 +43,7 @@ public class ActionContext extends org.apache.struts2.ActionContext {
         super(actualContext.getContextMap());
     }
 
-    private static ActionContext adapt(org.apache.struts2.ActionContext actualContext) {
+    static ActionContext adapt(org.apache.struts2.ActionContext actualContext) {
         return actualContext != null ? new ActionContext(actualContext) : null;
     }
 

--- a/core/src/main/java/com/opensymphony/xwork2/ActionInvocation.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ActionInvocation.java
@@ -22,158 +22,95 @@ import com.opensymphony.xwork2.interceptor.PreResultListener;
 import com.opensymphony.xwork2.util.ValueStack;
 
 /**
- * An {@link ActionInvocation} represents the execution state of an {@link Action}. It holds the Interceptors and the Action instance.
- * By repeated re-entrant execution of the <code>invoke()</code> method, initially by the {@link ActionProxy}, then by the Interceptors, the
- * Interceptors are all executed, and then the {@link Action} and the {@link Result}.
+ * {@inheritDoc}
  *
- * @author Jason Carreira
- * @see com.opensymphony.xwork2.ActionProxy
+ * @deprecated since 6.7.0, use {@link org.apache.struts2.ActionInvocation} instead.
  */
-public interface ActionInvocation {
+@Deprecated
+public interface ActionInvocation extends org.apache.struts2.ActionInvocation {
 
-    /**
-     * Get the Action associated with this ActionInvocation.
-     *
-     * @return the Action
-     */
-    Object getAction();
-
-    /**
-     * Gets whether this ActionInvocation has executed before.
-     * This will be set after the Action and the Result have executed.
-     *
-     * @return <tt>true</tt> if this ActionInvocation has executed before.
-     */
-    boolean isExecuted();
-
-    /**
-     * Gets the ActionContext associated with this ActionInvocation. The ActionProxy is
-     * responsible for setting this ActionContext onto the ThreadLocal before invoking
-     * the ActionInvocation and resetting the old ActionContext afterwards.
-     *
-     * @return the ActionContext.
-     */
+    @Override
     ActionContext getInvocationContext();
 
-    /**
-     * Get the ActionProxy holding this ActionInvocation.
-     *
-     * @return the ActionProxy.
-     */
-    ActionProxy getProxy();
-
-    /**
-     * If the ActionInvocation has been executed before and the Result is an instance of {@link ActionChainResult}, this method
-     * will walk down the chain of <code>ActionChainResult</code>s until it finds a non-chain result, which will be returned. If the
-     * ActionInvocation's result has not been executed before, the Result instance will be created and populated with
-     * the result params.
-     *
-     * @return the result.
-     * @throws Exception can be thrown.
-     */
+    @Override
     Result getResult() throws Exception;
 
-    /**
-     * Gets the result code returned from this ActionInvocation.
-     *
-     * @return the result code
-     */
-    String getResultCode();
+    static ActionInvocation adapt(org.apache.struts2.ActionInvocation actualInvocation) {
+        return actualInvocation != null ? new LegacyAdapter(actualInvocation) : null;
+    }
 
-    /**
-     * Sets the result code, possibly overriding the one returned by the
-     * action.
-     *
-     * <p>
-     * The "intended" purpose of this method is to allow PreResultListeners to
-     * override the result code returned by the Action.
-     * </p>
-     *
-     * <p>
-     * If this method is used before the Action executes, the Action's returned
-     * result code will override what was set. However the Action could (if
-     * specifically coded to do so) inspect the ActionInvocation to see that
-     * someone "upstream" (e.g. an Interceptor) had suggested a value as the
-     * result, and it could therefore return the same value itself.
-     * </p>
-     *
-     * <p>
-     * If this method is called between the Action execution and the Result
-     * execution, then the value set here will override the result code the
-     * action had returned.  Creating an Interceptor that implements
-     * {@link PreResultListener} will give you this opportunity.
-     * </p>
-     *
-     * <p>
-     * If this method is called after the Result has been executed, it will
-     * have the effect of raising an IllegalStateException.
-     * </p>
-     *
-     * @param resultCode  the result code.
-     * @throws IllegalStateException if called after the Result has been executed.
-     * @see #isExecuted()
-     */
-    void setResultCode(String resultCode);
+    class LegacyAdapter implements ActionInvocation {
 
-    /**
-     * Gets the ValueStack associated with this ActionInvocation.
-     *
-     * @return the ValueStack
-     */
-    ValueStack getStack();
+        private final org.apache.struts2.ActionInvocation adaptee;
 
-    /**
-     * Register a {@link PreResultListener} to be notified after the Action is executed and
-     * before the Result is executed.
-     *
-     * <p>
-     * The ActionInvocation implementation must guarantee that listeners will be called in
-     * the order in which they are registered.
-     * </p>
-     *
-     * <p>
-     * Listener registration and execution does not need to be thread-safe.
-     * </p>
-     *
-     * @param listener the listener to add.
-     */
-    void addPreResultListener(PreResultListener listener);
+        private LegacyAdapter(org.apache.struts2.ActionInvocation adaptee) {
+            this.adaptee = adaptee;
+        }
 
-    /**
-     * Invokes the next step in processing this ActionInvocation.
-     *
-     * <p>
-     * If there are more Interceptors, this will call the next one. If Interceptors choose not to short-circuit
-     * ActionInvocation processing and return their own return code, they will call invoke() to allow the next Interceptor
-     * to execute. If there are no more Interceptors to be applied, the Action is executed.
-     * If the {@link ActionProxy#getExecuteResult()} method returns <tt>true</tt>, the Result is also executed.
-     * </p>
-     *
-     * @throws Exception can be thrown.
-     * @return the return code.
-     */
-    String invoke() throws Exception;
+        @Override
+        public Object getAction() {
+            return adaptee.getAction();
+        }
 
-    /**
-     * Invokes only the Action (not Interceptors or Results).
-     *
-     * <p>
-     * This is useful in rare situations where advanced usage with the interceptor/action/result workflow is
-     * being manipulated for certain functionality.
-     * </p>
-     *
-     * @return the return code.
-     * @throws Exception can be thrown.
-     */
-    String invokeActionOnly() throws Exception;
+        @Override
+        public boolean isExecuted() {
+            return adaptee.isExecuted();
+        }
 
-    /**
-     * Sets the action event listener to respond to key action events.
-     *
-     * @param listener the listener.
-     */
-    void setActionEventListener(ActionEventListener listener);
+        @Override
+        public ActionContext getInvocationContext() {
+            return ActionContext.adapt(adaptee.getInvocationContext());
+        }
 
-    void init(ActionProxy proxy) ;
+        @Override
+        public ActionProxy getProxy() {
+            return adaptee.getProxy();
+        }
+
+        @Override
+        public Result getResult() throws Exception {
+            return Result.adapt(adaptee.getResult());
+        }
+
+        @Override
+        public String getResultCode() {
+            return adaptee.getResultCode();
+        }
+
+        @Override
+        public void setResultCode(String resultCode) {
+            adaptee.setResultCode(resultCode);
+        }
+
+        @Override
+        public ValueStack getStack() {
+            return adaptee.getStack();
+        }
+
+        @Override
+        public void addPreResultListener(PreResultListener listener) {
+            adaptee.addPreResultListener(listener);
+        }
+
+        @Override
+        public String invoke() throws Exception {
+            return adaptee.invoke();
+        }
+
+        @Override
+        public String invokeActionOnly() throws Exception {
+            return adaptee.invokeActionOnly();
+        }
+
+        @Override
+        public void setActionEventListener(ActionEventListener listener) {
+            adaptee.setActionEventListener(listener);
+        }
+
+        @Override
+        public void init(ActionProxy proxy) {
+            adaptee.init(proxy);
+        }
+    }
 
 }

--- a/core/src/main/java/com/opensymphony/xwork2/ActionInvocation.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ActionInvocation.java
@@ -35,6 +35,13 @@ public interface ActionInvocation extends org.apache.struts2.ActionInvocation {
     @Override
     Result getResult() throws Exception;
 
+    @Override
+    default void addPreResultListener(org.apache.struts2.interceptor.PreResultListener listener) {
+        addPreResultListener(PreResultListener.adapt(listener));
+    }
+
+    void addPreResultListener(PreResultListener listener);
+
     static ActionInvocation adapt(org.apache.struts2.ActionInvocation actualInvocation) {
         return actualInvocation != null ? new LegacyAdapter(actualInvocation) : null;
     }

--- a/core/src/main/java/com/opensymphony/xwork2/Result.java
+++ b/core/src/main/java/com/opensymphony/xwork2/Result.java
@@ -25,4 +25,29 @@ package com.opensymphony.xwork2;
  */
 @Deprecated
 public interface Result extends org.apache.struts2.Result {
+
+    @Override
+    default void execute(org.apache.struts2.ActionInvocation invocation) throws Exception {
+        execute(ActionInvocation.adapt(invocation));
+    }
+
+    void execute(ActionInvocation invocation) throws Exception;
+
+    static Result adapt(org.apache.struts2.Result actualResult) {
+        return actualResult != null ? new LegacyAdapter(actualResult) : null;
+    }
+
+    class LegacyAdapter implements Result {
+
+        private final org.apache.struts2.Result adaptee;
+
+        private LegacyAdapter(org.apache.struts2.Result adaptee) {
+            this.adaptee = adaptee;
+        }
+
+        @Override
+        public void execute(ActionInvocation invocation) throws Exception {
+            adaptee.execute(ActionInvocation.adapt(invocation));
+        }
+    }
 }

--- a/core/src/main/java/com/opensymphony/xwork2/interceptor/ConditionalInterceptor.java
+++ b/core/src/main/java/com/opensymphony/xwork2/interceptor/ConditionalInterceptor.java
@@ -18,6 +18,8 @@
  */
 package com.opensymphony.xwork2.interceptor;
 
+import com.opensymphony.xwork2.ActionInvocation;
+
 /**
  * {@inheritDoc}
  *
@@ -25,4 +27,10 @@ package com.opensymphony.xwork2.interceptor;
  */
 @Deprecated
 public interface ConditionalInterceptor extends org.apache.struts2.interceptor.ConditionalInterceptor, Interceptor {
+
+    default boolean shouldIntercept(org.apache.struts2.ActionInvocation invocation) {
+        return shouldIntercept(ActionInvocation.adapt(invocation));
+    }
+
+    boolean shouldIntercept(ActionInvocation invocation);
 }

--- a/core/src/main/java/com/opensymphony/xwork2/interceptor/Interceptor.java
+++ b/core/src/main/java/com/opensymphony/xwork2/interceptor/Interceptor.java
@@ -18,6 +18,8 @@
  */
 package com.opensymphony.xwork2.interceptor;
 
+import com.opensymphony.xwork2.ActionInvocation;
+
 /**
  * {@inheritDoc}
  *
@@ -25,4 +27,11 @@ package com.opensymphony.xwork2.interceptor;
  */
 @Deprecated
 public interface Interceptor extends org.apache.struts2.interceptor.Interceptor {
+
+    @Override
+    default String intercept(org.apache.struts2.ActionInvocation invocation) throws Exception {
+        return intercept(ActionInvocation.adapt(invocation));
+    }
+
+    String intercept(ActionInvocation invocation) throws Exception;
 }

--- a/core/src/main/java/com/opensymphony/xwork2/interceptor/PreResultListener.java
+++ b/core/src/main/java/com/opensymphony/xwork2/interceptor/PreResultListener.java
@@ -21,21 +21,35 @@ package com.opensymphony.xwork2.interceptor;
 import com.opensymphony.xwork2.ActionInvocation;
 
 /**
- * PreResultListeners may be registered with an {@link ActionInvocation} to get a callback after the
- * {@link com.opensymphony.xwork2.Action} has been executed but before the {@link com.opensymphony.xwork2.Result}
- * is executed.
+ * {@inheritDoc}
  *
- * @author Jason Carreira
+ * @deprecated since 6.7.0, use {@link org.apache.struts2.interceptor.PreResultListener} instead.
  */
-public interface PreResultListener {
+@Deprecated
+public interface PreResultListener extends org.apache.struts2.interceptor.PreResultListener {
 
-    /**
-     * This callback method will be called after the {@link com.opensymphony.xwork2.Action} execution and
-     * before the {@link com.opensymphony.xwork2.Result} execution.
-     *
-     * @param invocation  the action invocation
-     * @param resultCode  the result code returned by the action (eg. <code>success</code>).
-     */
+    @Override
+    default void beforeResult(org.apache.struts2.ActionInvocation invocation, String resultCode) {
+        beforeResult(ActionInvocation.adapt(invocation), resultCode);
+    }
+
     void beforeResult(ActionInvocation invocation, String resultCode);
 
+    static PreResultListener adapt(org.apache.struts2.interceptor.PreResultListener actualListener) {
+        return actualListener != null ? new LegacyAdapter(actualListener) : null;
+    }
+
+    class LegacyAdapter implements PreResultListener {
+
+        private final org.apache.struts2.interceptor.PreResultListener adaptee;
+
+        private LegacyAdapter(org.apache.struts2.interceptor.PreResultListener adaptee) {
+            this.adaptee = adaptee;
+        }
+
+        @Override
+        public void beforeResult(ActionInvocation invocation, String resultCode) {
+            adaptee.beforeResult(invocation, resultCode);
+        }
+    }
 }

--- a/core/src/main/java/org/apache/struts2/ActionContext.java
+++ b/core/src/main/java/org/apache/struts2/ActionContext.java
@@ -18,8 +18,6 @@
  */
 package org.apache.struts2;
 
-import com.opensymphony.xwork2.Action;
-import com.opensymphony.xwork2.ActionInvocation;
 import com.opensymphony.xwork2.conversion.impl.ConversionData;
 import com.opensymphony.xwork2.inject.Container;
 import com.opensymphony.xwork2.util.ValueStack;

--- a/core/src/main/java/org/apache/struts2/ActionInvocation.java
+++ b/core/src/main/java/org/apache/struts2/ActionInvocation.java
@@ -1,0 +1,182 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.struts2;
+
+import com.opensymphony.xwork2.ActionChainResult;
+import com.opensymphony.xwork2.ActionEventListener;
+import com.opensymphony.xwork2.ActionProxy;
+import com.opensymphony.xwork2.interceptor.PreResultListener;
+import com.opensymphony.xwork2.util.ValueStack;
+
+/**
+ * An {@link ActionInvocation} represents the execution state of an {@link com.opensymphony.xwork2.Action}. It holds the Interceptors and the Action instance.
+ * By repeated re-entrant execution of the <code>invoke()</code> method, initially by the {@link ActionProxy}, then by the Interceptors, the
+ * Interceptors are all executed, and then the {@link Action} and the {@link com.opensymphony.xwork2.Result}.
+ *
+ * @author Jason Carreira
+ * @see ActionProxy
+ */
+public interface ActionInvocation {
+
+    /**
+     * Get the Action associated with this ActionInvocation.
+     *
+     * @return the Action
+     */
+    Object getAction();
+
+    /**
+     * Gets whether this ActionInvocation has executed before.
+     * This will be set after the Action and the Result have executed.
+     *
+     * @return <tt>true</tt> if this ActionInvocation has executed before.
+     */
+    boolean isExecuted();
+
+    /**
+     * Gets the ActionContext associated with this ActionInvocation. The ActionProxy is
+     * responsible for setting this ActionContext onto the ThreadLocal before invoking
+     * the ActionInvocation and resetting the old ActionContext afterwards.
+     *
+     * @return the ActionContext.
+     */
+    ActionContext getInvocationContext();
+
+    /**
+     * Get the ActionProxy holding this ActionInvocation.
+     *
+     * @return the ActionProxy.
+     */
+    ActionProxy getProxy();
+
+    /**
+     * If the ActionInvocation has been executed before and the Result is an instance of {@link ActionChainResult}, this method
+     * will walk down the chain of <code>ActionChainResult</code>s until it finds a non-chain result, which will be returned. If the
+     * ActionInvocation's result has not been executed before, the Result instance will be created and populated with
+     * the result params.
+     *
+     * @return the result.
+     * @throws Exception can be thrown.
+     */
+    Result getResult() throws Exception;
+
+    /**
+     * Gets the result code returned from this ActionInvocation.
+     *
+     * @return the result code
+     */
+    String getResultCode();
+
+    /**
+     * Sets the result code, possibly overriding the one returned by the
+     * action.
+     *
+     * <p>
+     * The "intended" purpose of this method is to allow PreResultListeners to
+     * override the result code returned by the Action.
+     * </p>
+     *
+     * <p>
+     * If this method is used before the Action executes, the Action's returned
+     * result code will override what was set. However the Action could (if
+     * specifically coded to do so) inspect the ActionInvocation to see that
+     * someone "upstream" (e.g. an Interceptor) had suggested a value as the
+     * result, and it could therefore return the same value itself.
+     * </p>
+     *
+     * <p>
+     * If this method is called between the Action execution and the Result
+     * execution, then the value set here will override the result code the
+     * action had returned.  Creating an Interceptor that implements
+     * {@link PreResultListener} will give you this opportunity.
+     * </p>
+     *
+     * <p>
+     * If this method is called after the Result has been executed, it will
+     * have the effect of raising an IllegalStateException.
+     * </p>
+     *
+     * @param resultCode  the result code.
+     * @throws IllegalStateException if called after the Result has been executed.
+     * @see #isExecuted()
+     */
+    void setResultCode(String resultCode);
+
+    /**
+     * Gets the ValueStack associated with this ActionInvocation.
+     *
+     * @return the ValueStack
+     */
+    ValueStack getStack();
+
+    /**
+     * Register a {@link PreResultListener} to be notified after the Action is executed and
+     * before the Result is executed.
+     *
+     * <p>
+     * The ActionInvocation implementation must guarantee that listeners will be called in
+     * the order in which they are registered.
+     * </p>
+     *
+     * <p>
+     * Listener registration and execution does not need to be thread-safe.
+     * </p>
+     *
+     * @param listener the listener to add.
+     */
+    void addPreResultListener(PreResultListener listener);
+
+    /**
+     * Invokes the next step in processing this ActionInvocation.
+     *
+     * <p>
+     * If there are more Interceptors, this will call the next one. If Interceptors choose not to short-circuit
+     * ActionInvocation processing and return their own return code, they will call invoke() to allow the next Interceptor
+     * to execute. If there are no more Interceptors to be applied, the Action is executed.
+     * If the {@link ActionProxy#getExecuteResult()} method returns <tt>true</tt>, the Result is also executed.
+     * </p>
+     *
+     * @throws Exception can be thrown.
+     * @return the return code.
+     */
+    String invoke() throws Exception;
+
+    /**
+     * Invokes only the Action (not Interceptors or Results).
+     *
+     * <p>
+     * This is useful in rare situations where advanced usage with the interceptor/action/result workflow is
+     * being manipulated for certain functionality.
+     * </p>
+     *
+     * @return the return code.
+     * @throws Exception can be thrown.
+     */
+    String invokeActionOnly() throws Exception;
+
+    /**
+     * Sets the action event listener to respond to key action events.
+     *
+     * @param listener the listener.
+     */
+    void setActionEventListener(ActionEventListener listener);
+
+    void init(ActionProxy proxy) ;
+
+}

--- a/core/src/main/java/org/apache/struts2/ActionInvocation.java
+++ b/core/src/main/java/org/apache/struts2/ActionInvocation.java
@@ -21,8 +21,8 @@ package org.apache.struts2;
 import com.opensymphony.xwork2.ActionChainResult;
 import com.opensymphony.xwork2.ActionEventListener;
 import com.opensymphony.xwork2.ActionProxy;
-import com.opensymphony.xwork2.interceptor.PreResultListener;
 import com.opensymphony.xwork2.util.ValueStack;
+import org.apache.struts2.interceptor.PreResultListener;
 
 /**
  * An {@link ActionInvocation} represents the execution state of an {@link com.opensymphony.xwork2.Action}. It holds the Interceptors and the Action instance.

--- a/core/src/main/java/org/apache/struts2/Result.java
+++ b/core/src/main/java/org/apache/struts2/Result.java
@@ -18,9 +18,6 @@
  */
 package org.apache.struts2;
 
-import com.opensymphony.xwork2.Action;
-import com.opensymphony.xwork2.ActionInvocation;
-
 import java.io.Serializable;
 
 /**

--- a/core/src/main/java/org/apache/struts2/interceptor/ConditionalInterceptor.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/ConditionalInterceptor.java
@@ -18,7 +18,7 @@
  */
 package org.apache.struts2.interceptor;
 
-import com.opensymphony.xwork2.ActionInvocation;
+import org.apache.struts2.ActionInvocation;
 
 /**
  * A marking interface, when implemented allows to conditionally execute a given interceptor

--- a/core/src/main/java/org/apache/struts2/interceptor/Interceptor.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/Interceptor.java
@@ -18,7 +18,7 @@
  */
 package org.apache.struts2.interceptor;
 
-import com.opensymphony.xwork2.ActionInvocation;
+import org.apache.struts2.ActionInvocation;
 
 import java.io.Serializable;
 

--- a/core/src/main/java/org/apache/struts2/interceptor/PreResultListener.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/PreResultListener.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.struts2.interceptor;
+
+import org.apache.struts2.ActionInvocation;
+
+/**
+ * PreResultListeners may be registered with an {@link ActionInvocation} to get a callback after the
+ * {@link com.opensymphony.xwork2.Action} has been executed but before the {@link com.opensymphony.xwork2.Result}
+ * is executed.
+ *
+ * @author Jason Carreira
+ */
+public interface PreResultListener {
+
+    /**
+     * This callback method will be called after the {@link com.opensymphony.xwork2.Action} execution and
+     * before the {@link com.opensymphony.xwork2.Result} execution.
+     *
+     * @param invocation  the action invocation
+     * @param resultCode  the result code returned by the action (eg. <code>success</code>).
+     */
+    void beforeResult(ActionInvocation invocation, String resultCode);
+
+}

--- a/core/src/test/java/org/apache/struts2/views/jsp/ActionTagTest.java
+++ b/core/src/test/java/org/apache/struts2/views/jsp/ActionTagTest.java
@@ -403,6 +403,7 @@ public class ActionTagTest extends AbstractTagTest {
 
     public void testExecuteButResetReturnSameInvocation() throws Exception {
         Mock mockActionInv = new Mock(ActionInvocation.class);
+        mockActionInv.matchAndReturn("invoke", "TEST");
         ActionTag tag = new ActionTag();
         tag.setPageContext(pageContext);
         tag.setNamespace("");
@@ -419,7 +420,7 @@ public class ActionTagTest extends AbstractTagTest {
         ActionComponent component = (ActionComponent) tag.getComponent();
 
         tag.doEndTag();
-        assertSame(oldInvocation, ActionContext.getContext().getActionInvocation());
+        assertEquals(oldInvocation.invoke(), ActionContext.getContext().getActionInvocation().invoke());
 
         // Basic sanity check of clearTagStateForTagPoolingServers() behaviour for Struts Tags after doEndTag().
         ActionTag freshTag = new ActionTag();
@@ -432,6 +433,7 @@ public class ActionTagTest extends AbstractTagTest {
 
     public void testExecuteButResetReturnSameInvocation_clearTagStateSet() throws Exception {
         Mock mockActionInv = new Mock(ActionInvocation.class);
+        mockActionInv.matchAndReturn("invoke", "TEST");
         ActionTag tag = new ActionTag();
         tag.setPerformClearTagStateForTagPoolingServers(true);  // Explicitly request tag state clearing.
         tag.setPageContext(pageContext);
@@ -450,7 +452,7 @@ public class ActionTagTest extends AbstractTagTest {
         ActionComponent component = (ActionComponent) tag.getComponent();
 
         tag.doEndTag();
-        assertTrue(oldInvocation == ActionContext.getContext().getActionInvocation());
+        assertEquals(oldInvocation.invoke(), ActionContext.getContext().getActionInvocation().invoke());
 
         // Basic sanity check of clearTagStateForTagPoolingServers() behaviour for Struts Tags after doEndTag().
         ActionTag freshTag = new ActionTag();


### PR DESCRIPTION
WW-3714
--
This PR deprecates and provides repackaged replacements for the following APIs, ahead of their permanent migration in Struts 7.0:
- `com.opensymphony.xwork2.ActionInvocation`
- `com.opensymphony.xwork2.interceptor.PreResultListener`

Full backwards compatibility with the deprecated types are retained - I achieved this by doing the following:
1. Move 'old' class to new package
1. Update any imports in this moved class to replacement types if applicable/available
1. Create a class in the old package (where the original class was) which extends the new updated one
1. Add back any APIs/methods which are not inherited due to updated imports from (2)
1. Provide default implementations for inherited APIs/methods which were not present in the 'old' class, delegating to the APIs added back in (4)
1. Create internal adapter classes as necessary to achieve (5)

Another variation of this approach that is sometimes employed is to have the new class extend the deprecated one instead. I deliberately avoided this as it pollutes the new/replacement class with compatibility code and references to deprecated types. I'd prefer compatibility code to appear in the deprecated class instead, to avoid confusion for anyone inspecting the bytecode/source of the APIs.

Additionally, this approach usually facilitates much more straightforward deletion of the deprecated classes when ready. However, in this case, this point is moot as the deletion PR for Struts 7.0 has already been prepared. We can simply discard all changes in my series of deprecation PRs when we merge them forward from `master` to `release/struts-7-0-x`.