### PR TITLE
WW-3714 Deprecate and repackage common APIs part 3

### DIFF
--- a/core/src/main/java/com/opensymphony/xwork2/ActionEventListener.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ActionEventListener.java
@@ -21,24 +21,33 @@ package com.opensymphony.xwork2;
 import com.opensymphony.xwork2.util.ValueStack;
 
 /**
- * Provides hooks for handling key action events
+ * {@inheritDoc}
+ *
+ * @deprecated since 6.7.0, use {@link org.apache.struts2.ActionEventListener} instead.
  */
-public interface ActionEventListener {
-    /**
-     * Called after an action has been created. 
-     * 
-     * @param action The action
-     * @param stack The current value stack
-     * @return The action to use
-     */
-    public Object prepare(Object action, ValueStack stack);
-    
-    /**
-     * Called when an exception is thrown by the action
-     * 
-     * @param t The exception/error that was thrown
-     * @param stack The current value stack
-     * @return A result code to execute, can be null
-     */
-    public String handleException(Throwable t, ValueStack stack);
+@Deprecated
+public interface ActionEventListener extends org.apache.struts2.ActionEventListener {
+
+    static ActionEventListener adapt(org.apache.struts2.ActionEventListener actualListener) {
+        return actualListener != null ? new LegacyAdapter(actualListener) : null;
+    }
+
+    class LegacyAdapter implements ActionEventListener {
+
+        private final org.apache.struts2.ActionEventListener adaptee;
+
+        private LegacyAdapter(org.apache.struts2.ActionEventListener adaptee) {
+            this.adaptee = adaptee;
+        }
+
+        @Override
+        public Object prepare(Object action, ValueStack stack) {
+            return adaptee.prepare(action, stack);
+        }
+
+        @Override
+        public String handleException(Throwable t, ValueStack stack) {
+            return adaptee.handleException(t, stack);
+        }
+    }
 }

--- a/core/src/main/java/com/opensymphony/xwork2/ActionInvocation.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ActionInvocation.java
@@ -42,6 +42,13 @@ public interface ActionInvocation extends org.apache.struts2.ActionInvocation {
 
     void addPreResultListener(PreResultListener listener);
 
+    @Override
+    default void setActionEventListener(org.apache.struts2.ActionEventListener listener) {
+        setActionEventListener(ActionEventListener.adapt(listener));
+    }
+
+    void setActionEventListener(ActionEventListener listener);
+
     static ActionInvocation adapt(org.apache.struts2.ActionInvocation actualInvocation) {
         return actualInvocation != null ? new LegacyAdapter(actualInvocation) : null;
     }

--- a/core/src/main/java/com/opensymphony/xwork2/ActionInvocation.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ActionInvocation.java
@@ -36,6 +36,9 @@ public interface ActionInvocation extends org.apache.struts2.ActionInvocation {
     Result getResult() throws Exception;
 
     @Override
+    ActionProxy getProxy();
+
+    @Override
     default void addPreResultListener(org.apache.struts2.interceptor.PreResultListener listener) {
         addPreResultListener(PreResultListener.adapt(listener));
     }
@@ -48,6 +51,13 @@ public interface ActionInvocation extends org.apache.struts2.ActionInvocation {
     }
 
     void setActionEventListener(ActionEventListener listener);
+
+    @Override
+    default void init(org.apache.struts2.ActionProxy proxy) {
+        init(ActionProxy.adapt(proxy));
+    }
+
+    void init(ActionProxy proxy);
 
     static ActionInvocation adapt(org.apache.struts2.ActionInvocation actualInvocation) {
         return actualInvocation != null ? new LegacyAdapter(actualInvocation) : null;
@@ -78,7 +88,7 @@ public interface ActionInvocation extends org.apache.struts2.ActionInvocation {
 
         @Override
         public ActionProxy getProxy() {
-            return adaptee.getProxy();
+            return ActionProxy.adapt(adaptee.getProxy());
         }
 
         @Override

--- a/core/src/main/java/com/opensymphony/xwork2/ActionProxy.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ActionProxy.java
@@ -20,88 +20,72 @@ package com.opensymphony.xwork2;
 
 import com.opensymphony.xwork2.config.entities.ActionConfig;
 
-/**
- * ActionProxy is an extra layer between XWork and the action so that different proxies are possible.
- *
- * <p>
- * An example of this would be a remote proxy, where the layer between XWork and the action might be RMI or SOAP.
- * </p>
- * 
- * @author Jason Carreira
- */
-public interface ActionProxy {
+@Deprecated
+public interface ActionProxy extends org.apache.struts2.ActionProxy {
 
-    /**
-     * Gets the Action instance for this Proxy.
-     *
-     * @return the Action instance
-     */
-    Object getAction();
-
-    /**
-     * Gets the alias name this ActionProxy is mapped to.
-     *
-     * @return the alias name
-     */
-    String getActionName();
-
-    /**
-     * Gets the ActionConfig this ActionProxy is built from.
-     *
-     * @return the ActionConfig
-     */
-    ActionConfig getConfig();
-
-    /**
-     * Sets whether this ActionProxy should also execute the Result after executing the Action.
-     *
-     * @param executeResult <tt>true</tt> to also execute the Result.
-     */
-    void setExecuteResult(boolean executeResult);
-
-    /**
-     * Gets the status of whether the ActionProxy is set to execute the Result after the Action is executed.
-     *
-     * @return the status
-     */
-    boolean getExecuteResult();
-
-    /**
-     * Gets the ActionInvocation associated with this ActionProxy.
-     *
-     * @return the ActionInvocation
-     */
+    @Override
     ActionInvocation getInvocation();
 
-    /**
-     * Gets the namespace the ActionConfig for this ActionProxy is mapped to.
-     *
-     * @return the namespace
-     */
-    String getNamespace();
+    static ActionProxy adapt(org.apache.struts2.ActionProxy actualProxy) {
+        return actualProxy != null ? new LegacyAdapter(actualProxy) : null;
+    }
 
-    /**
-     * Execute this ActionProxy. This will set the ActionContext from the ActionInvocation into the ActionContext
-     * ThreadLocal before invoking the ActionInvocation, then set the old ActionContext back into the ThreadLocal.
-     *
-     * @return the result code returned from executing the ActionInvocation
-     * @throws Exception can be thrown.
-     * @see ActionInvocation
-     */
-    String execute() throws Exception;
+    class LegacyAdapter implements ActionProxy {
 
-    /**
-     * Gets the method name to execute, or <tt>null</tt> if no method has been specified (meaning <code>execute</code> will be invoked).
-     *
-     * @return the method to execute
-     */
-    String getMethod();
+        private final org.apache.struts2.ActionProxy adaptee;
 
-    /**
-     * Gets status of the method value's initialization.
-     *
-     * @return true if the method returned by getMethod() is not a default initializer value.
-     */
-    boolean isMethodSpecified();
-    
+        private LegacyAdapter(org.apache.struts2.ActionProxy adaptee) {
+            this.adaptee = adaptee;
+        }
+
+        @Override
+        public Object getAction() {
+            return adaptee.getAction();
+        }
+
+        @Override
+        public String getActionName() {
+            return adaptee.getActionName();
+        }
+
+        @Override
+        public ActionConfig getConfig() {
+            return adaptee.getConfig();
+        }
+
+        @Override
+        public void setExecuteResult(boolean executeResult) {
+            adaptee.setExecuteResult(executeResult);
+        }
+
+        @Override
+        public boolean getExecuteResult() {
+            return adaptee.getExecuteResult();
+        }
+
+        @Override
+        public ActionInvocation getInvocation() {
+            return ActionInvocation.adapt(adaptee.getInvocation());
+        }
+
+        @Override
+        public String getNamespace() {
+            return adaptee.getNamespace();
+        }
+
+        @Override
+        public String execute() throws Exception {
+            return adaptee.execute();
+        }
+
+        @Override
+        public String getMethod() {
+            return adaptee.getMethod();
+        }
+
+        @Override
+        public boolean isMethodSpecified() {
+            return adaptee.isMethodSpecified();
+        }
+    }
 }

--- a/core/src/main/java/org/apache/struts2/ActionEventListener.java
+++ b/core/src/main/java/org/apache/struts2/ActionEventListener.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.struts2;
+
+import com.opensymphony.xwork2.util.ValueStack;
+
+/**
+ * Provides hooks for handling key action events
+ */
+public interface ActionEventListener {
+    /**
+     * Called after an action has been created.
+     *
+     * @param action The action
+     * @param stack  The current value stack
+     * @return The action to use
+     */
+    Object prepare(Object action, ValueStack stack);
+
+    /**
+     * Called when an exception is thrown by the action
+     *
+     * @param t     The exception/error that was thrown
+     * @param stack The current value stack
+     * @return A result code to execute, can be null
+     */
+    String handleException(Throwable t, ValueStack stack);
+}

--- a/core/src/main/java/org/apache/struts2/ActionInvocation.java
+++ b/core/src/main/java/org/apache/struts2/ActionInvocation.java
@@ -19,7 +19,6 @@
 package org.apache.struts2;
 
 import com.opensymphony.xwork2.ActionChainResult;
-import com.opensymphony.xwork2.ActionProxy;
 import com.opensymphony.xwork2.util.ValueStack;
 import org.apache.struts2.interceptor.PreResultListener;
 
@@ -176,6 +175,6 @@ public interface ActionInvocation {
      */
     void setActionEventListener(ActionEventListener listener);
 
-    void init(ActionProxy proxy) ;
+    void init(ActionProxy proxy);
 
 }

--- a/core/src/main/java/org/apache/struts2/ActionInvocation.java
+++ b/core/src/main/java/org/apache/struts2/ActionInvocation.java
@@ -19,7 +19,6 @@
 package org.apache.struts2;
 
 import com.opensymphony.xwork2.ActionChainResult;
-import com.opensymphony.xwork2.ActionEventListener;
 import com.opensymphony.xwork2.ActionProxy;
 import com.opensymphony.xwork2.util.ValueStack;
 import org.apache.struts2.interceptor.PreResultListener;

--- a/core/src/main/java/org/apache/struts2/ActionProxy.java
+++ b/core/src/main/java/org/apache/struts2/ActionProxy.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.struts2;
+
+import com.opensymphony.xwork2.config.entities.ActionConfig;
+
+/**
+ * ActionProxy is an extra layer between XWork and the action so that different proxies are possible.
+ *
+ * <p>
+ * An example of this would be a remote proxy, where the layer between XWork and the action might be RMI or SOAP.
+ * </p>
+ *
+ * @author Jason Carreira
+ */
+public interface ActionProxy {
+
+    /**
+     * Gets the Action instance for this Proxy.
+     *
+     * @return the Action instance
+     */
+    Object getAction();
+
+    /**
+     * Gets the alias name this ActionProxy is mapped to.
+     *
+     * @return the alias name
+     */
+    String getActionName();
+
+    /**
+     * Gets the ActionConfig this ActionProxy is built from.
+     *
+     * @return the ActionConfig
+     */
+    ActionConfig getConfig();
+
+    /**
+     * Sets whether this ActionProxy should also execute the Result after executing the Action.
+     *
+     * @param executeResult <tt>true</tt> to also execute the Result.
+     */
+    void setExecuteResult(boolean executeResult);
+
+    /**
+     * Gets the status of whether the ActionProxy is set to execute the Result after the Action is executed.
+     *
+     * @return the status
+     */
+    boolean getExecuteResult();
+
+    ActionInvocation getInvocation();
+
+    /**
+     * Gets the namespace the ActionConfig for this ActionProxy is mapped to.
+     *
+     * @return the namespace
+     */
+    String getNamespace();
+
+    /**
+     * Execute this ActionProxy. This will set the ActionContext from the ActionInvocation into the ActionContext
+     * ThreadLocal before invoking the ActionInvocation, then set the old ActionContext back into the ThreadLocal.
+     *
+     * @return the result code returned from executing the ActionInvocation
+     * @throws Exception can be thrown.
+     * @see ActionInvocation
+     */
+    String execute() throws Exception;
+
+    /**
+     * Gets the method name to execute, or <tt>null</tt> if no method has been specified (meaning <code>execute</code> will be invoked).
+     *
+     * @return the method to execute
+     */
+    String getMethod();
+
+    /**
+     * Gets status of the method value's initialization.
+     *
+     * @return true if the method returned by getMethod() is not a default initializer value.
+     */
+    boolean isMethodSpecified();
+
+}


### PR DESCRIPTION
WW-3714
--
This PR deprecates and provides repackaged replacements for the following APIs, ahead of their permanent migration in Struts 7.0:
- `com.opensymphony.xwork2.ActionProxy`
- `com.opensymphony.xwork2.ActionEventListener`

Please refer to #1081 for the techniques and methodology employed in this PR.