### PR TITLE
Removes checking branch ref and removes branch name as not needed

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -44,6 +44,4 @@ jobs:
       - env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
-          MAIN_BRANCH: ${{ github.ref || github.base_ref || github.ref || github.base_ref }}
-        if: ${{ github.ref == 'main' || github.base_ref == 'main' }}
-        run: ./mvnw -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.branch.name=${{ env.MAIN_BRANCH }} -Pcoverage -DskipAssembly
+        run: ./mvnw -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Pcoverage -DskipAssembly


### PR DESCRIPTION
Right now Sonar scans are [skipped](https://github.com/apache/struts/actions/runs/12479769638/job/34829469378), because branch ref is wrong and basically not needed as Sonar can detect branch name itself.