### PR TITLE
WW-5538 Add conversion handling for java.time.OffsetDateTime

### DIFF
--- a/core/src/main/java/org/apache/struts2/conversion/impl/DateConverter.java
+++ b/core/src/main/java/org/apache/struts2/conversion/impl/DateConverter.java
@@ -33,6 +33,7 @@ import java.text.SimpleDateFormat;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
@@ -116,6 +117,14 @@ public class DateConverter extends DefaultTypeConverter {
                     throw new TypeConversionException("Could not parse date", e);
                 }
 
+            } else if (OffsetDateTime.class == toType) {
+                DateTimeFormatter dtf = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+
+                try {
+                    return OffsetDateTime.parse(sa, dtf);
+                } catch (DateTimeParseException e) {
+                    throw new TypeConversionException("Could not parse OffsetDateTime", e);
+                }
             }
 
             // final fallback for dates without time

--- a/core/src/main/java/org/apache/struts2/conversion/impl/XWorkBasicConverter.java
+++ b/core/src/main/java/org/apache/struts2/conversion/impl/XWorkBasicConverter.java
@@ -28,6 +28,7 @@ import java.lang.reflect.Member;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.OffsetDateTime;
 import java.util.Calendar;
 import java.util.Collection;
 import java.util.Date;
@@ -107,6 +108,8 @@ public class XWorkBasicConverter extends DefaultTypeConverter {
         } else if (LocalDateTime.class.isAssignableFrom(toType)) {
             result = doConvertToDate(context, value, toType);
         } else if (LocalTime.class.isAssignableFrom(toType)) {
+            result = doConvertToDate(context, value, toType);
+        } else if (OffsetDateTime.class.isAssignableFrom(toType)) {
             result = doConvertToDate(context, value, toType);
         } else if (Calendar.class.isAssignableFrom(toType)) {
             result = doConvertToCalendar(context, value);

--- a/core/src/test/java/org/apache/struts2/conversion/impl/XWorkConverterTest.java
+++ b/core/src/test/java/org/apache/struts2/conversion/impl/XWorkConverterTest.java
@@ -54,6 +54,7 @@ import java.time.format.DateTimeFormatter;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.OffsetDateTime;
 import java.util.Date;
 import java.util.Set;
 
@@ -115,9 +116,13 @@ public class XWorkConverterTest extends XWorkTestCase {
         DateTimeFormatter formatterTime = DateTimeFormatter.ofPattern("HH:mm:ss");
         LocalTime localTime = LocalTime.parse("10:11:12", formatterTime);
 
+        DateTimeFormatter formatterOffsetDateTime = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+        OffsetDateTime offsetDateTime = OffsetDateTime.parse("2001-01-10T10:11:12+05:00", formatterOffsetDateTime);
+
         String localDateStr = (String) converter.convertValue(context, null, null, null, localDate, String.class);
         String localDateTimeStr = (String) converter.convertValue(context, null, null, null, localDateTime, String.class);
         String localTimeStr = (String) converter.convertValue(context, null, null, null, localTime, String.class);
+        String offsetDateTimeStr = (String) converter.convertValue(context, null, null, null, offsetDateTime, String.class);
 
         LocalDate localDate2 = (LocalDate) converter.convertValue(context, null, null, null, localDateStr, LocalDate.class);
         assertEquals(localDate, localDate2);
@@ -127,6 +132,9 @@ public class XWorkConverterTest extends XWorkTestCase {
 
         LocalTime localTime2 = (LocalTime) converter.convertValue(context, null, null, null, localTimeStr, LocalTime.class);
         assertEquals(localTime, localTime2);
+
+        OffsetDateTime offsetDateTime2 = (OffsetDateTime) converter.convertValue(context, null, null, null, offsetDateTimeStr, OffsetDateTime.class);
+        assertEquals(offsetDateTime, offsetDateTime2);
     }
 
     public void testDateConversionWithDefault() throws ParseException {


### PR DESCRIPTION
WW-5538
--

These patches allow DateConverter to handle OffsetDateTime conversions using the standard patterns for that data type. Testing code is included.