### PR TITLE
WW-5498 Adds devMode errors as action messages to avoid breaking validation logic

### DIFF
--- a/core/src/main/java/org/apache/struts2/util/DebugUtils.java
+++ b/core/src/main/java/org/apache/struts2/util/DebugUtils.java
@@ -38,7 +38,7 @@ public final class DebugUtils {
         }
         log.error(message);
         if (action instanceof ValidationAware validationAware) {
-            validationAware.addActionError(message);
+            validationAware.addActionMessage(message);
         }
     }
 

--- a/core/src/test/java/org/apache/struts2/interceptor/parameter/ParametersInterceptorTest.java
+++ b/core/src/test/java/org/apache/struts2/interceptor/parameter/ParametersInterceptorTest.java
@@ -117,9 +117,9 @@ public class ParametersInterceptorTest extends XWorkTestCase {
         pi.applyParameters(action, vs, HttpParameters.create(params).build());
 
         // then
-        assertEquals(3, action.getActionErrors().size());
+        assertEquals(3, action.getActionMessages().size());
 
-        List<String> actionErrors = new ArrayList<>(action.getActionErrors());
+        List<String> actionErrors = new ArrayList<>(action.getActionMessages());
 
         String msg1 = actionErrors.get(0);
         String msg2 = actionErrors.get(1);
@@ -204,9 +204,9 @@ public class ParametersInterceptorTest extends XWorkTestCase {
         pi.applyParameters(action, vs, HttpParameters.create(params).build());
 
         // then
-        assertEquals(3, action.getActionErrors().size());
+        assertEquals(3, action.getActionMessages().size());
 
-        List<String> actionErrors = new ArrayList<>(action.getActionErrors());
+        List<String> actionErrors = new ArrayList<>(action.getActionMessages());
         String msg1 = actionErrors.get(0);
         String msg2 = actionErrors.get(1);
         String msg3 = actionErrors.get(2);
@@ -586,7 +586,7 @@ public class ParametersInterceptorTest extends XWorkTestCase {
         container.inject(config.getInterceptors().get(0).getInterceptor());
         ActionProxy proxy = actionProxyFactory.createActionProxy("", MockConfigurationProvider.PARAM_INTERCEPTOR_ACTION_NAME, null, extraContext.getContextMap());
         proxy.execute();
-        final String actionError = "" + ((SimpleAction) proxy.getAction()).getActionErrors().toArray()[0];
+        final String actionError = "" + ((SimpleAction) proxy.getAction()).getActionMessages().toArray()[0];
         assertTrue(actionError.contains("Error setting expression 'not_a_property' with value 'There is no action property named like this'"));
     }
 


### PR DESCRIPTION
[WW-5498](https://issues.apache.org/jira/browse/WW-5498)

Cherry picks 9d07c3b4c37031ddfecddd44d0a5057c9e6964fa in Struts 7