### PR TITLE
WW-5493 Restores parameters and uses getAttributes()

### DIFF
--- a/core/src/main/java/org/apache/struts2/components/ActionComponent.java
+++ b/core/src/main/java/org/apache/struts2/components/ActionComponent.java
@@ -215,8 +215,8 @@ public class ActionComponent extends ContextBean {
 
         HttpParameters.Builder builder = HttpParameters.create().withParent(parentParams);
 
-        if (attributes != null) {
-            builder = builder.withExtraParams(attributes);
+        if (getAttributes() != null) {
+            builder = builder.withExtraParams(getAttributes());
         }
         return builder.build();
     }

--- a/core/src/main/java/org/apache/struts2/components/Component.java
+++ b/core/src/main/java/org/apache/struts2/components/Component.java
@@ -71,7 +71,11 @@ public class Component {
     protected boolean devMode = false;
     protected boolean escapeHtmlBody = false;
     protected ValueStack stack;
-    protected Map<String, Object> attributes;
+    /**
+     * @deprecated use {@link #getAttributes} instead of directly depending on this field
+     */
+    @Deprecated
+    protected Map<String, Object> parameters;
     protected ActionMapper actionMapper;
     protected boolean throwExceptionOnELFailure;
     protected boolean performClearTagStateForTagPoolingServers = false;
@@ -86,7 +90,7 @@ public class Component {
      */
     public Component(ValueStack stack) {
         this.stack = stack;
-        this.attributes = new LinkedHashMap<>();
+        this.parameters = new LinkedHashMap<>();
         getComponentStack().push(this);
     }
 
@@ -279,7 +283,7 @@ public class Component {
      */
     protected StrutsException fieldError(String field, String errorMsg, Exception e) {
         String msg = "tag '" + getComponentName() + "', field '" + field +
-            (attributes != null && attributes.containsKey("name") ? "', name '" + attributes.get("name") : "") +
+            (getAttributes() != null && getAttributes().containsKey("name") ? "', name '" + getAttributes().get("name") : "") +
             "': " + errorMsg;
         throw new StrutsException(msg, e);
     }
@@ -457,7 +461,7 @@ public class Component {
      * @param params the parameters to copy.
      */
     public void copyParams(Map<String, Object> params) {
-        stack.push(attributes);
+        stack.push(getAttributes());
         stack.push(this);
         try {
             for (Map.Entry<String, Object> entry : params.entrySet()) {
@@ -467,7 +471,7 @@ public class Component {
                     // UI component attributes may contain hypens (e.g. data-ajax), but ognl
                     // can't handle that, and there can't be a component property with a hypen
                     // so into the parameters map it goes. See WW-4493
-                    attributes.put(key, entry.getValue());
+                    getAttributes().put(key, entry.getValue());
                 } else {
                     stack.setValue(key, entry.getValue());
                 }
@@ -500,7 +504,7 @@ public class Component {
      */
     @Deprecated
     public Map<String, Object> getParameters() {
-        return attributes;
+        return parameters;
     }
 
     /**
@@ -509,7 +513,7 @@ public class Component {
      * @return the parameters. Is never <tt>null</tt>.
      */
     public Map<String, Object> getAttributes() {
-        return attributes;
+        return parameters;
     }
 
     /**
@@ -518,7 +522,7 @@ public class Component {
      * @param params the parameters to add.
      */
     public void addAllParameters(Map<String, Object> params) {
-        attributes.putAll(params);
+        getAttributes().putAll(params);
     }
 
     /**

--- a/core/src/main/java/org/apache/struts2/components/Form.java
+++ b/core/src/main/java/org/apache/struts2/components/Form.java
@@ -204,7 +204,7 @@ public class Form extends ClosingUIBean {
 
         // keep a collection of the tag names for anything special the templates might want to do (such as pure client
         // side validation)
-        if (!attributes.containsKey("tagNames")) {
+        if (!getAttributes().containsKey("tagNames")) {
             // we have this if check so we don't do this twice (on open and close of the template)
             addParameter("tagNames", new ArrayList());
         }

--- a/core/src/main/java/org/apache/struts2/components/Include.java
+++ b/core/src/main/java/org/apache/struts2/components/Include.java
@@ -137,14 +137,13 @@ public class Include extends Component {
         urlBuf.append(page);
 
         // Add request parameters
-        if (attributes.size() > 0) {
+        if (!getAttributes().isEmpty()) {
             urlBuf.append('?');
 
             String concat = "";
 
             // Set parameters
-            for (Object next : attributes.entrySet()) {
-                Map.Entry entry = (Map.Entry) next;
+            for (Map.Entry<String, Object> entry : getAttributes().entrySet()) {
                 Object name = entry.getKey();
                 List values = (List) entry.getValue();
 
@@ -234,11 +233,11 @@ public class Include extends Component {
         // instead, include tag requires that each parameter be a list of objects,
         // just like the HTTP servlet interfaces are (String[])
         if (value != null) {
-            List currentValues = (List) attributes.get(key);
+            List currentValues = (List) getAttributes().get(key);
 
             if (currentValues == null) {
                 currentValues = new ArrayList();
-                attributes.put(key, currentValues);
+                getAttributes().put(key, currentValues);
             }
 
             currentValues.add(value);

--- a/core/src/main/java/org/apache/struts2/components/Label.java
+++ b/core/src/main/java/org/apache/struts2/components/Label.java
@@ -81,8 +81,8 @@ public class Label extends UIBean {
         if (value != null) {
             addParameter("nameValue", findString(value));
         } else if (key != null) {
-            Object nameValue = attributes.get("nameValue");
-            if (nameValue == null || nameValue.toString().length() == 0) {
+            Object nameValue = getAttributes().get("nameValue");
+            if (nameValue == null || nameValue.toString().isEmpty()) {
                 // get the label from a TextProvider (default value is the key)
                 String providedLabel = TextProviderHelper.getText(key, key, stack);
                 addParameter("nameValue", providedLabel);

--- a/core/src/main/java/org/apache/struts2/components/ListUIBean.java
+++ b/core/src/main/java/org/apache/struts2/components/ListUIBean.java
@@ -67,7 +67,7 @@ public abstract class ListUIBean extends UIBean {
         Object value = null;
 
         if (list == null) {
-            list = attributes.get("list");
+            list = getAttributes().get("list");
         }
 
         if (list instanceof String) {

--- a/core/src/main/java/org/apache/struts2/components/ServletUrlRenderer.java
+++ b/core/src/main/java/org/apache/struts2/components/ServletUrlRenderer.java
@@ -174,7 +174,7 @@ public class ServletUrlRenderer implements UrlRenderer {
             namespace, actionName);
         if (actionConfig != null) {
 
-            ActionMapping mapping = new ActionMapping(actionName, namespace, actionMethod, formComponent.attributes);
+            ActionMapping mapping = new ActionMapping(actionName, namespace, actionMethod, formComponent.getAttributes());
             String result = urlHelper.buildUrl(formComponent.actionMapper.getUriFromActionMapping(mapping),
                 formComponent.request, formComponent.response, queryStringResult.getQueryParams(), scheme, formComponent.includeContext, true, false, false);
             formComponent.addParameter("action", result);

--- a/core/src/main/java/org/apache/struts2/components/UIBean.java
+++ b/core/src/main/java/org/apache/struts2/components/UIBean.java
@@ -882,8 +882,8 @@ public abstract class UIBean extends Component {
      */
     protected void applyValueParameter(String translatedName) {
         // see if the value has been specified as a parameter already
-        if (attributes.containsKey(ATTR_VALUE)) {
-            attributes.put(ATTR_NAME_VALUE, attributes.get(ATTR_VALUE));
+        if (getAttributes().containsKey(ATTR_VALUE)) {
+            getAttributes().put(ATTR_NAME_VALUE, getAttributes().get(ATTR_VALUE));
         } else {
             if (evaluateNameValue()) {
                 final Class<?> valueClazz = getValueClassType();

--- a/core/src/main/java/org/apache/struts2/components/URL.java
+++ b/core/src/main/java/org/apache/struts2/components/URL.java
@@ -111,7 +111,7 @@ public class URL extends ContextBean {
 
     public URL(ValueStack stack, HttpServletRequest req, HttpServletResponse res) {
         super(stack);
-        urlProvider = new ComponentUrlProvider(this, this.attributes);
+        urlProvider = new ComponentUrlProvider(this, this.getAttributes());
         urlProvider.setHttpServletRequest(req);
         urlProvider.setHttpServletResponse(res);
     }


### PR DESCRIPTION
Instead of using parameters field directly, this PR uses getAttributes() instead to avoid coupling with internal Component state

Fixes [WW-5493](https://issues.apache.org/jira/browse/WW-5493)