### PR TITLE
WW-5528 Ensure multipart upload illegal characters reported as error

### DIFF
--- a/core/src/main/resources/org/apache/struts2/struts-messages.properties
+++ b/core/src/main/resources/org/apache/struts2/struts-messages.properties
@@ -40,6 +40,10 @@ struts.messages.error.file.too.large=The file is too large to be uploaded: {0} "
 # 1 - max string length
 # 2 - actual size
 struts.messages.upload.error.parameter.too.long=The request parameter "{0}" was too long. Max length allowed is {1}, but found {2}!
+# 0 - field name
+struts.messages.upload.error.illegal.characters.field=The multipart upload field name "{0}" contains illegal characters!
+# 0 - file name
+struts.messages.upload.error.illegal.characters.name=The multipart upload filename "{0}" contains illegal characters!
 # 0 - input name
 # 1 - original filename
 # 2 - file name after uploading the file

--- a/core/src/test/java/org/apache/struts2/dispatcher/multipart/AbstractMultiPartRequestTest.java
+++ b/core/src/test/java/org/apache/struts2/dispatcher/multipart/AbstractMultiPartRequestTest.java
@@ -518,8 +518,8 @@ abstract class AbstractMultiPartRequestTest {
 
         multiPart.parse(mockRequest, tempDir);
 
-        assertThat(multiPart.getErrors())
-                .isEmpty();
+        assertThat(multiPart.getErrors()).extracting(LocalizedMessage::getTextKey)
+                .containsExactly(AbstractMultiPartRequest.STRUTS_MESSAGES_UPLOAD_ERROR_ILLEGAL_CHARACTERS_FIELD);
 
         assertThat(multiPart.getParameterNames().asIterator()).toIterable()
                 .isEmpty();
@@ -537,8 +537,8 @@ abstract class AbstractMultiPartRequestTest {
 
         multiPart.parse(mockRequest, tempDir);
 
-        assertThat(multiPart.getErrors())
-                .isEmpty();
+        assertThat(multiPart.getErrors()).extracting(LocalizedMessage::getTextKey)
+                .containsExactly(AbstractMultiPartRequest.STRUTS_MESSAGES_UPLOAD_ERROR_ILLEGAL_CHARACTERS_NAME);
 
         assertThat(multiPart.getParameterNames().asIterator()).toIterable()
                 .hasSize(1);

--- a/core/src/test/java/org/apache/struts2/interceptor/ActionFileUploadInterceptorTest.java
+++ b/core/src/test/java/org/apache/struts2/interceptor/ActionFileUploadInterceptorTest.java
@@ -18,21 +18,21 @@
  */
 package org.apache.struts2.interceptor;
 
-import org.apache.struts2.ActionContext;
-import org.apache.struts2.ActionSupport;
-import org.apache.struts2.locale.DefaultLocaleProvider;
-import org.apache.struts2.ValidationAwareSupport;
-import org.apache.struts2.mock.MockActionInvocation;
-import org.apache.struts2.mock.MockActionProxy;
-import org.apache.struts2.util.ClassLoaderUtil;
 import org.apache.commons.fileupload2.jakarta.servlet6.JakartaServletDiskFileUpload;
 import org.apache.commons.fileupload2.jakarta.servlet6.JakartaServletFileUpload;
+import org.apache.struts2.ActionContext;
+import org.apache.struts2.ActionSupport;
 import org.apache.struts2.StrutsInternalTestCase;
+import org.apache.struts2.ValidationAwareSupport;
 import org.apache.struts2.action.UploadedFilesAware;
 import org.apache.struts2.dispatcher.multipart.JakartaMultiPartRequest;
 import org.apache.struts2.dispatcher.multipart.MultiPartRequestWrapper;
 import org.apache.struts2.dispatcher.multipart.StrutsUploadedFile;
 import org.apache.struts2.dispatcher.multipart.UploadedFile;
+import org.apache.struts2.locale.DefaultLocaleProvider;
+import org.apache.struts2.mock.MockActionInvocation;
+import org.apache.struts2.mock.MockActionProxy;
+import org.apache.struts2.util.ClassLoaderUtil;
 import org.assertj.core.util.Files;
 import org.springframework.mock.web.MockHttpServletRequest;
 
@@ -540,7 +540,8 @@ public class ActionFileUploadInterceptorTest extends StrutsInternalTestCase {
 
         interceptor.intercept(mai);
 
-        assertFalse(action.hasActionErrors());
+        assertThat(action.getActionErrors())
+                .containsExactly("The multipart upload field name \"top.file\" contains illegal characters!");
         assertNull(action.getUploadFiles());
     }
 
@@ -570,7 +571,8 @@ public class ActionFileUploadInterceptorTest extends StrutsInternalTestCase {
 
         interceptor.intercept(mai);
 
-        assertFalse(action.hasActionErrors());
+        assertThat(action.getActionErrors())
+                .containsExactly("The multipart upload filename \"../deleteme.txt\" contains illegal characters!");
         assertNull(action.getUploadFiles());
     }
 


### PR DESCRIPTION
WW-5528
--
We add an error message to be returned by `org.apache.struts2.dispatcher.multipart.MultiPartRequest#getErrors` so we can notify users of why their upload failed.