### PR TITLE
WW-5533 Add compilation support for Jakarta EE 11

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -30,18 +30,25 @@ env:
 
 jobs:
   build:
-    name: Build and Test
+    name: Build and Test (JDK ${{ matrix.java }})${{ matrix.profile == '-Pjakartaee11' && ' with Jakarta EE 11' || matrix.profile }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '17', '21' ]
+        include:
+          - java: '17'
+            profile: ''
+          - java: '21'
+            profile: ''
+          - java: '21'
+            profile: '-Pjakartaee11'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - name: Setup Java ${{ matrix.java }}
+        uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: ${{ matrix.java }}
           cache: 'maven'
-      - name: Build with Maven on Java ${{ matrix.java }}
-        run: mvn -B -V -DskipAssembly verify --no-transfer-progress
+      - name: Maven Verify on Java ${{ matrix.java }}${{ matrix.profile == '-Pjakartaee11' && ' (Jakarta EE 11)' || matrix.profile }}
+        run: mvn -B -V -DskipAssembly verify ${{ matrix.profile }} --no-transfer-progress

--- a/core/src/test/java/org/apache/struts2/dispatcher/multipart/AbstractMultiPartRequestTest.java
+++ b/core/src/test/java/org/apache/struts2/dispatcher/multipart/AbstractMultiPartRequestTest.java
@@ -417,7 +417,6 @@ abstract class AbstractMultiPartRequestTest {
         assertThat(JakartaServletDiskFileUpload.isMultipartContent(mockRequest)).isTrue();
 
         // when
-        mockRequest.setCharacterEncoding(null);
         multiPart.setDefaultEncoding(StandardCharsets.ISO_8859_1.name());
         multiPart.parse(mockRequest, tempDir);
 

--- a/plugins/tiles/src/main/java/org/apache/tiles/el/ScopeELResolver.java
+++ b/plugins/tiles/src/main/java/org/apache/tiles/el/ScopeELResolver.java
@@ -57,7 +57,7 @@ public class ScopeELResolver extends ELResolver {
     /**
      * {@inheritDoc}
      */
-    @Override
+    // @Override // To allow compilation with Maven profile jakartaee11 where this interface method does not exist
     public Iterator<FeatureDescriptor> getFeatureDescriptors(ELContext context, Object base) {
         if (base != null) {
             return Collections.emptyIterator();

--- a/plugins/tiles/src/main/java/org/apache/tiles/el/TilesContextBeanELResolver.java
+++ b/plugins/tiles/src/main/java/org/apache/tiles/el/TilesContextBeanELResolver.java
@@ -47,7 +47,7 @@ public class TilesContextBeanELResolver extends ELResolver {
     }
 
     /** {@inheritDoc} */
-    @Override
+    // @Override // To allow compilation with Maven profile jakartaee11 where this interface method does not exist
     public Iterator<FeatureDescriptor> getFeatureDescriptors(ELContext context, Object base) {
         List<FeatureDescriptor> list = new ArrayList<>();
 

--- a/plugins/tiles/src/main/java/org/apache/tiles/el/TilesContextELResolver.java
+++ b/plugins/tiles/src/main/java/org/apache/tiles/el/TilesContextELResolver.java
@@ -70,7 +70,7 @@ public class TilesContextELResolver extends ELResolver {
     /**
      * {@inheritDoc}
      */
-    @Override
+    // @Override // To allow compilation with Maven profile jakartaee11 where this interface method does not exist
     public Iterator<FeatureDescriptor> getFeatureDescriptors(ELContext context,
                                                              Object base) {
         // only resolve at the root of the context

--- a/pom.xml
+++ b/pom.xml
@@ -151,6 +151,13 @@
             </modules>
         </profile>
         <profile>
+            <id>jakartaee11</id>
+            <properties>
+                <jakarta-ee.version>11.0.0-M5</jakarta-ee.version>
+                <spring.version>7.0.0-M2</spring.version>
+            </properties>
+        </profile>
+        <profile>
             <id>dependency-check</id>
             <build>
                 <plugins>


### PR DESCRIPTION
WW-5533
--
This PR adds an additional build job which ensures compilation compatibility with the upcoming Jakarta EE 11 and Spring 7. It ensures we do not make any code changes which may break forwards compatibility with those releases (e.g. using an API which no longer exists in Jakarta EE 11 or Spring 7).

By using a profile, we can continue to compile against both Jakarta EE 10 and 11, avoiding the need for separate release branches for as long as practical.

This change does NOT ensure compatibility with Tomcat 11.0. That will likely require a follow-up change where we update our Showcase app to use Tomcat 10.1 (and override to 11.0 when the Jakarta EE 11 profile is activated).

Open to feedback on this approach