### PR TITLE
WW-5502 Removes deprecated sanitizeNewlines method

### DIFF
--- a/core/src/main/java/org/apache/struts2/dispatcher/multipart/AbstractMultiPartRequest.java
+++ b/core/src/main/java/org/apache/struts2/dispatcher/multipart/AbstractMultiPartRequest.java
@@ -312,13 +312,6 @@ public abstract class AbstractMultiPartRequest implements MultiPartRequest {
         return FilenameUtils.getName(originalFileName);
     }
 
-    /**
-     * @deprecated since 7.0.1, use {@link StringUtils#normalizeSpace(String)} instead
-     */
-    @Deprecated
-    protected String sanitizeNewlines(String before) {
-        return before.replaceAll("\\R", "_");
-    }
 
     /* (non-Javadoc)
      * @see org.apache.struts2.dispatcher.multipart.MultiPartRequest#getErrors()


### PR DESCRIPTION
Closes [WW-5502](https://issues.apache.org/jira/browse/WW-5502)