### PR TITLE
WW-3714 Ensure correct delegation of deprecated API methods

### DIFF
--- a/core/src/main/java/com/opensymphony/xwork2/DefaultActionInvocation.java
+++ b/core/src/main/java/com/opensymphony/xwork2/DefaultActionInvocation.java
@@ -378,7 +378,7 @@ public class DefaultActionInvocation implements ActionInvocation {
         result = createResult();
 
         if (result != null) {
-            result.execute(this);
+            result.execute((org.apache.struts2.ActionInvocation) this);
         } else if (resultCode != null && !Action.NONE.equals(resultCode)) {
             throw new ConfigurationException("No result defined for action " + getAction().getClass().getName()
                 + " and result " + getResultCode(), proxy.getConfig());

--- a/core/src/main/java/com/opensymphony/xwork2/DefaultActionInvocation.java
+++ b/core/src/main/java/com/opensymphony/xwork2/DefaultActionInvocation.java
@@ -257,7 +257,7 @@ public class DefaultActionInvocation implements ActionInvocation {
                     resultCode = executeConditional((ConditionalInterceptor) interceptor);
                 } else {
                     LOG.debug("Executing normal interceptor: {}", interceptorMapping.getName());
-                    resultCode = interceptor.intercept(this);
+                    resultCode = interceptor.intercept((org.apache.struts2.ActionInvocation) this);
                 }
             } else {
                 resultCode = invokeActionOnly();
@@ -298,9 +298,9 @@ public class DefaultActionInvocation implements ActionInvocation {
     }
 
     protected String executeConditional(ConditionalInterceptor conditionalInterceptor) throws Exception {
-        if (conditionalInterceptor.shouldIntercept(this)) {
+        if (conditionalInterceptor.shouldIntercept((org.apache.struts2.ActionInvocation) this)) {
             LOG.debug("Executing conditional interceptor: {}", conditionalInterceptor.getClass().getSimpleName());
-            return conditionalInterceptor.intercept(this);
+            return conditionalInterceptor.intercept((org.apache.struts2.ActionInvocation) this);
         } else {
             LOG.debug("Interceptor: {} is disabled, skipping to next", conditionalInterceptor.getClass().getSimpleName());
             return this.invoke();

--- a/core/src/main/java/com/opensymphony/xwork2/interceptor/AbstractInterceptor.java
+++ b/core/src/main/java/com/opensymphony/xwork2/interceptor/AbstractInterceptor.java
@@ -38,6 +38,11 @@ public abstract class AbstractInterceptor extends org.apache.struts2.interceptor
 
     @Override
     public boolean shouldIntercept(ActionInvocation invocation) {
-        return shouldIntercept((org.apache.struts2.ActionInvocation) invocation);
+        return super.shouldIntercept(invocation);
+    }
+
+    @Override
+    public boolean shouldIntercept(org.apache.struts2.ActionInvocation invocation) {
+        return shouldIntercept(ActionInvocation.adapt(invocation));
     }
 }

--- a/core/src/main/java/org/apache/struts2/dispatcher/Dispatcher.java
+++ b/core/src/main/java/org/apache/struts2/dispatcher/Dispatcher.java
@@ -734,7 +734,7 @@ public class Dispatcher {
             // if the ActionMapping says to go straight to a result, do it!
             if (mapping.getResult() != null) {
                 Result result = mapping.getResult();
-                result.execute(proxy.getInvocation());
+                result.execute((org.apache.struts2.ActionInvocation) proxy.getInvocation());
             } else {
                 proxy.execute();
             }

--- a/core/src/main/java/org/apache/struts2/interceptor/TokenSessionStoreInterceptor.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/TokenSessionStoreInterceptor.java
@@ -116,15 +116,15 @@ public class TokenSessionStoreInterceptor extends TokenInterceptor {
      * Handles processing of invalid tokens.  If a previously stored invocation is
      * available, the method will attempt to return and render its result.  Otherwise
      * it will return INVALID_TOKEN_CODE.
-     * 
+     *
      * Note: Because a stored (previously completed) invocation's PageContext will be closed,
      *   this method must replace the stored PageContext with the current invocation's one (or a null).
      *   See {@link org.apache.struts2.util.InvocationSessionStore#loadInvocation(String key, String token)} for details.
-     * 
+     *
      * @param invocation
-     * 
+     *
      * @return
-     * @throws Exception 
+     * @throws Exception
      */
     @Override
     protected String handleInvalidToken(ActionInvocation invocation) throws Exception {
@@ -154,7 +154,7 @@ public class TokenSessionStoreInterceptor extends TokenInterceptor {
                 Result result = savedInvocation.getResult();
 
                 if ((result != null) && (savedInvocation.getProxy().getExecuteResult())) {
-                    result.execute(savedInvocation);
+                    result.execute((org.apache.struts2.ActionInvocation) savedInvocation);
                 }
 
                 // turn off execution of this invocations result
@@ -171,11 +171,11 @@ public class TokenSessionStoreInterceptor extends TokenInterceptor {
      * Handles processing of valid tokens.  Stores the current invocation for
      * later use by {@see #handleValidToken(ActionInvocation)}.
      * See {@link org.apache.struts2.util.InvocationSessionStore#storeInvocation(String key, String token, ActionInvocation invocation)} for details.
-     * 
+     *
      * @param invocation
-     * 
+     *
      * @return
-     * @throws Exception 
+     * @throws Exception
      */
     @Override
     protected String handleValidToken(ActionInvocation invocation) throws Exception {

--- a/plugins/rest/src/main/java/org/apache/struts2/rest/RestActionInvocation.java
+++ b/plugins/rest/src/main/java/org/apache/struts2/rest/RestActionInvocation.java
@@ -207,7 +207,7 @@ public class RestActionInvocation extends DefaultActionInvocation {
         if (this.result instanceof HttpHeaderResult) {
 
             // execute the result to apply headers and status in every representations
-            this.result.execute(this);
+            this.result.execute((org.apache.struts2.ActionInvocation) this);
             updateStatusFromResult();
         }
 
@@ -219,7 +219,7 @@ public class RestActionInvocation extends DefaultActionInvocation {
             // Normal struts execution (html o other struts result)
             findResult();
             if (result != null) {
-                this.result.execute(this);
+                this.result.execute((org.apache.struts2.ActionInvocation) this);
             } else {
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("No result returned for action {} at {}", getAction().getClass().getName(), proxy.getConfig().getLocation());


### PR DESCRIPTION
WW-3714
--
Whilst working on #1116, I noticed a minor issue with how overriding of classes that implement the old/deprecated `Result`/`Interceptor` interfaces behave.

Currently, if an application extends for example, `org.apache.struts2.result.HttpHeaderResult` and overrides the new signature `void execute(org.apache.struts2.ActionInvocation invocation)` instead of the old one `void execute(com.opensymphony.xwork2.ActionInvocation invocation)` - this override will have no effect.

The changes in this PR ensure the override will function as expected irrespective of whether the old or new signature is overridden. This works because the default implementation for the new signature in the old/deprecated interfaces is to delegate to the old signature.