### PR TITLE
WW-5524 Fixup StrutsConverterFactory - Struts 6

### DIFF
--- a/core/src/main/java/com/opensymphony/xwork2/factory/StrutsConverterFactory.java
+++ b/core/src/main/java/com/opensymphony/xwork2/factory/StrutsConverterFactory.java
@@ -18,8 +18,8 @@
  */
 package com.opensymphony.xwork2.factory;
 
+import com.opensymphony.xwork2.ObjectFactory;
 import com.opensymphony.xwork2.conversion.TypeConverter;
-import com.opensymphony.xwork2.inject.Container;
 import com.opensymphony.xwork2.inject.Inject;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
@@ -33,16 +33,15 @@ public class StrutsConverterFactory implements ConverterFactory {
 
     private static final Logger LOG = LogManager.getLogger(StrutsConverterFactory.class);
 
-    private Container container;
+    private ObjectFactory objectFactory;
 
     @Inject
-    public void setContainer(Container container) {
-        this.container = container;
+    public void setObjectFactory(ObjectFactory objectFactory) {
+        this.objectFactory = objectFactory;
     }
 
     public TypeConverter buildConverter(Class<? extends TypeConverter> converterClass, Map<String, Object> extraContext) throws Exception {
         LOG.debug("Creating converter of type [{}]", converterClass.getCanonicalName());
-        return container.inject(converterClass);
+        return (TypeConverter)objectFactory.buildBean(converterClass, extraContext);
     }
-
 }


### PR DESCRIPTION
It should delegate back to ObjectFactory#buildBean instead of directly calling Container#inject, otherwise overrides of buildBean in subclasses of ObjectFactory e.g. SpringObjectFactory are skipped; meaning that TypeConverters cannot make use of Spring dependency injection

Closes [WW-5524](https://issues.apache.org/jira/browse/WW-5524)