### PR TITLE
WW-5476 Deprecates tag's parameters as replaced with attributes

### DIFF
--- a/core/src/main/java/org/apache/struts2/components/ActionComponent.java
+++ b/core/src/main/java/org/apache/struts2/components/ActionComponent.java
@@ -215,8 +215,8 @@ public class ActionComponent extends ContextBean {
 
         HttpParameters.Builder builder = HttpParameters.create().withParent(parentParams);
 
-        if (parameters != null) {
-            builder = builder.withExtraParams(parameters);
+        if (attributes != null) {
+            builder = builder.withExtraParams(attributes);
         }
         return builder.build();
     }

--- a/core/src/main/java/org/apache/struts2/components/Component.java
+++ b/core/src/main/java/org/apache/struts2/components/Component.java
@@ -71,7 +71,7 @@ public class Component {
     protected boolean devMode = false;
     protected boolean escapeHtmlBody = false;
     protected ValueStack stack;
-    protected Map<String, Object> parameters;
+    protected Map<String, Object> attributes;
     protected ActionMapper actionMapper;
     protected boolean throwExceptionOnELFailure;
     protected boolean performClearTagStateForTagPoolingServers = false;
@@ -86,7 +86,7 @@ public class Component {
      */
     public Component(ValueStack stack) {
         this.stack = stack;
-        this.parameters = new LinkedHashMap<>();
+        this.attributes = new LinkedHashMap<>();
         getComponentStack().push(this);
     }
 
@@ -279,7 +279,7 @@ public class Component {
      */
     protected StrutsException fieldError(String field, String errorMsg, Exception e) {
         String msg = "tag '" + getComponentName() + "', field '" + field +
-            (parameters != null && parameters.containsKey("name") ? "', name '" + parameters.get("name") : "") +
+            (attributes != null && attributes.containsKey("name") ? "', name '" + attributes.get("name") : "") +
             "': " + errorMsg;
         throw new StrutsException(msg, e);
     }
@@ -457,7 +457,7 @@ public class Component {
      * @param params the parameters to copy.
      */
     public void copyParams(Map<String, Object> params) {
-        stack.push(parameters);
+        stack.push(attributes);
         stack.push(this);
         try {
             for (Map.Entry<String, Object> entry : params.entrySet()) {
@@ -467,7 +467,7 @@ public class Component {
                     // UI component attributes may contain hypens (e.g. data-ajax), but ognl
                     // can't handle that, and there can't be a component property with a hypen
                     // so into the parameters map it goes. See WW-4493
-                    parameters.put(key, entry.getValue());
+                    attributes.put(key, entry.getValue());
                 } else {
                     stack.setValue(key, entry.getValue());
                 }
@@ -496,9 +496,20 @@ public class Component {
      * Gets the parameters.
      *
      * @return the parameters. Is never <tt>null</tt>.
+     * @deprecated since 6.7.0, use {@link #getAttributes()} instead
      */
+    @Deprecated
     public Map<String, Object> getParameters() {
-        return parameters;
+        return attributes;
+    }
+
+    /**
+     * Gets the parameters.
+     *
+     * @return the parameters. Is never <tt>null</tt>.
+     */
+    public Map<String, Object> getAttributes() {
+        return attributes;
     }
 
     /**
@@ -507,7 +518,7 @@ public class Component {
      * @param params the parameters to add.
      */
     public void addAllParameters(Map<String, Object> params) {
-        parameters.putAll(params);
+        attributes.putAll(params);
     }
 
     /**
@@ -522,7 +533,7 @@ public class Component {
      */
     public void addParameter(String key, Object value) {
         if (key != null) {
-            Map<String, Object> params = getParameters();
+            Map<String, Object> params = getAttributes();
 
             if (value == null) {
                 params.remove(key);

--- a/core/src/main/java/org/apache/struts2/components/DoubleListUIBean.java
+++ b/core/src/main/java/org/apache/struts2/components/DoubleListUIBean.java
@@ -164,7 +164,7 @@ public abstract class DoubleListUIBean extends ListUIBean {
             // ok, let's look it up
             Component form = findAncestor(Form.class);
             if (form != null) {
-                addParameter("formName", form.getParameters().get("name"));
+                addParameter("formName", form.getAttributes().get("name"));
             }
         }
 
@@ -188,7 +188,7 @@ public abstract class DoubleListUIBean extends ListUIBean {
         if (doubleId != null) {
             addParameter("doubleId", findString(doubleId));
         } else if (form != null) {
-            addParameter("doubleId", form.getParameters().get("id") + "_" + escape(doubleName != null ? findString(doubleName) : null));
+            addParameter("doubleId", form.getAttributes().get("id") + "_" + escape(doubleName != null ? findString(doubleName) : null));
         } else {
             addParameter("doubleId", escape(doubleName != null ? findString(doubleName) : null));
         }

--- a/core/src/main/java/org/apache/struts2/components/DoubleSelect.java
+++ b/core/src/main/java/org/apache/struts2/components/DoubleSelect.java
@@ -57,7 +57,7 @@ public class DoubleSelect extends DoubleListUIBean {
     public void evaluateExtraParams() {
         super.evaluateExtraParams();
         StringBuilder onchangeParam = new StringBuilder();
-        onchangeParam.append(getParameters().get("id")).append("Redirect(this.selectedIndex)");
+        onchangeParam.append(getAttributes().get("id")).append("Redirect(this.selectedIndex)");
         if(StringUtils.isNotEmpty(this.onchange)) {
         	onchangeParam.append(";").append(this.onchange);
         }

--- a/core/src/main/java/org/apache/struts2/components/File.java
+++ b/core/src/main/java/org/apache/struts2/components/File.java
@@ -68,13 +68,13 @@ public class File extends UIBean {
 
         Form form = (Form) findAncestor(Form.class);
         if (form != null) {
-            String encType = (String) form.getParameters().get("enctype");
+            String encType = (String) form.getAttributes().get("enctype");
             if (!"multipart/form-data".equals(encType)) {
                 // uh oh, this isn't good! Let's warn the developer
                 LOG.warn("Struts has detected a file upload UI tag (s:file) being used without a form set to enctype 'multipart/form-data'. This is probably an error!");
             }
 
-            String method = (String) form.getParameters().get("method");
+            String method = (String) form.getAttributes().get("method");
             if (!"post".equalsIgnoreCase(method)) {
                 // uh oh, this isn't good! Let's warn the developer
                 LOG.warn("Struts has detected a file upload UI tag (s:file) being used without a form set to method 'POST'. This is probably an error!");

--- a/core/src/main/java/org/apache/struts2/components/Form.java
+++ b/core/src/main/java/org/apache/struts2/components/Form.java
@@ -172,7 +172,7 @@ public class Form extends ClosingUIBean {
 
         if (name == null) {
             //make the name the same as the id
-            String id = (String) getParameters().get("id");
+            String id = (String) getAttributes().get("id");
             if (StringUtils.isNotEmpty(id)) {
                 addParameter("name", id);
             }
@@ -204,7 +204,7 @@ public class Form extends ClosingUIBean {
 
         // keep a collection of the tag names for anything special the templates might want to do (such as pure client
         // side validation)
-        if (!parameters.containsKey("tagNames")) {
+        if (!attributes.containsKey("tagNames")) {
             // we have this if check so we don't do this twice (on open and close of the template)
             addParameter("tagNames", new ArrayList());
         }
@@ -242,7 +242,7 @@ public class Form extends ClosingUIBean {
     protected void evaluateClientSideJsEnablement(String actionName, String namespace, String actionMethod) {
 
         // Only evaluate if Client-Side js is to be enable when validate=true
-        Boolean validate = (Boolean) getParameters().get("validate");
+        Boolean validate = (Boolean) getAttributes().get("validate");
         if (validate != null && validate) {
 
             addParameter("performValidation", Boolean.FALSE);
@@ -270,7 +270,7 @@ public class Form extends ClosingUIBean {
     }
 
     public List getValidators(String name) {
-        Class actionClass = (Class) getParameters().get("actionClass");
+        Class actionClass = (Class) getAttributes().get("actionClass");
         if (actionClass == null) {
             return Collections.EMPTY_LIST;
         }
@@ -279,7 +279,7 @@ public class Form extends ClosingUIBean {
         ActionMapping mapping = actionMapper.getMappingFromActionName(formActionValue);
 
         if (mapping == null) {
-            mapping = actionMapper.getMappingFromActionName((String) getParameters().get("actionName"));
+            mapping = actionMapper.getMappingFromActionName((String) getAttributes().get("actionName"));
         }
 
         if (mapping == null) {

--- a/core/src/main/java/org/apache/struts2/components/FormButton.java
+++ b/core/src/main/java/org/apache/struts2/components/FormButton.java
@@ -58,7 +58,7 @@ public abstract class FormButton extends ClosingUIBean {
         addParameter("type", submitType);
 
         if (!BUTTON_TYPE_INPUT.equals(submitType) && (label == null)) {
-            addParameter("label", getParameters().get("nameValue"));
+            addParameter("label", getAttributes().get("nameValue"));
         }
 
         if (action != null || method != null) {
@@ -101,8 +101,8 @@ public abstract class FormButton extends ClosingUIBean {
             // this check is needed for backwards compatibility with 2.1.x
             tmpId = findString(id);
         } else {
-            if (form != null && form.getParameters().get("id") != null) {
-                tmpId = tmpId + form.getParameters().get("id").toString() + "_";
+            if (form != null && form.getAttributes().get("id") != null) {
+                tmpId = tmpId + form.getAttributes().get("id").toString() + "_";
             }
             if (name != null) {
                 tmpId = tmpId + escape(findString(name));

--- a/core/src/main/java/org/apache/struts2/components/Include.java
+++ b/core/src/main/java/org/apache/struts2/components/Include.java
@@ -137,13 +137,13 @@ public class Include extends Component {
         urlBuf.append(page);
 
         // Add request parameters
-        if (parameters.size() > 0) {
+        if (attributes.size() > 0) {
             urlBuf.append('?');
 
             String concat = "";
 
             // Set parameters
-            for (Object next : parameters.entrySet()) {
+            for (Object next : attributes.entrySet()) {
                 Map.Entry entry = (Map.Entry) next;
                 Object name = entry.getKey();
                 List values = (List) entry.getValue();
@@ -234,11 +234,11 @@ public class Include extends Component {
         // instead, include tag requires that each parameter be a list of objects,
         // just like the HTTP servlet interfaces are (String[])
         if (value != null) {
-            List currentValues = (List) parameters.get(key);
+            List currentValues = (List) attributes.get(key);
 
             if (currentValues == null) {
                 currentValues = new ArrayList();
-                parameters.put(key, currentValues);
+                attributes.put(key, currentValues);
             }
 
             currentValues.add(value);

--- a/core/src/main/java/org/apache/struts2/components/InputTransferSelect.java
+++ b/core/src/main/java/org/apache/struts2/components/InputTransferSelect.java
@@ -174,7 +174,7 @@ public class InputTransferSelect extends ListUIBean {
 
 
             // key -> select tag id, value -> headerKey (if exists)
-            Map formInputtransferselectIds = (Map) formAncestor.getParameters().get("inputtransferselectIds");
+            Map formInputtransferselectIds = (Map) formAncestor.getAttributes().get("inputtransferselectIds");
 
             // init lists
             if (formInputtransferselectIds == null) {
@@ -182,13 +182,13 @@ public class InputTransferSelect extends ListUIBean {
             }
 
             // id
-            String tmpId = (String) getParameters().get("id");
-            String tmpHeaderKey = (String) getParameters().get("headerKey");
+            String tmpId = (String) getAttributes().get("id");
+            String tmpHeaderKey = (String) getAttributes().get("headerKey");
             if (tmpId != null && (! formInputtransferselectIds.containsKey(tmpId))) {
                 formInputtransferselectIds.put(tmpId, tmpHeaderKey);
             }
 
-            formAncestor.getParameters().put("inputtransferselectIds", formInputtransferselectIds);
+            formAncestor.getAttributes().put("inputtransferselectIds", formInputtransferselectIds);
 
         }
         else {

--- a/core/src/main/java/org/apache/struts2/components/Label.java
+++ b/core/src/main/java/org/apache/struts2/components/Label.java
@@ -81,7 +81,7 @@ public class Label extends UIBean {
         if (value != null) {
             addParameter("nameValue", findString(value));
         } else if (key != null) {
-            Object nameValue = parameters.get("nameValue");
+            Object nameValue = attributes.get("nameValue");
             if (nameValue == null || nameValue.toString().length() == 0) {
                 // get the label from a TextProvider (default value is the key)
                 String providedLabel = TextProviderHelper.getText(key, key, stack);

--- a/core/src/main/java/org/apache/struts2/components/ListUIBean.java
+++ b/core/src/main/java/org/apache/struts2/components/ListUIBean.java
@@ -67,7 +67,7 @@ public abstract class ListUIBean extends UIBean {
         Object value = null;
 
         if (list == null) {
-            list = parameters.get("list");
+            list = attributes.get("list");
         }
 
         if (list instanceof String) {

--- a/core/src/main/java/org/apache/struts2/components/OptGroup.java
+++ b/core/src/main/java/org/apache/struts2/components/OptGroup.java
@@ -90,7 +90,7 @@ public class OptGroup extends Component {
             }
         };
     }
-    
+
     @Inject
     public void setContainer(Container container) {
         container.inject(internalUiBean);
@@ -106,7 +106,7 @@ public class OptGroup extends Component {
         internalUiBean.start(writer);
         internalUiBean.end(writer, body);
 
-        List listUiBeans = (List) select.getParameters().get(INTERNAL_LIST_UI_BEAN_LIST_PARAMETER_KEY);
+        List listUiBeans = (List) select.getAttributes().get(INTERNAL_LIST_UI_BEAN_LIST_PARAMETER_KEY);
         if (listUiBeans == null) {
             listUiBeans = new ArrayList();
         }

--- a/core/src/main/java/org/apache/struts2/components/OptionTransferSelect.java
+++ b/core/src/main/java/org/apache/struts2/components/OptionTransferSelect.java
@@ -287,8 +287,8 @@ public class OptionTransferSelect extends DoubleListUIBean {
 
 
             // key -> select tag id, value -> headerKey (if exists)
-            Map formOptiontransferselectIds = (Map) formAncestor.getParameters().get("optiontransferselectIds");
-            Map formOptiontransferselectDoubleIds = (Map) formAncestor.getParameters().get("optiontransferselectDoubleIds");
+            Map formOptiontransferselectIds = (Map) formAncestor.getAttributes().get("optiontransferselectIds");
+            Map formOptiontransferselectDoubleIds = (Map) formAncestor.getAttributes().get("optiontransferselectDoubleIds");
 
             // init lists
             if (formOptiontransferselectIds == null) {
@@ -300,21 +300,21 @@ public class OptionTransferSelect extends DoubleListUIBean {
 
 
             // id
-            String tmpId = (String) getParameters().get("id");
-            String tmpHeaderKey = (String) getParameters().get("headerKey");
+            String tmpId = (String) getAttributes().get("id");
+            String tmpHeaderKey = (String) getAttributes().get("headerKey");
             if (tmpId != null && (! formOptiontransferselectIds.containsKey(tmpId))) {
                 formOptiontransferselectIds.put(tmpId, tmpHeaderKey);
             }
 
             // doubleId
-            String tmpDoubleId = (String) getParameters().get("doubleId");
-            String tmpDoubleHeaderKey = (String) getParameters().get("doubleHeaderKey");
+            String tmpDoubleId = (String) getAttributes().get("doubleId");
+            String tmpDoubleHeaderKey = (String) getAttributes().get("doubleHeaderKey");
             if (tmpDoubleId != null && (! formOptiontransferselectDoubleIds.containsKey(tmpDoubleId))) {
                 formOptiontransferselectDoubleIds.put(tmpDoubleId, tmpDoubleHeaderKey);
             }
 
-            formAncestor.getParameters().put("optiontransferselectIds", formOptiontransferselectIds);
-            formAncestor.getParameters().put("optiontransferselectDoubleIds", formOptiontransferselectDoubleIds);
+            formAncestor.getAttributes().put("optiontransferselectIds", formOptiontransferselectIds);
+            formAncestor.getAttributes().put("optiontransferselectDoubleIds", formOptiontransferselectDoubleIds);
 
         }
         else {

--- a/core/src/main/java/org/apache/struts2/components/ServletUrlRenderer.java
+++ b/core/src/main/java/org/apache/struts2/components/ServletUrlRenderer.java
@@ -174,7 +174,7 @@ public class ServletUrlRenderer implements UrlRenderer {
             namespace, actionName);
         if (actionConfig != null) {
 
-            ActionMapping mapping = new ActionMapping(actionName, namespace, actionMethod, formComponent.parameters);
+            ActionMapping mapping = new ActionMapping(actionName, namespace, actionMethod, formComponent.attributes);
             String result = urlHelper.buildUrl(formComponent.actionMapper.getUriFromActionMapping(mapping),
                 formComponent.request, formComponent.response, queryStringResult.getQueryParams(), scheme, formComponent.includeContext, true, false, false);
             formComponent.addParameter("action", result);

--- a/core/src/main/java/org/apache/struts2/components/Token.java
+++ b/core/src/main/java/org/apache/struts2/components/Token.java
@@ -73,7 +73,7 @@ public class Token extends UIBean {
         super.evaluateExtraParams();
 
         String tokenName;
-        Map parameters = getParameters();
+        Map parameters = getAttributes();
 
         if (parameters.containsKey("name")) {
             tokenName = (String) parameters.get("name");

--- a/core/src/main/java/org/apache/struts2/components/UIBean.java
+++ b/core/src/main/java/org/apache/struts2/components/UIBean.java
@@ -591,7 +591,7 @@ public abstract class UIBean extends Component {
 
         LOG.debug("Rendering template {}", template);
 
-        final TemplateRenderingContext context = new TemplateRenderingContext(template, writer, getStack(), getParameters(), this);
+        final TemplateRenderingContext context = new TemplateRenderingContext(template, writer, getStack(), getAttributes(), this);
         engine.renderTemplate(context);
     }
 
@@ -797,11 +797,11 @@ public abstract class UIBean extends Component {
         populateComponentHtmlId(form);
 
         if (form != null ) {
-            addParameter("form", form.getParameters());
+            addParameter("form", form.getAttributes());
 
             if ( translatedName != null ) {
                 // list should have been created by the form component
-                List<String> tags = (List<String>) form.getParameters().get("tagNames");
+                List<String> tags = (List<String>) form.getAttributes().get("tagNames");
                 tags.add(translatedName);
             }
         }
@@ -833,19 +833,19 @@ public abstract class UIBean extends Component {
             }
 
             //TODO: this is to keep backward compatibility, remove once when tooltipConfig is dropped
-            String  jsTooltipEnabled = (String) getParameters().get("jsTooltipEnabled");
+            String  jsTooltipEnabled = (String) getAttributes().get("jsTooltipEnabled");
             if (jsTooltipEnabled != null)
                 this.javascriptTooltip = jsTooltipEnabled;
 
             //TODO: this is to keep backward compatibility, remove once when tooltipConfig is dropped
-            String tooltipIcon = (String) getParameters().get("tooltipIcon");
+            String tooltipIcon = (String) getAttributes().get("tooltipIcon");
             if (tooltipIcon != null)
                 this.addParameter("tooltipIconPath", tooltipIcon);
             if (this.tooltipIconPath != null)
                 this.addParameter("tooltipIconPath", findString(this.tooltipIconPath));
 
             //TODO: this is to keep backward compatibility, remove once when tooltipConfig is dropped
-            String tooltipDelayParam = (String) getParameters().get("tooltipDelay");
+            String tooltipDelayParam = (String) getAttributes().get("tooltipDelay");
             if (tooltipDelayParam != null)
                 this.addParameter("tooltipDelay", tooltipDelayParam);
             if (this.tooltipDelay != null)
@@ -882,8 +882,8 @@ public abstract class UIBean extends Component {
      */
     protected void applyValueParameter(String translatedName) {
         // see if the value has been specified as a parameter already
-        if (parameters.containsKey(ATTR_VALUE)) {
-            parameters.put(ATTR_NAME_VALUE, parameters.get(ATTR_VALUE));
+        if (attributes.containsKey(ATTR_VALUE)) {
+            attributes.put(ATTR_NAME_VALUE, attributes.get(ATTR_VALUE));
         } else {
             if (evaluateNameValue()) {
                 final Class<?> valueClazz = getValueClassType();
@@ -969,7 +969,7 @@ public abstract class UIBean extends Component {
     }
 
     protected Map<String, String> getTooltipConfig(UIBean component) {
-        Object tooltipConfigObj = component.getParameters().get("tooltipConfig");
+        Object tooltipConfigObj = component.getAttributes().get("tooltipConfig");
         Map<String, String> result = new LinkedHashMap<>();
 
         if (tooltipConfigObj instanceof Map) {
@@ -1030,7 +1030,7 @@ public abstract class UIBean extends Component {
             LOG.debug("Cannot determine id attribute for [{}], consider defining id, name or key attribute!", this);
             tryId = null;
         } else if (form != null) {
-            tryId = form.getParameters().get("id") + "_" + generatedId;
+            tryId = form.getAttributes().get("id") + "_" + generatedId;
         } else {
             tryId = generatedId;
         }

--- a/core/src/main/java/org/apache/struts2/components/URL.java
+++ b/core/src/main/java/org/apache/struts2/components/URL.java
@@ -111,7 +111,7 @@ public class URL extends ContextBean {
 
     public URL(ValueStack stack, HttpServletRequest req, HttpServletResponse res) {
         super(stack);
-        urlProvider = new ComponentUrlProvider(this, this.parameters);
+        urlProvider = new ComponentUrlProvider(this, this.attributes);
         urlProvider.setHttpServletRequest(req);
         urlProvider.setHttpServletResponse(res);
     }

--- a/core/src/main/java/org/apache/struts2/components/UpDownSelect.java
+++ b/core/src/main/java/org/apache/struts2/components/UpDownSelect.java
@@ -70,7 +70,7 @@ import java.util.Map;
  * {@literal @}s.tag name="updownselect" tld-body-content="JSP" tld-tag-class="org.apache.struts2.views.jsp.ui.UpDownSelectTag"
  * description="Render a up down select element"
  */
-@StrutsTag(name="updownselect", tldTagClass="org.apache.struts2.views.jsp.ui.UpDownSelectTag", 
+@StrutsTag(name="updownselect", tldTagClass="org.apache.struts2.views.jsp.ui.UpDownSelectTag",
         description="Create a Select component with buttons to move the elements in the select component up and down")
 public class UpDownSelect extends Select {
 
@@ -136,13 +136,13 @@ public class UpDownSelect extends Select {
             // inform form ancestor that we are using a custom onSubmit
             enableAncestorFormCustomOnsubmit();
 
-            Map m = (Map) ancestorForm.getParameters().get("updownselectIds");
+            Map m = (Map) ancestorForm.getAttributes().get("updownselectIds");
             if (m == null) {
                 // map with key -> id ,  value -> headerKey
                 m = new LinkedHashMap();
             }
-            m.put(getParameters().get("id"), getParameters().get("headerKey"));
-            ancestorForm.getParameters().put("updownselectIds", m);
+            m.put(getAttributes().get("id"), getAttributes().get("headerKey"));
+            ancestorForm.getAttributes().put("updownselectIds", m);
         }
         else {
             if (LOG.isWarnEnabled()) {

--- a/core/src/test/java/org/apache/struts2/components/FormButtonTest.java
+++ b/core/src/test/java/org/apache/struts2/components/FormButtonTest.java
@@ -38,14 +38,14 @@ public class FormButtonTest extends StrutsInternalTestCase {
         ValueStack stack = ActionContext.getContext().getValueStack();
 
         Form form = new Form(stack, req, res);
-        form.getParameters().put("id", "formId");
+        form.getAttributes().put("id", "formId");
 
         Submit submit = new Submit(stack, req, res);
         submit.setId("submitId");
 
         submit.populateComponentHtmlId(form);
 
-        assertEquals("submitId", submit.getParameters().get("id"));
+        assertEquals("submitId", submit.getAttributes().get("id"));
     }
 
     public void testPopulateComponentHtmlId2() {
@@ -54,14 +54,14 @@ public class FormButtonTest extends StrutsInternalTestCase {
         ValueStack stack = ActionContext.getContext().getValueStack();
 
         Form form = new Form(stack, req, res);
-        form.getParameters().put("id", "formId");
+        form.getAttributes().put("id", "formId");
 
         Submit submit = new Submit(stack, req, res);
         submit.setName("submitName");
 
         submit.populateComponentHtmlId(form);
 
-        assertEquals("formId_submitName", submit.getParameters().get("id"));
+        assertEquals("formId_submitName", submit.getAttributes().get("id"));
     }
 
     public void testPopulateComponentHtmlId3() {
@@ -70,7 +70,7 @@ public class FormButtonTest extends StrutsInternalTestCase {
         ValueStack stack = ActionContext.getContext().getValueStack();
 
         Form form = new Form(stack, req, res);
-        form.getParameters().put("id", "formId");
+        form.getAttributes().put("id", "formId");
 
         Submit submit = new Submit(stack, req, res);
         submit.setAction("submitAction");
@@ -78,7 +78,7 @@ public class FormButtonTest extends StrutsInternalTestCase {
 
         submit.populateComponentHtmlId(form);
 
-        assertEquals("formId_submitAction_submitMethod", submit.getParameters().get("id"));
+        assertEquals("formId_submitAction_submitMethod", submit.getAttributes().get("id"));
     }
 
     public void testPopulateComponentHtmlId4() {
@@ -91,7 +91,7 @@ public class FormButtonTest extends StrutsInternalTestCase {
 
         submit.populateComponentHtmlId(null);
 
-        assertEquals("submitId", submit.getParameters().get("id"));
+        assertEquals("submitId", submit.getAttributes().get("id"));
     }
 
     public void testPopulateComponentHtmlId5() {
@@ -104,7 +104,7 @@ public class FormButtonTest extends StrutsInternalTestCase {
 
         submit.populateComponentHtmlId(null);
 
-        assertEquals("submitName", submit.getParameters().get("id"));
+        assertEquals("submitName", submit.getAttributes().get("id"));
     }
 
     public void testPopulateComponentHtmlId6() {
@@ -118,7 +118,7 @@ public class FormButtonTest extends StrutsInternalTestCase {
 
         submit.populateComponentHtmlId(null);
 
-        assertEquals("submitAction_submitMethod", submit.getParameters().get("id"));
+        assertEquals("submitAction_submitMethod", submit.getAttributes().get("id"));
     }
 
     public void testPopulateComponentHtmlId7() {
@@ -134,7 +134,7 @@ public class FormButtonTest extends StrutsInternalTestCase {
 
         submit.populateComponentHtmlId(null);
 
-        assertEquals("secondAction", submit.getParameters().get("id"));
+        assertEquals("secondAction", submit.getAttributes().get("id"));
     }
 
     public void testPopulateComponentHtmlId8() {
@@ -152,6 +152,6 @@ public class FormButtonTest extends StrutsInternalTestCase {
 
         submit.populateComponentHtmlId(null);
 
-        assertEquals("boo_foo", submit.getParameters().get("id"));
+        assertEquals("boo_foo", submit.getAttributes().get("id"));
     }
 }

--- a/core/src/test/java/org/apache/struts2/components/FormTest.java
+++ b/core/src/test/java/org/apache/struts2/components/FormTest.java
@@ -60,7 +60,7 @@ public class FormTest extends AbstractUITagTest {
     		int expectedFooValidators, int expectedStatusValidators, int expectedResultValidators) {
 		Form form = new Form(stack, request, response);
         container.inject(form);
-        form.getParameters().put("actionClass", TestAction.class);
+        form.getAttributes().put("actionClass", TestAction.class);
 
         form.setAction("actionName" + (methodName != null ? "!" + methodName : ""));
         validationInterceptor.setValidateAnnotatedMethodOnly(validateAnnotatedMethodOnly);
@@ -101,7 +101,7 @@ public class FormTest extends AbstractUITagTest {
         EasyMock.expect(invocation.invoke()).andReturn(Action.SUCCESS).anyTimes();
         EasyMock.expect(proxy.getMethod()).andReturn("execute").anyTimes();
         EasyMock.expect(proxy.getConfig()).andReturn(config).anyTimes();
-        
+
         EasyMock.replay(invocation);
         EasyMock.replay(proxy);
 
@@ -109,7 +109,7 @@ public class FormTest extends AbstractUITagTest {
         defaultNamespace.put("actionName", config);
 
         ((DefaultActionMapper) container.getInstance(ActionMapper.class)).setAllowDynamicMethodCalls("true");
-        
+
         ActionContext.getContext().withActionInvocation(invocation);
     }
 }

--- a/core/src/test/java/org/apache/struts2/components/UIBeanTest.java
+++ b/core/src/test/java/org/apache/struts2/components/UIBeanTest.java
@@ -44,14 +44,14 @@ public class UIBeanTest extends StrutsInternalTestCase {
         MockHttpServletResponse res = new MockHttpServletResponse();
 
         Form form = new Form(stack, req, res);
-        form.getParameters().put("id", "formId");
+        form.getAttributes().put("id", "formId");
 
         TextField txtFld = new TextField(stack, req, res);
         txtFld.setId("txtFldId");
 
         txtFld.populateComponentHtmlId(form);
 
-        assertEquals("txtFldId", txtFld.getParameters().get("id"));
+        assertEquals("txtFldId", txtFld.getAttributes().get("id"));
     }
 
     public void testPopulateComponentHtmlIdWithOgnl() {
@@ -60,14 +60,14 @@ public class UIBeanTest extends StrutsInternalTestCase {
         MockHttpServletResponse res = new MockHttpServletResponse();
 
         Form form = new Form(stack, req, res);
-        form.getParameters().put("id", "formId");
+        form.getAttributes().put("id", "formId");
 
         TextField txtFld = new TextField(stack, req, res);
         txtFld.setName("txtFldName%{'1'}");
 
         txtFld.populateComponentHtmlId(form);
 
-        assertEquals("formId_txtFldName1", txtFld.getParameters().get("id"));
+        assertEquals("formId_txtFldName1", txtFld.getAttributes().get("id"));
     }
 
     public void testPopulateComponentHtmlId2() {
@@ -76,14 +76,14 @@ public class UIBeanTest extends StrutsInternalTestCase {
         MockHttpServletResponse res = new MockHttpServletResponse();
 
         Form form = new Form(stack, req, res);
-        form.getParameters().put("id", "formId");
+        form.getAttributes().put("id", "formId");
 
         TextField txtFld = new TextField(stack, req, res);
         txtFld.setName("txtFldName");
 
         txtFld.populateComponentHtmlId(form);
 
-        assertEquals("formId_txtFldName", txtFld.getParameters().get("id"));
+        assertEquals("formId_txtFldName", txtFld.getAttributes().get("id"));
     }
 
     public void testPopulateComponentHtmlWithoutNameAndId() {
@@ -92,13 +92,13 @@ public class UIBeanTest extends StrutsInternalTestCase {
         MockHttpServletResponse res = new MockHttpServletResponse();
 
         Form form = new Form(stack, req, res);
-        form.getParameters().put("id", "formId");
+        form.getAttributes().put("id", "formId");
 
         TextField txtFld = new TextField(stack, req, res);
 
         txtFld.populateComponentHtmlId(form);
 
-        assertNull(txtFld.getParameters().get("id"));
+        assertNull(txtFld.getAttributes().get("id"));
     }
 
     public void testEscape() {
@@ -124,12 +124,12 @@ public class UIBeanTest extends StrutsInternalTestCase {
         MockHttpServletResponse res = new MockHttpServletResponse();
 
         Form form = new Form(stack, req, res);
-        form.getParameters().put("id", "formId");
+        form.getAttributes().put("id", "formId");
 
         TextField txtFld = new TextField(stack, req, res);
         txtFld.setName("foo/bar");
         txtFld.populateComponentHtmlId(form);
-        assertEquals("formId_foo_bar", txtFld.getParameters().get("id"));
+        assertEquals("formId_foo_bar", txtFld.getAttributes().get("id"));
     }
 
     public void testGetThemeFromForm() {
@@ -232,7 +232,7 @@ public class UIBeanTest extends StrutsInternalTestCase {
         txtFld.setAccesskey(accesskeyValue);
         txtFld.evaluateParams();
 
-        assertEquals(accesskeyValue, txtFld.getParameters().get("accesskey"));
+        assertEquals(accesskeyValue, txtFld.getAttributes().get("accesskey"));
     }
 
     public void testValueParameterEvaluation() {
@@ -246,7 +246,7 @@ public class UIBeanTest extends StrutsInternalTestCase {
         txtFld.addParameter("value", value);
         txtFld.evaluateParams();
 
-        assertEquals(value, txtFld.getParameters().get("nameValue"));
+        assertEquals(value, txtFld.getAttributes().get("nameValue"));
     }
 
     public void testValueParameterRecursion() {
@@ -270,8 +270,8 @@ public class UIBeanTest extends StrutsInternalTestCase {
         txtFld.setName("%{myValue}");
         txtFld.evaluateParams();
 
-        assertEquals("%{myBad}", txtFld.getParameters().get("nameValue"));
-        assertEquals("%{myBad}", txtFld.getParameters().get("name"));
+        assertEquals("%{myBad}", txtFld.getAttributes().get("nameValue"));
+        assertEquals("%{myBad}", txtFld.getAttributes().get("name"));
     }
 
     public void testValueNameParameterNotAccepted() {
@@ -294,13 +294,13 @@ public class UIBeanTest extends StrutsInternalTestCase {
         container.inject(txtFld);
         txtFld.setName("%{myValueName}");
         txtFld.evaluateParams();
-        assertEquals("getMyValue()", txtFld.getParameters().get("name"));
-        assertEquals("getMyValue()", txtFld.getParameters().get("nameValue"));
+        assertEquals("getMyValue()", txtFld.getAttributes().get("name"));
+        assertEquals("getMyValue()", txtFld.getAttributes().get("nameValue"));
 
         txtFld.setNotExcludedAcceptedPatterns(NO_EXCLUSION_ACCEPT_ALL_PATTERNS_CHECKER);
         txtFld.evaluateParams();
-        assertEquals("getMyValue()", txtFld.getParameters().get("name"));
-        assertEquals("value", txtFld.getParameters().get("nameValue"));
+        assertEquals("getMyValue()", txtFld.getAttributes().get("name"));
+        assertEquals("value", txtFld.getAttributes().get("nameValue"));
     }
 
     public void testValueNameParameterGetterAccepted() {
@@ -319,8 +319,8 @@ public class UIBeanTest extends StrutsInternalTestCase {
         container.inject(txtFld);
         txtFld.setName("getMyValue()");
         txtFld.evaluateParams();
-        assertEquals("getMyValue()", txtFld.getParameters().get("name"));
-        assertEquals("value", txtFld.getParameters().get("nameValue"));
+        assertEquals("getMyValue()", txtFld.getAttributes().get("name"));
+        assertEquals("value", txtFld.getAttributes().get("nameValue"));
     }
 
     public void testSetClass() {
@@ -334,7 +334,7 @@ public class UIBeanTest extends StrutsInternalTestCase {
         txtFld.setCssClass(cssClass);
         txtFld.evaluateParams();
 
-        assertEquals(cssClass, txtFld.getParameters().get("cssClass"));
+        assertEquals(cssClass, txtFld.getAttributes().get("cssClass"));
     }
 
     public void testSetStyle() {
@@ -348,7 +348,7 @@ public class UIBeanTest extends StrutsInternalTestCase {
         txtFld.setStyle(cssStyle);
         txtFld.evaluateParams();
 
-        assertEquals(cssStyle, txtFld.getParameters().get("cssStyle"));
+        assertEquals(cssStyle, txtFld.getAttributes().get("cssStyle"));
     }
 
     public void testNonce() {
@@ -367,7 +367,7 @@ public class UIBeanTest extends StrutsInternalTestCase {
         DoubleSelect dblSelect = new DoubleSelect(stack, req, res);
         dblSelect.evaluateParams();
 
-        assertEquals(nonceVal, dblSelect.getParameters().get("nonce"));
+        assertEquals(nonceVal, dblSelect.getAttributes().get("nonce"));
     }
 
     public void testNonceOfInvalidSession() {
@@ -387,7 +387,7 @@ public class UIBeanTest extends StrutsInternalTestCase {
         DoubleSelect dblSelect = new DoubleSelect(stack, req, res);
         dblSelect.evaluateParams();
 
-        assertNull(dblSelect.getParameters().get("nonce"));
+        assertNull(dblSelect.getAttributes().get("nonce"));
     }
 
     public void testSetNullUiStaticContentPath() {

--- a/core/src/test/java/org/apache/struts2/views/jsp/URLTagTest.java
+++ b/core/src/test/java/org/apache/struts2/views/jsp/URLTagTest.java
@@ -128,7 +128,7 @@ public class URLTagTest extends AbstractUITagTest {
         param3.doEndTag();
 
         URL url = (URL) tag.getComponent();
-        Map parameters = url.getParameters();
+        Map parameters = url.getAttributes();
 
 
         assertNotNull(parameters);
@@ -247,7 +247,7 @@ public class URLTagTest extends AbstractUITagTest {
         param3.doEndTag();
 
         URL url = (URL) tag.getComponent();
-        Map parameters = url.getParameters();
+        Map parameters = url.getAttributes();
 
 
         assertNotNull(parameters);
@@ -393,7 +393,7 @@ public class URLTagTest extends AbstractUITagTest {
         param3.doEndTag();
 
         URL url = (URL) tag.getComponent();
-        Map parameters = url.getParameters();
+        Map parameters = url.getAttributes();
 
         assertEquals(parameters.size(), 5);
         assertEquals(parameters.get("id1"), "paramId1");
@@ -476,7 +476,7 @@ public class URLTagTest extends AbstractUITagTest {
         param3.doEndTag();
 
         URL url = (URL) tag.getComponent();
-        Map parameters = url.getParameters();
+        Map parameters = url.getAttributes();
 
         assertEquals(parameters.size(), 5);
         assertEquals(parameters.get("id1"), "paramId1");
@@ -526,7 +526,7 @@ public class URLTagTest extends AbstractUITagTest {
         tag.doStartTag();
 
         URL url = (URL) tag.getComponent();
-        Map parameters = url.getParameters();
+        Map parameters = url.getAttributes();
 
         tag.doEndTag();
 
@@ -560,7 +560,7 @@ public class URLTagTest extends AbstractUITagTest {
         setComponentTagClearTagState(tag, true);  // Ensure component tag state clearing is set true (to match tag).
 
         URL url = (URL) tag.getComponent();
-        Map parameters = url.getParameters();
+        Map parameters = url.getAttributes();
 
         tag.doEndTag();
 

--- a/core/src/test/java/org/apache/struts2/views/jsp/ui/FormTagTest.java
+++ b/core/src/test/java/org/apache/struts2/views/jsp/ui/FormTagTest.java
@@ -798,7 +798,7 @@ public class FormTagTest extends AbstractUITagTest {
         t.setList("{}");
 
         tag.doStartTag();
-        tag.getComponent().getParameters().put("actionClass", IntValidationAction.class);
+        tag.getComponent().getAttributes().put("actionClass", IntValidationAction.class);
         t.doStartTag();
         t.doEndTag();
         tag.doEndTag();
@@ -847,7 +847,7 @@ public class FormTagTest extends AbstractUITagTest {
 
         tag.doStartTag();
         setComponentTagClearTagState(tag, true);  // Ensure component tag state clearing is set true (to match tag).
-        tag.getComponent().getParameters().put("actionClass", IntValidationAction.class);
+        tag.getComponent().getAttributes().put("actionClass", IntValidationAction.class);
         t.doStartTag();
         setComponentTagClearTagState(t, true);  // Ensure component tag state clearing is set true (to match tag).
         t.doEndTag();
@@ -896,7 +896,7 @@ public class FormTagTest extends AbstractUITagTest {
         t.setList("{}");
 
         tag.doStartTag();
-        tag.getComponent().getParameters().put("actionClass", DoubleValidationAction.class);
+        tag.getComponent().getAttributes().put("actionClass", DoubleValidationAction.class);
         t.doStartTag();
         t.doEndTag();
         tag.doEndTag();
@@ -945,7 +945,7 @@ public class FormTagTest extends AbstractUITagTest {
 
         tag.doStartTag();
         setComponentTagClearTagState(tag, true);  // Ensure component tag state clearing is set true (to match tag).
-        tag.getComponent().getParameters().put("actionClass", DoubleValidationAction.class);
+        tag.getComponent().getAttributes().put("actionClass", DoubleValidationAction.class);
         t.doStartTag();
         setComponentTagClearTagState(t, true);  // Ensure component tag state clearing is set true (to match tag).
         t.doEndTag();

--- a/plugins/javatemplates/src/main/java/org/apache/struts2/views/java/simple/SelectHandler.java
+++ b/plugins/javatemplates/src/main/java/org/apache/struts2/views/java/simple/SelectHandler.java
@@ -61,7 +61,7 @@ public class SelectHandler extends AbstractTagHandler implements TagGenerator {
             boolean selected = ContainUtil.contains(value, params.get("headerKey"));
             writeOption(headerKey, headerValue, selected);
         }
-	
+
 	//emptyoption
         Object emptyOption = params.get("emptyOption");
         if (emptyOption != null && emptyOption.toString().equals(Boolean.toString(true))) {
@@ -81,10 +81,10 @@ public class SelectHandler extends AbstractTagHandler implements TagGenerator {
 
                 //key
                 Object itemKey = findValue(listKey != null ? listKey : "top");
-                String itemKeyStr = StringUtils.defaultString(itemKey == null ? null : itemKey.toString()); 
+                String itemKeyStr = StringUtils.defaultString(itemKey == null ? null : itemKey.toString());
                 //value
                 Object itemValue = findValue(listValue != null ? listValue : "top");
-                String itemValueStr = StringUtils.defaultString(itemValue == null ? null : itemValue.toString()); 
+                String itemValueStr = StringUtils.defaultString(itemValue == null ? null : itemValue.toString());
 
                 boolean selected = ContainUtil.contains(value, itemKey);
                 writeOption(itemKeyStr, itemValueStr, selected);
@@ -115,7 +115,7 @@ public class SelectHandler extends AbstractTagHandler implements TagGenerator {
     }
 
     private void writeOptionGroup(ListUIBean listUIBean, Object value) throws IOException {
-        Map params = listUIBean.getParameters();
+        Map params = listUIBean.getAttributes();
         Attributes attrs = new Attributes();
         attrs.addIfExists("label", params.get("label"))
                 .addIfTrue("disabled", params.get("disabled"));

--- a/plugins/javatemplates/src/test/java/org/apache/struts2/views/java/simple/AbstractCommonAttributesTest.java
+++ b/plugins/javatemplates/src/test/java/org/apache/struts2/views/java/simple/AbstractCommonAttributesTest.java
@@ -30,7 +30,7 @@ public abstract class AbstractCommonAttributesTest extends AbstractTest {
         applyScriptingAttrs(tag);
 
         tag.evaluateParams();
-        map.putAll(tag.getParameters());
+        map.putAll(tag.getAttributes());
         theme.renderTag(getTagName(), context);
         String output = writer.getBuffer().toString();
 
@@ -44,7 +44,7 @@ public abstract class AbstractCommonAttributesTest extends AbstractTest {
         applyCommonAttrs(tag);
 
         tag.evaluateParams();
-        map.putAll(tag.getParameters());
+        map.putAll(tag.getAttributes());
         theme.renderTag(getTagName(), context);
         String output = writer.getBuffer().toString();
 
@@ -57,7 +57,7 @@ public abstract class AbstractCommonAttributesTest extends AbstractTest {
         applyDynamicAttrs(tag);
 
         tag.evaluateParams();
-        map.putAll(tag.getParameters());
+        map.putAll(tag.getAttributes());
         theme.renderTag(getTagName(), context);
         String output = writer.getBuffer().toString();
 

--- a/plugins/javatemplates/src/test/java/org/apache/struts2/views/java/simple/ActionErrorTest.java
+++ b/plugins/javatemplates/src/test/java/org/apache/struts2/views/java/simple/ActionErrorTest.java
@@ -36,7 +36,7 @@ public class ActionErrorTest extends AbstractTest {
         tag.setCssStyle("style");
 
         tag.evaluateParams();
-        map.putAll(tag.getParameters());
+        map.putAll(tag.getAttributes());
         theme.renderTag(getTagName(), context);
         String output = writer.getBuffer().toString();
         String expected = s("<ul style='style' class='class'><li><span>this clas is bad</span></li><li><span>baaaaad</span></li></ul>");
@@ -47,7 +47,7 @@ public class ActionErrorTest extends AbstractTest {
         tag.setCssStyle("style");
 
         tag.evaluateParams();
-        map.putAll(tag.getParameters());
+        map.putAll(tag.getAttributes());
         theme.renderTag(getTagName(), context);
         String output = writer.getBuffer().toString();
         String expected = s("<ul style='style' class='errorMessage'><li><span>this clas is bad</span></li><li><span>baaaaad</span></li></ul>");
@@ -57,7 +57,7 @@ public class ActionErrorTest extends AbstractTest {
     public void testRenderActionErrorNoErrors() {
         this.errors.clear();
         tag.evaluateParams();
-        map.putAll(tag.getParameters());
+        map.putAll(tag.getAttributes());
         theme.renderTag(getTagName(), context);
         String output = writer.getBuffer().toString();
         assertEquals("", output);

--- a/plugins/javatemplates/src/test/java/org/apache/struts2/views/java/simple/ActionMessageTest.java
+++ b/plugins/javatemplates/src/test/java/org/apache/struts2/views/java/simple/ActionMessageTest.java
@@ -36,7 +36,7 @@ public class ActionMessageTest extends AbstractTest {
         tag.setCssStyle("style");
 
         tag.evaluateParams();
-        map.putAll(tag.getParameters());
+        map.putAll(tag.getAttributes());
         theme.renderTag(getTagName(), context);
         String output = writer.getBuffer().toString();
         String expected = s("<ul style='style' class='class'><li><span>this clas is bad</span></li><li><span>baaaaad</span></li></ul>");
@@ -47,7 +47,7 @@ public class ActionMessageTest extends AbstractTest {
         tag.setCssStyle("style");
 
         tag.evaluateParams();
-        map.putAll(tag.getParameters());
+        map.putAll(tag.getAttributes());
         theme.renderTag(getTagName(), context);
         String output = writer.getBuffer().toString();
         String expected = s("<ul style='style' class='actionMessage'><li><span>this clas is bad</span></li><li><span>baaaaad</span></li></ul>");
@@ -57,7 +57,7 @@ public class ActionMessageTest extends AbstractTest {
     public void testRenderActionErrorNoErrors() {
         this.errors.clear();
         tag.evaluateParams();
-        map.putAll(tag.getParameters());
+        map.putAll(tag.getAttributes());
         theme.renderTag(getTagName(), context);
         String output = writer.getBuffer().toString();
         assertEquals("", output);

--- a/plugins/javatemplates/src/test/java/org/apache/struts2/views/java/simple/AnchorTest.java
+++ b/plugins/javatemplates/src/test/java/org/apache/struts2/views/java/simple/AnchorTest.java
@@ -39,7 +39,7 @@ public class AnchorTest extends AbstractTest {
         tag.setHref("http://sometest.com?ab=10");
 
         tag.evaluateParams();
-        map.putAll(tag.getParameters());
+        map.putAll(tag.getAttributes());
         theme.renderTag(getTagName(), context);
         theme.renderTag(getTagName() + "-close", context);
         String output = writer.getBuffer().toString();
@@ -59,7 +59,7 @@ public class AnchorTest extends AbstractTest {
         tag.setHref("http://sometest.com?ab=10");
 
         tag.evaluateParams();
-        map.putAll(tag.getParameters());
+        map.putAll(tag.getAttributes());
         theme.renderTag(getTagName(), context);
         theme.renderTag(getTagName() + "-close", context);
         String output = writer.getBuffer().toString();
@@ -75,7 +75,7 @@ public class AnchorTest extends AbstractTest {
         tag.setEscapeHtmlBody(true);
         tag.evaluateParams();
 
-        map.putAll(tag.getParameters());
+        map.putAll(tag.getAttributes());
         context.getParameters().put("body", s("<i class='i-image'/>"));
 
         theme.renderTag(getTagName(), context);
@@ -93,7 +93,7 @@ public class AnchorTest extends AbstractTest {
         //tag.setEscapeHtmlBody(true);
         tag.evaluateParams();
 
-        map.putAll(tag.getParameters());
+        map.putAll(tag.getAttributes());
         context.getParameters().put("body", s("<i class='i-image'/>"));
 
         theme.renderTag(getTagName(), context);

--- a/plugins/javatemplates/src/test/java/org/apache/struts2/views/java/simple/CheckboxTest.java
+++ b/plugins/javatemplates/src/test/java/org/apache/struts2/views/java/simple/CheckboxTest.java
@@ -38,7 +38,7 @@ public class CheckboxTest extends AbstractCommonAttributesTest {
         tag.setFieldValue("xyz");
 
         tag.evaluateParams();
-        map.putAll(tag.getParameters());
+        map.putAll(tag.getAttributes());
         theme.renderTag(getTagName(), context);
         String output = writer.getBuffer().toString();
         String expected = s("<input type='checkbox' name='name_' value='xyz' tabindex='1' id='id_' class='class' style='style' title='title'></input>");
@@ -57,7 +57,7 @@ public class CheckboxTest extends AbstractCommonAttributesTest {
         tag.setSubmitUnchecked("true");
 
         tag.evaluateParams();
-        map.putAll(tag.getParameters());
+        map.putAll(tag.getAttributes());
         theme.renderTag(getTagName(), context);
         String output = writer.getBuffer().toString();
         String expected = s("<input type='checkbox' name='name_' value='xyz' disabled='disabled' tabindex='1' id='id_' class='class' style='style' title='title'></input><input type='hidden' id='__checkbox_id_' name='__checkbox_name_' value='__checkbox_xyz' disabled='disabled'></input>");
@@ -69,7 +69,7 @@ public class CheckboxTest extends AbstractCommonAttributesTest {
         tag.setValue("%{someValue}");
 
         tag.evaluateParams();
-        map.putAll(tag.getParameters());
+        map.putAll(tag.getAttributes());
         theme.renderTag(getTagName(), context);
         String output = writer.getBuffer().toString();
         String expected = s("<input type='checkbox' name='name_' value='true' checked='checked' id='name_'></input>");

--- a/plugins/javatemplates/src/test/java/org/apache/struts2/views/java/simple/DateTextFieldTest.java
+++ b/plugins/javatemplates/src/test/java/org/apache/struts2/views/java/simple/DateTextFieldTest.java
@@ -33,7 +33,7 @@ public class DateTextFieldTest extends AbstractCommonAttributesTest {
         tag.setFormat("yyyy-MM-dd");
 
         tag.evaluateParams();
-        map.putAll(tag.getParameters());
+        map.putAll(tag.getAttributes());
         theme.renderTag(getTagName(), context);
         String output = writer.getBuffer().toString();
         String expected = s("<div id='id'>" +
@@ -42,10 +42,10 @@ public class DateTextFieldTest extends AbstractCommonAttributesTest {
         		"-<input type='text' class='date_day' size='2' maxlength='2' id='__day_id' name='__day_name'></input></div>");
         assertEquals(expected, output);
     }
-    
+
     @Override
     public void testRenderTextFieldScriptingAttrs() throws Exception { }
-    
+
     @Override
     public void testRenderTextFieldCommonAttrs() throws Exception { }
 

--- a/plugins/javatemplates/src/test/java/org/apache/struts2/views/java/simple/FieldErrorTest.java
+++ b/plugins/javatemplates/src/test/java/org/apache/struts2/views/java/simple/FieldErrorTest.java
@@ -35,7 +35,7 @@ public class FieldErrorTest extends AbstractTest {
         tag.setCssStyle("style");
 
         tag.evaluateParams();
-        map.putAll(tag.getParameters());
+        map.putAll(tag.getAttributes());
         theme.renderTag(getTagName(), context);
         String output = writer.getBuffer().toString();
         String expected = s("<ul style='style' class='class'><li><span>not good</span></li><li><span>bad</span></li><li><span>bad to the bone</span></li></ul>");
@@ -46,7 +46,7 @@ public class FieldErrorTest extends AbstractTest {
         tag.setCssStyle("style");
 
         tag.evaluateParams();
-        map.putAll(tag.getParameters());
+        map.putAll(tag.getAttributes());
         theme.renderTag(getTagName(), context);
         String output = writer.getBuffer().toString();
         String expected = s("<ul style='style' class='errorMessage'><li><span>not good</span></li><li><span>bad</span></li><li><span>bad to the bone</span></li></ul>");
@@ -57,7 +57,7 @@ public class FieldErrorTest extends AbstractTest {
         this.fieldNames.clear();
 
         tag.evaluateParams();
-        map.putAll(tag.getParameters());
+        map.putAll(tag.getAttributes());
         theme.renderTag(getTagName(), context);
         String output = writer.getBuffer().toString();
         String expected = s("<ul class='errorMessage'><li><span>not good</span></li><li><span>bad</span></li><li><span>bad to the bone</span></li></ul>");
@@ -67,7 +67,7 @@ public class FieldErrorTest extends AbstractTest {
     public void testRenderFieldErrorWithoutOneFieldName() {
         tag.setFieldName("field1");
         tag.evaluateParams();
-        map.putAll(tag.getParameters());
+        map.putAll(tag.getAttributes());
         theme.renderTag(getTagName(), context);
         String output = writer.getBuffer().toString();
         String expected = s("<ul class='errorMessage'><li><span>not good</span></li><li><span>bad</span></li></ul>");
@@ -79,7 +79,7 @@ public class FieldErrorTest extends AbstractTest {
         this.fieldNames.clear();
 
         tag.evaluateParams();
-        map.putAll(tag.getParameters());
+        map.putAll(tag.getAttributes());
         theme.renderTag(getTagName(), context);
         String output = writer.getBuffer().toString();
         assertEquals("", output);

--- a/plugins/javatemplates/src/test/java/org/apache/struts2/views/java/simple/FileTest.java
+++ b/plugins/javatemplates/src/test/java/org/apache/struts2/views/java/simple/FileTest.java
@@ -39,7 +39,7 @@ public class FileTest extends AbstractCommonAttributesTest {
 
 
         tag.evaluateParams();
-        map.putAll(tag.getParameters());
+        map.putAll(tag.getAttributes());
         theme.renderTag(getTagName(), context);
         String output = writer.getBuffer().toString();
         String expected = s("<input name='name' type='file' size='10' disabled='disabled' accept='accept_' tabindex='1' id='id1' class='class1' style='style1' title='title'></input>");

--- a/plugins/javatemplates/src/test/java/org/apache/struts2/views/java/simple/FormTest.java
+++ b/plugins/javatemplates/src/test/java/org/apache/struts2/views/java/simple/FormTest.java
@@ -45,7 +45,7 @@ public class FormTest extends AbstractCommonAttributesTest {
         tag.setMethod("post");
 
         tag.evaluateParams();
-        map.putAll(tag.getParameters());
+        map.putAll(tag.getAttributes());
         theme.renderTag(getTagName(), context);
         theme.renderTag(getTagName() + "-close", context);
         String output = writer.getBuffer().toString();
@@ -55,7 +55,7 @@ public class FormTest extends AbstractCommonAttributesTest {
 
     public void testDefaultMethod() {
         tag.evaluateParams();
-        map.putAll(tag.getParameters());
+        map.putAll(tag.getAttributes());
         theme.renderTag(getTagName(), context);
         theme.renderTag(getTagName() + "-close", context);
         String output = writer.getBuffer().toString();

--- a/plugins/javatemplates/src/test/java/org/apache/struts2/views/java/simple/HeadTest.java
+++ b/plugins/javatemplates/src/test/java/org/apache/struts2/views/java/simple/HeadTest.java
@@ -28,7 +28,7 @@ public class HeadTest extends AbstractTest {
 
     public void testRenderTextField() {
         tag.evaluateParams();
-        map.putAll(tag.getParameters());
+        map.putAll(tag.getAttributes());
         theme.renderTag(getTagName(), context);
         String output = writer.getBuffer().toString();
         String expected = s("<script type='text/javascript' base='/some/path' src='/some/path/static/utils.js' nonce='r4andom'></script>");

--- a/plugins/javatemplates/src/test/java/org/apache/struts2/views/java/simple/HiddenTest.java
+++ b/plugins/javatemplates/src/test/java/org/apache/struts2/views/java/simple/HiddenTest.java
@@ -38,7 +38,7 @@ public class HiddenTest extends AbstractTest {
 
 
         tag.evaluateParams();
-        map.putAll(tag.getParameters());
+        map.putAll(tag.getAttributes());
         theme.renderTag(getTagName(), context);
         String output = writer.getBuffer().toString();
         String expected = s("<input name='name' type='hidden' value='val1' disabled='disabled' id='id1' class='class1' style='style1'></input>");

--- a/plugins/javatemplates/src/test/java/org/apache/struts2/views/java/simple/LabelTest.java
+++ b/plugins/javatemplates/src/test/java/org/apache/struts2/views/java/simple/LabelTest.java
@@ -37,7 +37,7 @@ public class LabelTest extends AbstractCommonAttributesTest {
 
 
         tag.evaluateParams();
-        map.putAll(tag.getParameters());
+        map.putAll(tag.getAttributes());
         theme.renderTag(getTagName(), context);
         String output = writer.getBuffer().toString();
         String expected = s("<label name='name' for='for_' id='id1' class='class1' style='style1' title='title'>val1</label>");

--- a/plugins/javatemplates/src/test/java/org/apache/struts2/views/java/simple/LinkTest.java
+++ b/plugins/javatemplates/src/test/java/org/apache/struts2/views/java/simple/LinkTest.java
@@ -39,7 +39,7 @@ public class LinkTest extends AbstractTest {
         tag.setTitle("test");
 
         tag.evaluateParams();
-        map.putAll(tag.getParameters());
+        map.putAll(tag.getAttributes());
         theme.renderTag(getTagName(), context);
         String output = writer.getBuffer().toString();
 
@@ -71,7 +71,7 @@ public class LinkTest extends AbstractTest {
         tag.setTitle("test");
 
         tag.evaluateParams();
-        map.putAll(tag.getParameters());
+        map.putAll(tag.getAttributes());
         theme.renderTag(getTagName(), context);
         String output = writer.getBuffer().toString();
 

--- a/plugins/javatemplates/src/test/java/org/apache/struts2/views/java/simple/PasswordTest.java
+++ b/plugins/javatemplates/src/test/java/org/apache/struts2/views/java/simple/PasswordTest.java
@@ -43,7 +43,7 @@ public class PasswordTest extends AbstractCommonAttributesTest {
 
 
         tag.evaluateParams();
-        map.putAll(tag.getParameters());
+        map.putAll(tag.getAttributes());
         theme.renderTag(getTagName(), context);
         String output = writer.getBuffer().toString();
         String expected = s("<input name='name' type='password' size='10' disabled='disabled' tabindex='1' id='id1' class='class1' style='style1' title='title'></input>");
@@ -66,7 +66,7 @@ public class PasswordTest extends AbstractCommonAttributesTest {
         tag.setShowPassword("%{'true'}");
 
         tag.evaluateParams();
-        map.putAll(tag.getParameters());
+        map.putAll(tag.getAttributes());
         theme.renderTag(getTagName(), context);
         String output = writer.getBuffer().toString();
         String expected = s("<input value='val1' name='name' type='password' size='10' disabled='disabled' tabindex='1' id='id1' class='class1' style='style1' title='title'></input>");

--- a/plugins/javatemplates/src/test/java/org/apache/struts2/views/java/simple/ResetTest.java
+++ b/plugins/javatemplates/src/test/java/org/apache/struts2/views/java/simple/ResetTest.java
@@ -39,7 +39,7 @@ public class ResetTest extends AbstractCommonAttributesTest {
 
 
         tag.evaluateParams();
-        map.putAll(tag.getParameters());
+        map.putAll(tag.getAttributes());
         theme.renderTag(getTagName(), context);
         String output = writer.getBuffer().toString();
         String expected = s("<input name='name' type='reset' value='val1' tabindex='1' id='id1' class='class1' style='style1'>some label</input>");
@@ -58,7 +58,7 @@ public class ResetTest extends AbstractCommonAttributesTest {
 
 
         tag.evaluateParams();
-        map.putAll(tag.getParameters());
+        map.putAll(tag.getAttributes());
         theme.renderTag(getTagName(), context);
         String output = writer.getBuffer().toString();
         String expected = s("<input name='name' type='reset' value='val1' tabindex='1' id='id1' class='class1' style='style1' title='title'></input>");

--- a/plugins/javatemplates/src/test/java/org/apache/struts2/views/java/simple/ScriptTest.java
+++ b/plugins/javatemplates/src/test/java/org/apache/struts2/views/java/simple/ScriptTest.java
@@ -40,7 +40,7 @@ public class ScriptTest extends AbstractTest {
         tag.setCrossorigin("test");
 
         tag.evaluateParams();
-        map.putAll(tag.getParameters());
+        map.putAll(tag.getAttributes());
         theme.renderTag(getTagName(), context);
         String output = writer.getBuffer().toString();
 

--- a/plugins/javatemplates/src/test/java/org/apache/struts2/views/java/simple/SelectTest.java
+++ b/plugins/javatemplates/src/test/java/org/apache/struts2/views/java/simple/SelectTest.java
@@ -42,7 +42,7 @@ public class SelectTest extends AbstractCommonAttributesTest {
         tag.setTitle("title");
 
         tag.evaluateParams();
-        map.putAll(tag.getParameters());
+        map.putAll(tag.getAttributes());
         theme.renderTag(getTagName(), context);
         String output = writer.getBuffer().toString();
         String expected = s("<select name='name_' size='10' disabled='disabled' tabindex='1' id='id_' class='class' style='style' title='title'></select>");
@@ -55,7 +55,7 @@ public class SelectTest extends AbstractCommonAttributesTest {
         tag.setHeaderValue("%{'val'}");
 
         tag.evaluateParams();
-        map.putAll(tag.getParameters());
+        map.putAll(tag.getAttributes());
         theme.renderTag(getTagName(), context);
         String output = writer.getBuffer().toString();
         String expected = s("<select name=''><option value='key0'>val</option></select>");
@@ -68,7 +68,7 @@ public class SelectTest extends AbstractCommonAttributesTest {
         tag.setListValue("stringField");
 
         tag.evaluateParams();
-        map.putAll(tag.getParameters());
+        map.putAll(tag.getAttributes());
         theme.renderTag(getTagName(), context);
         String output = writer.getBuffer().toString();
         String expected = s("<select name=''><option value='1'>val</option></select>");
@@ -79,7 +79,7 @@ public class SelectTest extends AbstractCommonAttributesTest {
         tag.setList("%{#{'key0' : 'val'}}");
 
         tag.evaluateParams();
-        map.putAll(tag.getParameters());
+        map.putAll(tag.getAttributes());
         theme.renderTag(getTagName(), context);
         String output = writer.getBuffer().toString();
         String expected = s("<select name=''><option value='key0'>val</option></select>");
@@ -93,7 +93,7 @@ public class SelectTest extends AbstractCommonAttributesTest {
         tag.setValue("%{'1'}");
 
         tag.evaluateParams();
-        map.putAll(tag.getParameters());
+        map.putAll(tag.getAttributes());
         theme.renderTag(getTagName(), context);
         String output = writer.getBuffer().toString();
         String expected = s("<select name='' value='1'><option value='1' selected='selected'>val</option></select>");

--- a/plugins/javatemplates/src/test/java/org/apache/struts2/views/java/simple/SubmitTest.java
+++ b/plugins/javatemplates/src/test/java/org/apache/struts2/views/java/simple/SubmitTest.java
@@ -39,12 +39,12 @@ public class SubmitTest extends AbstractCommonAttributesTest {
         tag.setType("button");
 
         tag.evaluateParams();
-        map.putAll(tag.getParameters());
+        map.putAll(tag.getAttributes());
         theme.renderTag(getTagName(), context);
 
         tag.addParameter("body", "<span>hey hey hey, here I go now</span>");
         map.clear();
-        map.putAll(tag.getParameters());
+        map.putAll(tag.getAttributes());
         theme.renderTag(getTagName() + "-close", context);
         String output = writer.getBuffer().toString();
         String expected = s("<button name='name' type='submit' value='val1' disabled='disabled' tabindex='1' id='id1' class='class1' style='style1'><span>hey hey hey, here I go now</span></button>");
@@ -65,7 +65,7 @@ public class SubmitTest extends AbstractCommonAttributesTest {
 
 
         tag.evaluateParams();
-        map.putAll(tag.getParameters());
+        map.putAll(tag.getAttributes());
         theme.renderTag(getTagName(), context);
         theme.renderTag(getTagName() + "-close", context);
         String output = writer.getBuffer().toString();
@@ -87,7 +87,7 @@ public class SubmitTest extends AbstractCommonAttributesTest {
 
 
         tag.evaluateParams();
-        map.putAll(tag.getParameters());
+        map.putAll(tag.getAttributes());
         theme.renderTag(getTagName(), context);
         theme.renderTag(getTagName() + "-close", context);
         String output = writer.getBuffer().toString();
@@ -108,7 +108,7 @@ public class SubmitTest extends AbstractCommonAttributesTest {
 
 
         tag.evaluateParams();
-        map.putAll(tag.getParameters());
+        map.putAll(tag.getAttributes());
         theme.renderTag(getTagName(), context);
         theme.renderTag(getTagName() + "-close", context);
         String output = writer.getBuffer().toString();
@@ -123,7 +123,7 @@ public class SubmitTest extends AbstractCommonAttributesTest {
 
 
         tag.evaluateParams();
-        map.putAll(tag.getParameters());
+        map.putAll(tag.getAttributes());
         theme.renderTag(getTagName(), context);
         theme.renderTag(getTagName() + "-close", context);
         String output = writer.getBuffer().toString();
@@ -138,12 +138,12 @@ public class SubmitTest extends AbstractCommonAttributesTest {
 
 
         tag.evaluateParams();
-        map.putAll(tag.getParameters());
+        map.putAll(tag.getAttributes());
         theme.renderTag(getTagName(), context);
         map.clear();
         tag.setType("image");
         tag.addParameter("body", "<span>hey hey hey, here I go now</span>");
-        map.putAll(tag.getParameters());
+        map.putAll(tag.getAttributes());
         theme.renderTag(getTagName() + "-close", context);
         String output = writer.getBuffer().toString();
         String expected = s("<input src='http://somesource/image.gif' type='image' alt='alt text'><span>hey hey hey, here I go now</span></input>");

--- a/plugins/javatemplates/src/test/java/org/apache/struts2/views/java/simple/TextAreaTest.java
+++ b/plugins/javatemplates/src/test/java/org/apache/struts2/views/java/simple/TextAreaTest.java
@@ -41,7 +41,7 @@ public class TextAreaTest extends AbstractCommonAttributesTest {
 
 
         tag.evaluateParams();
-        map.putAll(tag.getParameters());
+        map.putAll(tag.getAttributes());
         theme.renderTag(getTagName(), context);
         String output = writer.getBuffer().toString();
         String expected = s("<textarea name='name' cols='2' rows='1' disabled='disabled' tabindex='1' id='id1' class='class1' style='style1' title='title'>val1</textarea>");
@@ -60,7 +60,7 @@ public class TextAreaTest extends AbstractCommonAttributesTest {
 
 
         tag.evaluateParams();
-        map.putAll(tag.getParameters());
+        map.putAll(tag.getAttributes());
         theme.renderTag(getTagName(), context);
         String output = writer.getBuffer().toString();
         String expected = s("<textarea name='' cols='' rows='' disabled='disabled' tabindex='1' id='id1' class='class1' style='style1' title='title'>val1</textarea>");

--- a/plugins/javatemplates/src/test/java/org/apache/struts2/views/java/simple/TextFieldTest.java
+++ b/plugins/javatemplates/src/test/java/org/apache/struts2/views/java/simple/TextFieldTest.java
@@ -41,7 +41,7 @@ public class TextFieldTest extends AbstractCommonAttributesTest {
 
 
         tag.evaluateParams();
-        map.putAll(tag.getParameters());
+        map.putAll(tag.getAttributes());
         theme.renderTag(getTagName(), context);
         String output = writer.getBuffer().toString();
         String expected = s("<input type='text' name='name' size='10' maxlength='11' value='val1' disabled='disabled' tabindex='1' id='id1' class='class1' style='style1' title='title'></input>");

--- a/plugins/javatemplates/src/test/java/org/apache/struts2/views/java/simple/TokenTest.java
+++ b/plugins/javatemplates/src/test/java/org/apache/struts2/views/java/simple/TokenTest.java
@@ -35,7 +35,7 @@ public class TokenTest extends AbstractTest {
         tag.setValue("val1");
 
         tag.evaluateParams();
-        map.putAll(tag.getParameters());
+        map.putAll(tag.getAttributes());
         theme.renderTag(getTagName(), context);
         String output = writer.getBuffer().toString();
 

--- a/plugins/portlet/src/main/java/org/apache/struts2/components/PortletUrlRenderer.java
+++ b/plugins/portlet/src/main/java/org/apache/struts2/components/PortletUrlRenderer.java
@@ -180,7 +180,7 @@ public class PortletUrlRenderer implements UrlRenderer {
         }
         if (action != null) {
             String result = portletUrlHelper.buildUrl(action, namespace, null,
-                formComponent.getParameters(), type, formComponent.portletMode, formComponent.windowState);
+                formComponent.getAttributes(), type, formComponent.portletMode, formComponent.windowState);
             formComponent.addParameter("action", result);
 
 


### PR DESCRIPTION
WW-5476
--

Use `attributes` instead of `parameters` in tags