### PR TITLE
WW-5209 Upgrade to Jakarta Bean Validation 3.1.0

### DIFF
--- a/apps/showcase/pom.xml
+++ b/apps/showcase/pom.xml
@@ -149,6 +149,12 @@
             <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
             <version>${hibernate-validator.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>jakarta.validation</groupId>
+                    <artifactId>jakarta.validation-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!--

--- a/core/src/test/java/org/apache/struts2/components/UIBeanTest.java
+++ b/core/src/test/java/org/apache/struts2/components/UIBeanTest.java
@@ -387,7 +387,7 @@ public class UIBeanTest extends StrutsInternalTestCase {
         DoubleSelect dblSelect = new DoubleSelect(stack, req, res);
         dblSelect.evaluateParams();
 
-        assertNull(dblSelect.getParameters().get("nonce"));
+        assertNull(dblSelect.getAttributes().get("nonce"));
     }
 
     public void testSetNullUiStaticContentPath() {

--- a/plugins/bean-validation/pom.xml
+++ b/plugins/bean-validation/pom.xml
@@ -41,9 +41,8 @@
         <dependency>
            <groupId>jakarta.validation</groupId>
            <artifactId>jakarta.validation-api</artifactId>
-           <version>3.0.2</version>
+           <version>3.1.0</version>
         </dependency>
-
 
         <dependency>
             <groupId>org.hibernate.validator</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -884,7 +884,7 @@
             <dependency>
                 <groupId>org.htmlunit</groupId>
                 <artifactId>htmlunit</artifactId>
-                <version>3.6.0</version>
+                <version>4.2.0</version>
                 <scope>test</scope>
             </dependency>
 


### PR DESCRIPTION
WW-5209
--

Uses 
```xml
        <dependency>
           <groupId>jakarta.validation</groupId>
           <artifactId>jakarta.validation-api</artifactId>
           <version>3.1.0</version>
        </dependency>
```