### PR TITLE
WW-5500 Extends pattern to validate multipart uploads

### DIFF
--- a/core/src/main/java/org/apache/struts2/dispatcher/Dispatcher.java
+++ b/core/src/main/java/org/apache/struts2/dispatcher/Dispatcher.java
@@ -111,7 +111,7 @@ public class Dispatcher {
      */
     public static final String REQUEST_POST_METHOD = "POST";
 
-    public static final String MULTIPART_FORM_DATA_REGEX = "^multipart/form-data(?:\\s*;\\s*boundary=[0-9a-zA-Z'()+_,\\-./:=?]{1,70})?(?:\\s*;\\s*charset=[a-zA-Z\\-0-9]{3,14})?";
+    public static final String MULTIPART_FORM_DATA_REGEX = "^multipart/form-data(?:\\s*;\\s*boundary=[0-9a-zA-Z'\"()+_,\\-./:=?]{1,70})?(?:\\s*;\\s*charset=[a-zA-Z\\-0-9]{3,14})?";
 
     private static final String CONFIG_SPLIT_REGEX = "\\s*,\\s*";
 

--- a/core/src/test/java/org/apache/struts2/dispatcher/DispatcherTest.java
+++ b/core/src/test/java/org/apache/struts2/dispatcher/DispatcherTest.java
@@ -344,6 +344,9 @@ public class DispatcherTest extends StrutsJUnit4InternalTestCase {
 
         req.setContentType("Multipart/Form-Data ; boundary=---------------------------207103069210263;charset=UTF-16LE");
         assertTrue(dispatcher.isMultipartRequest(req));
+
+        req.setContentType("multipart/form-data; boundary=\"----=_Part_38_1092302434.1734807780737\"");
+        assertTrue(dispatcher.isMultipartRequest(req));
     }
 
     @Test


### PR DESCRIPTION
[WW-5500](https://issues.apache.org/jira/browse/WW-5500)

Cherry picks 575e4e8c9b0be2c1add1597099b7c2b90d93e5fa into Struts 7