### PR TITLE
fix(json-plugin): WW-5624 enforce @StrutsParameter in JSONPopulator.populateObject()

### DIFF
--- a/plugins/json/src/main/java/org/apache/struts2/json/JSONInterceptor.java
+++ b/plugins/json/src/main/java/org/apache/struts2/json/JSONInterceptor.java
@@ -378,6 +378,12 @@ public class JSONInterceptor extends AbstractInterceptor {
         this.defaultEncoding = val;
     }
 
+    @Inject(value = StrutsConstants.STRUTS_PARAMETERS_REQUIRE_ANNOTATIONS, required = false)
+    public void setRequireAnnotations(String requireAnnotations) {
+        boolean required = BooleanUtils.toBoolean(requireAnnotations);
+        this.populator.setRequireAnnotations(required);
+    }
+
     /**
      * @param ignoreHierarchy Ignore properties defined on base classes of the root object.
      */

--- a/plugins/json/src/main/java/org/apache/struts2/json/JSONPopulator.java
+++ b/plugins/json/src/main/java/org/apache/struts2/json/JSONPopulator.java
@@ -20,6 +20,7 @@ package org.apache.struts2.json;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 import org.apache.struts2.json.annotations.JSON;
 
 import java.beans.BeanInfo;
@@ -52,12 +53,25 @@ public class JSONPopulator {
     private static final Logger LOG = LogManager.getLogger(JSONPopulator.class);
 
     private String dateFormat = JSONUtil.RFC3339_FORMAT;
+    private boolean requireAnnotations = false;
 
     public JSONPopulator() {
     }
 
     public JSONPopulator(String dateFormat) {
         this.dateFormat = dateFormat;
+    }
+
+    /**
+     * Sets whether @StrutsParameter annotations are required on setter methods
+     * for JSON deserialization. When enabled, only setters annotated with
+     * @StrutsParameter will be populated from JSON input, consistent with
+     * ParametersInterceptor behavior.
+     *
+     * @param requireAnnotations true to enforce annotation requirement
+     */
+    public void setRequireAnnotations(boolean requireAnnotations) {
+        this.requireAnnotations = requireAnnotations;
     }
 
     public String getDateFormat() {
@@ -87,6 +101,14 @@ public class JSONPopulator {
                 if (method != null) {
                     JSON json = method.getAnnotation(JSON.class);
                     if ((json != null) && !json.deserialize()) {
+                        continue;
+                    }
+
+                    // Enforce @StrutsParameter annotation if required, consistent
+                    // with ParametersInterceptor behavior for URL parameters
+                    if (requireAnnotations && method.getAnnotation(StrutsParameter.class) == null) {
+                        LOG.debug("JSON property '{}' rejected: setter [{}] missing @StrutsParameter annotation",
+                                name, method.getName());
                         continue;
                     }
 


### PR DESCRIPTION
## Summary

`JSONPopulator.populateObject()` in the struts2-json-plugin sets action properties via direct Java reflection (`Method.invoke()`) without checking the `@StrutsParameter` annotation. This bypasses the parameter allowlisting that `ParametersInterceptor` enforces for URL parameters, enabling mass assignment of unannotated properties via JSON request body.

## Changes

- **JSONPopulator.java**: Add `@StrutsParameter` annotation check before `Method.invoke()`. When `struts.parameters.requireAnnotations` is enabled and the setter lacks the annotation, the property is skipped with a debug log message.
- **JSONInterceptor.java**: Wire the `struts.parameters.requireAnnotations` setting via `@Inject` into `JSONPopulator.setRequireAnnotations()`.

## Impact

Without this fix:
- URL params to unannotated setters: **BLOCKED** (ParametersInterceptor enforces)
- JSON body to same unannotated setters: **BYPASSES** (JSONPopulator ignores annotation)

With this fix, both pathways consistently enforce `@StrutsParameter`.

## Test

A PoC application with 8 test cases demonstrates the bypass and fix. An action with `@StrutsParameter`-annotated setter (`setUsername`) and unannotated setters (`setRole`, `setAdmin`) shows that JSON body sets unannotated fields before the fix, and blocks them after.
