### PR TITLE
fix(rest-plugin): WW-5624 enforce @StrutsParameter in JacksonJsonHandler.toObject()

### DIFF
--- a/plugins/rest/src/main/java/org/apache/struts2/rest/handler/JacksonJsonHandler.java
+++ b/plugins/rest/src/main/java/org/apache/struts2/rest/handler/JacksonJsonHandler.java
@@ -21,28 +21,82 @@ package org.apache.struts2.rest.handler;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.struts2.ActionInvocation;
 import org.apache.struts2.inject.Inject;
 import org.apache.struts2.StrutsConstants;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
+import java.beans.BeanInfo;
+import java.beans.Introspector;
+import java.beans.PropertyDescriptor;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.Writer;
+import java.lang.reflect.Method;
+import java.util.Map;
 
 /**
  * Handles JSON content using jackson-lib
  */
 public class JacksonJsonHandler implements ContentTypeHandler {
 
+    private static final Logger LOG = LogManager.getLogger(JacksonJsonHandler.class);
     private static final String DEFAULT_CONTENT_TYPE = "application/json";
     private String defaultEncoding = "ISO-8859-1";
     private ObjectMapper mapper = new ObjectMapper();
+    private boolean requireAnnotations = false;
+
+    @Inject(value = StrutsConstants.STRUTS_PARAMETERS_REQUIRE_ANNOTATIONS, required = false)
+    public void setRequireAnnotations(String requireAnnotations) {
+        this.requireAnnotations = org.apache.commons.lang3.BooleanUtils.toBoolean(requireAnnotations);
+    }
 
     @Override
     public void toObject(ActionInvocation invocation, Reader in, Object target) throws IOException {
         mapper.configure(SerializationFeature.WRITE_NULL_MAP_VALUES, false);
-        ObjectReader or = mapper.readerForUpdating(target);
-        or.readValue(in);
+        if (requireAnnotations) {
+            // Deserialize into a map first, then filter by @StrutsParameter annotation
+            @SuppressWarnings("unchecked")
+            Map<String, Object> jsonMap = mapper.readValue(in, Map.class);
+            applyAnnotatedProperties(target, jsonMap);
+        } else {
+            ObjectReader or = mapper.readerForUpdating(target);
+            or.readValue(in);
+        }
+    }
+
+    /**
+     * Sets only properties whose setter method is annotated with @StrutsParameter,
+     * consistent with ParametersInterceptor behavior for URL parameters.
+     */
+    private void applyAnnotatedProperties(Object target, Map<String, Object> jsonMap) {
+        try {
+            BeanInfo info = Introspector.getBeanInfo(target.getClass());
+            PropertyDescriptor[] props = info.getPropertyDescriptors();
+            for (PropertyDescriptor prop : props) {
+                String name = prop.getName();
+                if (!jsonMap.containsKey(name)) {
+                    continue;
+                }
+                Method setter = prop.getWriteMethod();
+                if (setter == null) {
+                    continue;
+                }
+                if (setter.getAnnotation(StrutsParameter.class) == null) {
+                    LOG.debug("REST JSON property '{}' rejected: setter [{}] missing @StrutsParameter annotation",
+                            name, setter.getName());
+                    continue;
+                }
+                // Use Jackson to convert the value to the correct type and set it
+                Object value = jsonMap.get(name);
+                Object converted = mapper.convertValue(value, setter.getParameterTypes()[0]);
+                setter.invoke(target, converted);
+            }
+        } catch (Exception e) {
+            LOG.error("Error applying annotated properties from JSON", e);
+        }
     }
 
     @Override


### PR DESCRIPTION
## Summary

`JacksonJsonHandler.toObject()` in the struts2-rest-plugin uses `ObjectMapper.readerForUpdating(target).readValue(reader)` to merge JSON request body directly into the action object. Jackson sets any field with a matching setter, completely bypassing the `@StrutsParameter` annotation check that `ParametersInterceptor` enforces for URL parameters. This enables mass assignment of unannotated properties via REST JSON request body.

## Changes

- **JacksonJsonHandler.java**: When `struts.parameters.requireAnnotations` is enabled, deserialize JSON into a map first, then filter properties against the `@StrutsParameter` annotation on the target class's setter methods before setting them. When disabled, preserve the original `readerForUpdating()` merge for backwards compatibility.

## Impact

Without this fix:
- URL params to unannotated setters: **BLOCKED** (ParametersInterceptor enforces)
- REST JSON body to same unannotated setters: **BYPASSES** (Jackson merge ignores annotation)

With this fix, both pathways consistently enforce `@StrutsParameter`.

## Test

A PoC application with 9 test cases demonstrates the bypass using an `OrderAction` with annotated (`setItemName`, `setQuantity`) and unannotated (`setUnitPrice`, `setDiscount`, `setApproved`, `setInternalNote`) setters. JSON body sets `unitPrice` from 99.99 to 0.01 and `approved` to true before the fix.
