### PR TITLE
fix: OGNL Expression Language statement with user-controlled input

### DIFF
--- a/core/src/main/java/org/apache/struts2/ognl/OgnlUtil.java
+++ b/core/src/main/java/org/apache/struts2/ognl/OgnlUtil.java
@@ -417,6 +417,10 @@ public class OgnlUtil {
     }
 
     private <T> T ognlGet(String expr, Map<String, Object> context, Object root, Class<T> resultType, Map<String, Object> checkContext, TreeValidator... treeValidators) throws OgnlException {
+        // Validate before parse/evaluation
+        if (ognlGuard.isRawExpressionBlocked(expr)) {
+            throw new OgnlException("Blocked potentially unsafe OGNL expression: " + expr);
+        }
         Object tree = toTree(expr);
         for (TreeValidator validator : treeValidators) {
             validator.validate(tree, checkContext);


### PR DESCRIPTION
fix the problem must ensure that OGNL expressions resolved and evaluated by Struts cannot originate from untrusted user input (i.e., header names, attribute names, etc.) unless robust validation is applied. The best way is to validate the OGNL expression specifically before parsing and evaluating, according to a whitelist of allowed expression patterns or types. This can be achieved by enhancing the OGNL guard with additional logic: if the expression is derived from a request header or attribute name, block its evaluation unless it passes strict validation (such as allowing only property lookup, no method calls, no reflection, and so forth).

To implement this:
1. Add a utility method to check (validate) that an OGNL expression is safe—e.g., only matches a whitelist pattern.
2. In the critical region, before parsing/evaluating an OGNL expression (e.g., in `OgnlUtil.ognlGet`, or, better, in the OgnlGuard itself), invoke this validation and block the expression if not safe.
3. Optionally, maintain a blacklist of known dangerous OGNL strings or patterns.
4. The fix needs to be in `OgnlGuard` (`isRawExpressionBlocked(String expr)`) and called during parsing as designed (but ensure its implementation), and possibly in `OgnlUtil` to catch unsafe situations not covered by configuration.
5. Add a simple pattern that allows bare property lookup (e.g., `^\w+$`) and blocks expressions containing `(`, `)`, method calls, array access, or reflection (`@`, `#`, `.` except for single property), etc.

Only modify snippets from files you're shown, notably the interface and wherever its implementation is likely (within interface itself for default, but ideally in a concrete implementing class; add a strong default if none exists).


### Refferences

 [Apache Commons OGNL](https://commons.apache.org/proper/commons-ognl/)
[Proactively protect from OGNL Expression Injections attacks](https://struts.apache.org/security/#proactively-protect-from-ognl-expression-injections-attacks-if-easily-applicable)
