### PR TITLE
WW-3714 Deprecate and repackage common APIs part 2.5

### DIFF
--- a/core/src/main/java/com/opensymphony/xwork2/DefaultActionInvocation.java
+++ b/core/src/main/java/com/opensymphony/xwork2/DefaultActionInvocation.java
@@ -248,6 +248,9 @@ public class DefaultActionInvocation implements ActionInvocation {
                 Interceptor interceptor = interceptorMapping.getInterceptor();
                 if (interceptor instanceof WithLazyParams) {
                     interceptor = lazyParamInjector.injectParams(interceptor, interceptorMapping.getParams(), invocationContext);
+                } else if (interceptor instanceof Interceptor.LegacyAdapter && ((Interceptor.LegacyAdapter) interceptor).getAdaptee() instanceof WithLazyParams) {
+                    org.apache.struts2.interceptor.Interceptor adaptee = ((Interceptor.LegacyAdapter) interceptor).getAdaptee();
+                    lazyParamInjector.injectParams(adaptee, interceptorMapping.getParams(), invocationContext);
                 }
                 if (interceptor instanceof ConditionalInterceptor) {
                     resultCode = executeConditional((ConditionalInterceptor) interceptor);

--- a/core/src/main/java/com/opensymphony/xwork2/factory/DefaultInterceptorFactory.java
+++ b/core/src/main/java/com/opensymphony/xwork2/factory/DefaultInterceptorFactory.java
@@ -70,13 +70,18 @@ public class DefaultInterceptorFactory implements InterceptorFactory {
                 reflectionProvider.setProperties(params, o);
             }
 
+            Interceptor interceptor = null;
             if (o instanceof Interceptor) {
-                Interceptor interceptor = (Interceptor) o;
-                interceptor.init();
-                return interceptor;
+                interceptor = (Interceptor) o;
+            } else if (o instanceof org.apache.struts2.interceptor.Interceptor) {
+                interceptor = Interceptor.adapt((org.apache.struts2.interceptor.Interceptor) o);
             }
 
-            throw new ConfigurationException("Class [" + interceptorClassName + "] does not implement Interceptor", interceptorConfig);
+            if (interceptor == null) {
+                throw new ConfigurationException("Class [" + interceptorClassName + "] does not implement Interceptor", interceptorConfig);
+            }
+            interceptor.init();
+            return interceptor;
         } catch (InstantiationException e) {
             cause = e;
             message = "Unable to instantiate an instance of Interceptor class [" + interceptorClassName + "].";

--- a/core/src/main/java/com/opensymphony/xwork2/factory/DefaultResultFactory.java
+++ b/core/src/main/java/com/opensymphony/xwork2/factory/DefaultResultFactory.java
@@ -20,6 +20,7 @@ package com.opensymphony.xwork2.factory;
 
 import com.opensymphony.xwork2.ObjectFactory;
 import com.opensymphony.xwork2.Result;
+import com.opensymphony.xwork2.config.ConfigurationException;
 import com.opensymphony.xwork2.config.entities.ResultConfig;
 import com.opensymphony.xwork2.inject.Inject;
 import com.opensymphony.xwork2.util.reflection.ReflectionException;
@@ -51,7 +52,16 @@ public class DefaultResultFactory implements ResultFactory {
         Result result = null;
 
         if (resultClassName != null) {
-            result = (Result) objectFactory.buildBean(resultClassName, extraContext);
+            Object o = objectFactory.buildBean(resultClassName, extraContext);
+            if (o instanceof Result) {
+                result = (Result) o;
+            } else if (o instanceof org.apache.struts2.Result) {
+                result = Result.adapt((org.apache.struts2.Result) o);
+            }
+            if (result == null) {
+                throw new ConfigurationException("Class [" + resultClassName + "] does not implement Result", resultConfig);
+            }
+
             Map<String, String> params = resultConfig.getParams();
             if (params != null) {
                 for (Map.Entry<String, String> paramEntry : params.entrySet()) {

--- a/core/src/main/java/com/opensymphony/xwork2/factory/DefaultResultFactory.java
+++ b/core/src/main/java/com/opensymphony/xwork2/factory/DefaultResultFactory.java
@@ -53,6 +53,20 @@ public class DefaultResultFactory implements ResultFactory {
 
         if (resultClassName != null) {
             Object o = objectFactory.buildBean(resultClassName, extraContext);
+
+            Map<String, String> params = resultConfig.getParams();
+            if (params != null) {
+                for (Map.Entry<String, String> paramEntry : params.entrySet()) {
+                    try {
+                        reflectionProvider.setProperty(paramEntry.getKey(), paramEntry.getValue(), o, extraContext, true);
+                    } catch (ReflectionException ex) {
+                        if (o instanceof ReflectionExceptionHandler) {
+                            ((ReflectionExceptionHandler) o).handle(ex);
+                        }
+                    }
+                }
+            }
+
             if (o instanceof Result) {
                 result = (Result) o;
             } else if (o instanceof org.apache.struts2.Result) {
@@ -60,19 +74,6 @@ public class DefaultResultFactory implements ResultFactory {
             }
             if (result == null) {
                 throw new ConfigurationException("Class [" + resultClassName + "] does not implement Result", resultConfig);
-            }
-
-            Map<String, String> params = resultConfig.getParams();
-            if (params != null) {
-                for (Map.Entry<String, String> paramEntry : params.entrySet()) {
-                    try {
-                        reflectionProvider.setProperty(paramEntry.getKey(), paramEntry.getValue(), result, extraContext, true);
-                    } catch (ReflectionException ex) {
-                        if (result instanceof ReflectionExceptionHandler) {
-                            ((ReflectionExceptionHandler) result).handle(ex);
-                        }
-                    }
-                }
             }
         }
 

--- a/core/src/main/java/com/opensymphony/xwork2/interceptor/ConditionalInterceptor.java
+++ b/core/src/main/java/com/opensymphony/xwork2/interceptor/ConditionalInterceptor.java
@@ -28,9 +28,32 @@ import com.opensymphony.xwork2.ActionInvocation;
 @Deprecated
 public interface ConditionalInterceptor extends org.apache.struts2.interceptor.ConditionalInterceptor, Interceptor {
 
+    @Override
     default boolean shouldIntercept(org.apache.struts2.ActionInvocation invocation) {
         return shouldIntercept(ActionInvocation.adapt(invocation));
     }
 
     boolean shouldIntercept(ActionInvocation invocation);
+
+    static ConditionalInterceptor adapt(org.apache.struts2.interceptor.ConditionalInterceptor actualInterceptor) {
+        if (actualInterceptor instanceof ConditionalInterceptor) {
+            return (ConditionalInterceptor) actualInterceptor;
+        }
+        return actualInterceptor != null ? new LegacyAdapter(actualInterceptor) : null;
+    }
+
+    class LegacyAdapter extends Interceptor.LegacyAdapter implements ConditionalInterceptor {
+
+        private final org.apache.struts2.interceptor.ConditionalInterceptor adaptee;
+
+        private LegacyAdapter(org.apache.struts2.interceptor.ConditionalInterceptor adaptee) {
+            super(adaptee);
+            this.adaptee = adaptee;
+        }
+
+        @Override
+        public boolean shouldIntercept(ActionInvocation invocation) {
+            return adaptee.shouldIntercept(invocation);
+        }
+    }
 }

--- a/core/src/main/java/com/opensymphony/xwork2/interceptor/Interceptor.java
+++ b/core/src/main/java/com/opensymphony/xwork2/interceptor/Interceptor.java
@@ -34,4 +34,38 @@ public interface Interceptor extends org.apache.struts2.interceptor.Interceptor 
     }
 
     String intercept(ActionInvocation invocation) throws Exception;
+
+    static Interceptor adapt(org.apache.struts2.interceptor.Interceptor actualInterceptor) {
+        if (actualInterceptor instanceof org.apache.struts2.interceptor.ConditionalInterceptor) {
+            return ConditionalInterceptor.adapt((org.apache.struts2.interceptor.ConditionalInterceptor) actualInterceptor);
+        }
+        if (actualInterceptor instanceof Interceptor) {
+            return (Interceptor) actualInterceptor;
+        }
+        return actualInterceptor != null ? new LegacyAdapter(actualInterceptor) : null;
+    }
+
+    class LegacyAdapter implements Interceptor {
+
+        private final org.apache.struts2.interceptor.Interceptor adaptee;
+
+        protected LegacyAdapter(org.apache.struts2.interceptor.Interceptor adaptee) {
+            this.adaptee = adaptee;
+        }
+
+        @Override
+        public String intercept(ActionInvocation invocation) throws Exception {
+            return adaptee.intercept(invocation);
+        }
+
+        @Override
+        public void destroy() {
+            adaptee.destroy();
+        }
+
+        @Override
+        public void init() {
+            adaptee.init();
+        }
+    }
 }

--- a/core/src/main/java/com/opensymphony/xwork2/interceptor/Interceptor.java
+++ b/core/src/main/java/com/opensymphony/xwork2/interceptor/Interceptor.java
@@ -53,6 +53,10 @@ public interface Interceptor extends org.apache.struts2.interceptor.Interceptor 
             this.adaptee = adaptee;
         }
 
+        public org.apache.struts2.interceptor.Interceptor getAdaptee() {
+            return adaptee;
+        }
+
         @Override
         public String intercept(ActionInvocation invocation) throws Exception {
             return adaptee.intercept(invocation);

--- a/core/src/main/java/com/opensymphony/xwork2/interceptor/WithLazyParams.java
+++ b/core/src/main/java/com/opensymphony/xwork2/interceptor/WithLazyParams.java
@@ -70,11 +70,14 @@ public interface WithLazyParams {
         }
 
         public Interceptor injectParams(Interceptor interceptor, Map<String, String> params, ActionContext invocationContext) {
+            return (Interceptor) injectParams((org.apache.struts2.interceptor.Interceptor) interceptor, params, invocationContext);
+        }
+
+        public org.apache.struts2.interceptor.Interceptor injectParams(org.apache.struts2.interceptor.Interceptor interceptor, Map<String, String> params, ActionContext invocationContext) {
             for (Map.Entry<String, String> entry : params.entrySet()) {
                 Object paramValue = textParser.evaluate(new char[]{ '$' }, entry.getValue(), valueEvaluator, TextParser.DEFAULT_LOOP_COUNT);
                 ognlUtil.setProperty(entry.getKey(), paramValue, interceptor, invocationContext.getContextMap());
             }
-
             return interceptor;
         }
     }


### PR DESCRIPTION
WW-3714
--
Ensure factory support for new Interceptor, Result interfaces introduced in #1079.

When Results and Interfaces are parsed and instantiated from XML configuration they are expected to be of the deprecated `com.opensymphony.xwork2` types. We want to also ensure the new `org.apache.struts2` types are supported. We cannot easily change the factory interface signatures without breaking compatibility for the associated extension points. Thus, we ensure these types are adapted within the default factory implementations instead. Additional helper code was needed to ensure that the marker interfaces `ReflectionExceptionHandler`, `WithLazyParams`, `ParamNameAwareResult` are still respected. This helper code can of course be completely discarded in Struts 7.0.