### PR TITLE
fix(core): WW-5623 HTML-encode form action in PostbackResult to prevent XSS

### DIFF
--- a/core/src/main/java/org/apache/struts2/result/PostbackResult.java
+++ b/core/src/main/java/org/apache/struts2/result/PostbackResult.java
@@ -104,7 +104,8 @@ public class PostbackResult extends StrutsResultSupport {
 
         // Render
         PrintWriter pw = new PrintWriter(response.getOutputStream());
-        pw.write("<!DOCTYPE html><html><body><form action=\"" + finalLocation + "\" method=\"POST\">");
+        String safeLocation = encodeHtml(finalLocation);
+        pw.write("<!DOCTYPE html><html><body><form action=\"" + safeLocation + "\" method=\"POST\">");
         writeFormElements(request, pw);
         writePrologueScript(pw);
         pw.write("</html>");
@@ -211,6 +212,19 @@ public class PostbackResult extends StrutsResultSupport {
 
     public final void setPrependServletContext(boolean prependServletContext) {
         this.prependServletContext = prependServletContext;
+    }
+
+    /**
+     * Encodes special HTML characters to prevent injection in HTML attribute context.
+     */
+    private static String encodeHtml(String value) {
+        if (value == null) {
+            return "";
+        }
+        return value.replace("&", "&amp;")
+                     .replace("\"", "&quot;")
+                     .replace("<", "&lt;")
+                     .replace(">", "&gt;");
     }
 
     protected void writeFormElement(PrintWriter pw, String name, String[] values) throws UnsupportedEncodingException {

--- a/core/src/main/java/org/apache/struts2/result/PostbackResult.java
+++ b/core/src/main/java/org/apache/struts2/result/PostbackResult.java
@@ -23,6 +23,7 @@ import org.apache.struts2.ActionInvocation;
 import org.apache.struts2.inject.Inject;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.struts2.dispatcher.mapper.ActionMapper;
 import org.apache.struts2.dispatcher.mapper.ActionMapping;
 
@@ -104,8 +105,7 @@ public class PostbackResult extends StrutsResultSupport {
 
         // Render
         PrintWriter pw = new PrintWriter(response.getOutputStream());
-        String safeLocation = encodeHtml(finalLocation);
-        pw.write("<!DOCTYPE html><html><body><form action=\"" + safeLocation + "\" method=\"POST\">");
+        pw.write("<!DOCTYPE html><html><body><form action=\"" + StringEscapeUtils.escapeHtml4(finalLocation) + "\" method=\"POST\">");
         writeFormElements(request, pw);
         writePrologueScript(pw);
         pw.write("</html>");
@@ -212,19 +212,6 @@ public class PostbackResult extends StrutsResultSupport {
 
     public final void setPrependServletContext(boolean prependServletContext) {
         this.prependServletContext = prependServletContext;
-    }
-
-    /**
-     * Encodes special HTML characters to prevent injection in HTML attribute context.
-     */
-    private static String encodeHtml(String value) {
-        if (value == null) {
-            return "";
-        }
-        return value.replace("&", "&amp;")
-                     .replace("\"", "&quot;")
-                     .replace("<", "&lt;")
-                     .replace(">", "&gt;");
     }
 
     protected void writeFormElement(PrintWriter pw, String name, String[] values) throws UnsupportedEncodingException {

--- a/core/src/test/java/org/apache/struts2/result/PostbackResultTest.java
+++ b/core/src/test/java/org/apache/struts2/result/PostbackResultTest.java
@@ -145,5 +145,108 @@ public class PostbackResultTest extends StrutsInternalTestCase {
         }
     }
 
+    /**
+     * WW-5623: Verify that HTML special characters in finalLocation are properly
+     * escaped in the rendered form action attribute to prevent XSS.
+     */
+    public void testFormActionHtmlEscaping() throws Exception {
+        ActionContext context = ActionContext.getContext();
+        ValueStack stack = context.getValueStack();
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        context.put(ServletActionContext.HTTP_REQUEST, req);
+        context.put(ServletActionContext.HTTP_RESPONSE, res);
+
+        // Push an object with a malicious property onto the value stack
+        stack.push(new Object() {
+            public String getTargetUrl() {
+                return "/test\"onmouseover=\"alert(1)";
+            }
+        });
+
+        PostbackResult result = new PostbackResult();
+        result.setLocation("/redirect?url=${targetUrl}");
+        result.setPrependServletContext(false);
+
+        IMocksControl control = createControl();
+        ActionInvocation mockInvocation = control.createMock(ActionInvocation.class);
+        expect(mockInvocation.getInvocationContext()).andReturn(context).anyTimes();
+        expect(mockInvocation.getStack()).andReturn(stack).anyTimes();
+
+        control.replay();
+        result.setActionMapper(container.getInstance(ActionMapper.class));
+
+        // Call doExecute directly with a malicious location containing all critical chars
+        result.doExecute("/test\"onmouseover=\"alert(1)\"&param=<script>", mockInvocation);
+
+        String output = res.getContentAsString();
+
+        // The action attribute must contain escaped HTML entities
+        assertTrue("Double quote should be escaped to &quot;",
+                output.contains("action=\"/test&quot;onmouseover=&quot;alert(1)&quot;&amp;param=&lt;script&gt;\""));
+        // Must not contain unescaped double-quote that breaks out of the attribute
+        assertFalse("Raw double-quote must not appear in action value",
+                output.contains("action=\"/test\""));
+
+        control.verify();
+    }
+
+    /**
+     * WW-5623: Verify that each individual HTML special character is properly escaped.
+     */
+    public void testFormActionEscapesAllHtmlSpecialChars() throws Exception {
+        ActionContext context = ActionContext.getContext();
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        context.put(ServletActionContext.HTTP_REQUEST, req);
+        context.put(ServletActionContext.HTTP_RESPONSE, res);
+
+        IMocksControl control = createControl();
+        ActionInvocation mockInvocation = control.createMock(ActionInvocation.class);
+        expect(mockInvocation.getInvocationContext()).andReturn(context).anyTimes();
+
+        control.replay();
+
+        PostbackResult result = new PostbackResult();
+        result.setActionMapper(container.getInstance(ActionMapper.class));
+        result.doExecute("/path?a=1&b=2\"<>", mockInvocation);
+
+        String output = res.getContentAsString();
+
+        assertTrue("Ampersand should be escaped", output.contains("&amp;"));
+        assertTrue("Double-quote should be escaped", output.contains("&quot;"));
+        assertTrue("Less-than should be escaped", output.contains("&lt;"));
+        assertTrue("Greater-than should be escaped", output.contains("&gt;"));
+
+        control.verify();
+    }
+
+    /**
+     * WW-5623: Verify that a clean location (no special chars) renders unchanged.
+     */
+    public void testFormActionCleanLocationUnchanged() throws Exception {
+        ActionContext context = ActionContext.getContext();
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        context.put(ServletActionContext.HTTP_REQUEST, req);
+        context.put(ServletActionContext.HTTP_RESPONSE, res);
+
+        IMocksControl control = createControl();
+        ActionInvocation mockInvocation = control.createMock(ActionInvocation.class);
+        expect(mockInvocation.getInvocationContext()).andReturn(context).anyTimes();
+
+        control.replay();
+
+        PostbackResult result = new PostbackResult();
+        result.setActionMapper(container.getInstance(ActionMapper.class));
+        result.doExecute("/clean/path/action.do", mockInvocation);
+
+        String output = res.getContentAsString();
+
+        assertTrue("Clean location should render as-is in action attribute",
+                output.contains("action=\"/clean/path/action.do\""));
+
+        control.verify();
+    }
 
 }


### PR DESCRIPTION
## Summary

PostbackResult.doExecute() at line 107 embeds finalLocation into a form action attribute via raw string concatenation without HTML encoding. The response Content-Type is text/html (line 103). A double-quote character in the location breaks out of the attribute, enabling reflected XSS.

This is an encoding inconsistency: form field names and values at lines 218-219 ARE properly URL-encoded via URLEncoder.encode(), but the form action attribute was not encoded at all.

## Changes

- **PostbackResult.java**: Add encodeHtml() method to escape &, ", <, > in finalLocation before embedding in the HTML form tag. Consistent with the existing encoding approach for form field values.

## Impact

When a developer uses PostbackResult with an OGNL expression referencing a user-controllable property (a documented framework feature for dynamic routing), an attacker can inject arbitrary HTML attributes and elements via the form action attribute.

## Test

A PoC application with 5 test scenarios verifies the vulnerability and fix. Browser-based testing with Playwright confirms the XSS alert fires before the fix.
