### PR TITLE
WW-5578 Don't catch and swallow ConfigurationException in InterceptorBuilder.

### DIFF
--- a/core/src/main/java/org/apache/struts2/config/providers/InterceptorBuilder.java
+++ b/core/src/main/java/org/apache/struts2/config/providers/InterceptorBuilder.java
@@ -70,22 +70,14 @@ public class InterceptorBuilder {
             throw new ConfigurationException("Unable to find interceptor class referenced by ref-name " + refName, location);
         } else {
             if (referencedConfig instanceof InterceptorConfig config) {
-                try {
-                    Interceptor inter = objectFactory.buildInterceptor(config, refParams);
-                    result.add(new InterceptorMapping(refName, inter, refParams));
-                } catch (ConfigurationException ex) {
-              	    LOG.warn(new ParameterizedMessage("Unable to load config class {} at {} probably due to a missing jar, which might be fine if you never plan to use the {} interceptor",
-                            config.getClassName(), ex.getLocation(), config.getName()), ex);
-                }
-
+                Interceptor inter = objectFactory.buildInterceptor(config, refParams);
+                result.add(new InterceptorMapping(refName, inter, refParams));
             } else if (referencedConfig instanceof InterceptorStackConfig stackConfig) {
-
                 if (refParams != null && !refParams.isEmpty()) {
                     result = constructParameterizedInterceptorReferences(interceptorLocator, stackConfig, refParams, objectFactory);
                 } else {
                     result.addAll(stackConfig.getInterceptors());
                 }
-
             } else {
                 LOG.error("Got unexpected type for interceptor {}. Got {}", refName, referencedConfig);
             }

--- a/core/src/test/java/org/apache/struts2/interceptor/FetchMetadataInterceptorTest.java
+++ b/core/src/test/java/org/apache/struts2/interceptor/FetchMetadataInterceptorTest.java
@@ -20,7 +20,9 @@ package org.apache.struts2.interceptor;
 
 import org.apache.struts2.ActionContext;
 import org.apache.struts2.XWorkTestCase;
+import org.apache.struts2.config.DefaultPropertiesProvider;
 import org.apache.struts2.config.RuntimeConfiguration;
+import org.apache.struts2.config.StrutsBeanSelectionProvider;
 import org.apache.struts2.config.entities.ActionConfig;
 import org.apache.struts2.config.entities.InterceptorMapping;
 import org.apache.struts2.config.entities.InterceptorStackConfig;
@@ -158,7 +160,7 @@ public class FetchMetadataInterceptorTest extends XWorkTestCase {
         // Ensure we're using the specific test configuration, not the default simple configuration.
         XmlConfigurationProvider configurationProvider = new StrutsXmlConfigurationProvider("struts-testing.xml");
         container.inject(configurationProvider);
-        loadConfigurationProviders(configurationProvider);
+        loadConfigurationProviders(configurationProvider, new DefaultPropertiesProvider(), new StrutsBeanSelectionProvider());
 
         // The test configuration in "struts-testing.xml" should define a "default" package.  That "default" package should contain a "defaultInterceptorStack" containing
         // a "fetchMetadata" interceptor parameter "fetchMetadata.setExemptedPaths".  If the parameter method injection is working correctly for the FetchMetadataInterceptor,


### PR DESCRIPTION
WW-5578
--

This can mask configuration errors and result in a non-working application.