### PR TITLE
WW-5478 Deprecate DefaultResultFactory

### DIFF
--- a/core/src/main/java/com/opensymphony/xwork2/config/entities/ResultConfig.java
+++ b/core/src/main/java/com/opensymphony/xwork2/config/entities/ResultConfig.java
@@ -38,7 +38,7 @@ import java.util.Map;
  */
 public class ResultConfig extends Located implements Serializable {
 
-    protected Map<String,String> params;
+    protected Map<String, String> params;
     protected String className;
     protected String name;
 
@@ -63,7 +63,7 @@ public class ResultConfig extends Located implements Serializable {
         return name;
     }
 
-    public Map<String,String> getParams() {
+    public Map<String, String> getParams() {
         return params;
     }
 
@@ -140,7 +140,7 @@ public class ResultConfig extends Located implements Serializable {
             return this;
         }
 
-        public Builder addParams(Map<String,String> params) {
+        public Builder addParams(Map<String, String> params) {
             target.params.putAll(params);
             return this;
         }

--- a/core/src/main/java/com/opensymphony/xwork2/config/impl/DefaultConfiguration.java
+++ b/core/src/main/java/com/opensymphony/xwork2/config/impl/DefaultConfiguration.java
@@ -66,7 +66,6 @@ import com.opensymphony.xwork2.factory.ActionFactory;
 import com.opensymphony.xwork2.factory.ConverterFactory;
 import com.opensymphony.xwork2.factory.DefaultActionFactory;
 import com.opensymphony.xwork2.factory.DefaultInterceptorFactory;
-import com.opensymphony.xwork2.factory.DefaultResultFactory;
 import com.opensymphony.xwork2.factory.DefaultUnknownHandlerFactory;
 import com.opensymphony.xwork2.factory.DefaultValidatorFactory;
 import com.opensymphony.xwork2.factory.InterceptorFactory;
@@ -109,6 +108,7 @@ import org.apache.struts2.StrutsConstants;
 import org.apache.struts2.conversion.StrutsConversionPropertiesProcessor;
 import org.apache.struts2.conversion.StrutsTypeConverterCreator;
 import org.apache.struts2.conversion.StrutsTypeConverterHolder;
+import org.apache.struts2.factory.StrutsResultFactory;
 import org.apache.struts2.ognl.OgnlGuard;
 import org.apache.struts2.ognl.ProviderAllowlist;
 import org.apache.struts2.ognl.StrutsOgnlGuard;
@@ -363,7 +363,7 @@ public class DefaultConfiguration implements Configuration {
                 // TODO: SpringObjectFactoryTest fails when these are SINGLETON
                 .factory(ObjectFactory.class, Scope.PROTOTYPE)
                 .factory(ActionFactory.class, DefaultActionFactory.class, Scope.PROTOTYPE)
-                .factory(ResultFactory.class, DefaultResultFactory.class, Scope.PROTOTYPE)
+                .factory(ResultFactory.class, StrutsResultFactory.class, Scope.PROTOTYPE)
                 .factory(InterceptorFactory.class, DefaultInterceptorFactory.class, Scope.PROTOTYPE)
                 .factory(ValidatorFactory.class, DefaultValidatorFactory.class, Scope.PROTOTYPE)
                 .factory(ConverterFactory.class, StrutsConverterFactory.class, Scope.PROTOTYPE)

--- a/core/src/main/java/com/opensymphony/xwork2/factory/DefaultResultFactory.java
+++ b/core/src/main/java/com/opensymphony/xwork2/factory/DefaultResultFactory.java
@@ -26,12 +26,16 @@ import com.opensymphony.xwork2.inject.Inject;
 import com.opensymphony.xwork2.util.reflection.ReflectionException;
 import com.opensymphony.xwork2.util.reflection.ReflectionExceptionHandler;
 import com.opensymphony.xwork2.util.reflection.ReflectionProvider;
+import org.apache.struts2.factory.StrutsResultFactory;
 
 import java.util.Map;
 
 /**
  * Default implementation
+ *
+ * @deprecated since 6.7.0, use {@link StrutsResultFactory} instead.
  */
+@Deprecated
 public class DefaultResultFactory implements ResultFactory {
 
     private ObjectFactory objectFactory;

--- a/core/src/main/java/org/apache/struts2/ActionContext.java
+++ b/core/src/main/java/org/apache/struts2/ActionContext.java
@@ -542,11 +542,16 @@ public class ActionContext implements Serializable {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public final boolean equals(Object obj) {
         if (!(obj instanceof ActionContext)) {
             return false;
         }
         ActionContext other = (ActionContext) obj;
         return Objects.equals(getContextMap(), other.getContextMap());
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(getContextMap());
     }
 }

--- a/core/src/test/java/com/opensymphony/xwork2/interceptor/ChainingInterceptorWithConfigTest.java
+++ b/core/src/test/java/com/opensymphony/xwork2/interceptor/ChainingInterceptorWithConfigTest.java
@@ -42,6 +42,7 @@ import org.apache.struts2.config.StrutsXmlConfigurationProvider;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Map;
 
 
 /**
@@ -101,11 +102,11 @@ public class ChainingInterceptorWithConfigTest extends XWorkTestCase {
             HashMap<String, String> interceptorParams = new HashMap<>();
             interceptorParams.put("excludes", "blah,bar");
 
-            HashMap successParams1 = new HashMap();
+            Map<String, String> successParams1 = new HashMap<>();
             successParams1.put("propertyName", "baz");
-            successParams1.put("expectedValue", 1);
+            successParams1.put("expectedValue", "1");
 
-            HashMap successParams2 = new HashMap();
+            Map<String, String> successParams2 = new HashMap<>();
             successParams2.put("propertyName", "blah");
             successParams2.put("expectedValue", null);
 

--- a/plugins/convention/src/test/java/org/apache/struts2/convention/PackageBasedActionConfigBuilderTest.java
+++ b/plugins/convention/src/test/java/org/apache/struts2/convention/PackageBasedActionConfigBuilderTest.java
@@ -35,7 +35,6 @@ import com.opensymphony.xwork2.config.entities.ResultConfig;
 import com.opensymphony.xwork2.config.entities.ResultTypeConfig;
 import com.opensymphony.xwork2.config.impl.DefaultConfiguration;
 import com.opensymphony.xwork2.factory.DefaultInterceptorFactory;
-import com.opensymphony.xwork2.factory.DefaultResultFactory;
 import com.opensymphony.xwork2.inject.Container;
 import com.opensymphony.xwork2.inject.Scope.Strategy;
 import com.opensymphony.xwork2.ognl.OgnlReflectionProvider;
@@ -97,6 +96,7 @@ import org.apache.struts2.convention.actions.transactions.TransNameAction;
 import org.apache.struts2.convention.annotation.Action;
 import org.apache.struts2.convention.annotation.Actions;
 import org.apache.struts2.convention.dontfind.DontFindMeAction;
+import org.apache.struts2.factory.StrutsResultFactory;
 import org.apache.struts2.ognl.ProviderAllowlist;
 import org.apache.struts2.result.ServletDispatcherResult;
 import org.easymock.EasyMock;
@@ -918,7 +918,7 @@ public class PackageBasedActionConfigBuilderTest extends TestCase {
                     dif.setObjectFactory((ObjectFactory) obj);
                     dif.setReflectionProvider(rp);
 
-                    DefaultResultFactory drf = new DefaultResultFactory();
+                    StrutsResultFactory drf = new StrutsResultFactory();
                     drf.setObjectFactory((ObjectFactory) obj);
                     drf.setReflectionProvider(rp);
 


### PR DESCRIPTION
WW-5478
--
I can't see any value in maintaining this class as it does the same thing as `StrutsResultFactory` minus support for the marker `ParamNameAwareResult`.