### PR TITLE
Library updates for cve's, suppression cleanup and not fail github action job SonarCloud if SONARCLOUD_TOKEN not found (summary report instead).

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -20,8 +20,11 @@ on:
   push:
     branches:
       - 'main'
+      - 'develop'
       - 'release/*'
       - 'support/*'
+  workflow_dispatch:
+  workflow_call:
 
 permissions: read-all
 
@@ -31,9 +34,10 @@ env:
 
 jobs:
   build:
-    name: Build and Test (JDK ${{ matrix.java }})${{ matrix.profile == '-Pjakartaee11' && ' with Jakarta EE 11' || matrix.profile }}
+    name: Build and Test (JDK ${{ matrix.java }})${{ matrix.profile == '-Pjakartaee11' && ' (Jakarta EE 11 + Spring 7)' || matrix.profile }}
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         include:
           - java: '17'
@@ -44,6 +48,8 @@ jobs:
             profile: '-Pjakartaee11'
           - java: '25'
             profile: ''
+          - java: '25'
+            profile: '-Pjakartaee11'
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -53,5 +59,16 @@ jobs:
           distribution: temurin
           java-version: ${{ matrix.java }}
           cache: 'maven'
-      - name: Maven Verify on Java ${{ matrix.java }}${{ matrix.profile == '-Pjakartaee11' && ' (Jakarta EE 11)' || matrix.profile }}
+      - name: Maven Verify on Java ${{ matrix.java }}${{ matrix.profile == '-Pjakartaee11' && ' (Jakarta EE 11 + Spring 7)' || matrix.profile }}
         run: mvn -B -V -DskipAssembly verify ${{ matrix.profile }} --no-transfer-progress
+
+      - name: Test Summary ${{ matrix.java }} ${{ matrix.profile }}
+        uses: mikepenz/action-junit-report@d9f48fc87bc235f7e214acf696ca5abc0a986f16 #v6.4.2
+        continue-on-error: true
+        if: always()
+        with:
+          annotate_only: true # forked repo cannot write to checks so just do annotations
+          report_paths: |
+            **/surefire-reports/TEST-*.xml
+            **/failsafe-reports/TEST-*.xml
+

--- a/.github/workflows/owasp.yml
+++ b/.github/workflows/owasp.yml
@@ -1,0 +1,91 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: OWASP checkup
+
+on:
+  pull_request:
+  push:
+    branches:
+      - 'main'
+      - 'develop'
+      - 'release/*'
+      - 'support/*'
+  workflow_dispatch:
+  workflow_call:
+
+permissions: read-all
+
+env:
+  MAVEN_OPTS: -Xmx2048m -Xms1024m
+  LANG: en_US.utf8
+
+jobs:
+
+
+  owasp:
+    name: OWASP
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+      - name: Setup Java 25
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 25
+          cache: 'maven'
+
+      - name: Cache NVD Database
+        id: cache-nvd
+        uses: actions/cache/restore@v6
+        with:
+          path: ~/.m2/repository/org/owasp/dependency-check-data
+          key: nvd-cache-${{ runner.os }}-owasp-${{ github.run_id }}
+          restore-keys: |
+            nvd-cache-${{ runner.os }}-owasp-
+            nvd-cache-${{ runner.os }}-
+
+      - name: OWASP Dependency check update cache
+        run:  mvn -N -V -DskipAssembly -Dmaven.test.skip=true -Powasp-nvd-mirror -Pdependency-update-only --no-transfer-progress
+        env:
+          NVD_NIST_APIKEY: ${{ secrets.NVD_NIST_APIKEY}}
+
+      - name: Cache NVD Database
+        uses: actions/cache/save@v6
+        if: ${{ always() }}
+        with:
+          path: ~/.m2/repository/org/owasp/dependency-check-data
+          key: nvd-cache-${{ runner.os }}-owasp-${{ github.run_id }}
+
+      - name: OWASP check (Without running tests)
+        run: mvn -B org.owasp:dependency-check-maven:aggregate -Pdependency-check -Pjakartaee11 --no-transfer-progress
+
+      - name: Upload Dependency Check reports
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: dependency-check
+          path: target/dependency-check*
+
+      - name: Add OWASP summary
+        if: always()
+        run: |
+          {
+            echo "## OWASP Dependency Check"
+            echo ""
+            echo "The HTML report has been uploaded as the **dependency-check** artifact."
+            echo "Download it from the Artifacts section of this workflow run."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/owasp.yml
+++ b/.github/workflows/owasp.yml
@@ -23,8 +23,7 @@ on:
       - 'develop'
       - 'release/*'
       - 'support/*'
-  workflow_dispatch:
-  workflow_call:
+  workflow_dispatch: #Allow manual triggers
 
 permissions: read-all
 
@@ -38,6 +37,8 @@ jobs:
   owasp:
     name: OWASP
     runs-on: ubuntu-latest
+    env:
+      HAVE_NIST_NVD_API_KEY: ${{ secrets.NIST_NVD_API_KEY != '' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -58,10 +59,15 @@ jobs:
             nvd-cache-${{ runner.os }}-owasp-
             nvd-cache-${{ runner.os }}-
 
-      - name: OWASP Dependency check update cache
-        run:  mvn -N -V -DskipAssembly -Dmaven.test.skip=true -Powasp-nvd-mirror -Pdependency-update-only --no-transfer-progress
+      - name: OWASP Dependency check update cache via NIST_NVD_API_KEY
+        if: ${{ env.HAVE_NIST_NVD_API_KEY == 'true' }}
+        run:  mvn -N -V -DskipAssembly -Dmaven.test.skip=true -Powasp-nvd-api -Pdependency-update-only --no-transfer-progress
         env:
-          NVD_NIST_APIKEY: ${{ secrets.NVD_NIST_APIKEY}}
+          NIST_NVD_API_KEY: ${{ secrets.NIST_NVD_API_KEY}}
+
+      - name: OWASP Dependency check update cache via Mirror
+        if: ${{ env.HAVE_NIST_NVD_API_KEY == 'false' }}
+        run:  mvn -N -V -DskipAssembly -Dmaven.test.skip=true -Powasp-nvd-mirror -Pdependency-update-only --no-transfer-progress
 
       - name: Cache NVD Database
         uses: actions/cache/save@v6

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -26,6 +26,7 @@ permissions: read-all
 env:
   MAVEN_OPTS: -Xmx2048m -Xms1024m
   LANG: en_US.utf8
+  HAVE_SONARCLOUD_TOKEN: ${{ secrets.SONARCLOUD_TOKEN != '' }}
 
 jobs:
   sonarcloud:
@@ -41,7 +42,14 @@ jobs:
           distribution: temurin
           java-version: 21
           cache: 'maven'
-      - env:
+      - name: SonarCloud Scan
+        if: ${{ env.HAVE_SONARCLOUD_TOKEN == 'true' }}
+        env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
         run: ./mvnw -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Pcoverage -DskipAssembly
+      - name: SonarCloud Scan -- SKIPPED
+        if: ${{ env.HAVE_SONARCLOUD_TOKEN != 'true' }}
+        run: |
+          echo "### SonarCloud not configured" >> $GITHUB_STEP_SUMMARY
+          echo "secrets.SONARCLOUD_TOKEN not existing, cannot push coverage checks" >> $GITHUB_STEP_SUMMARY

--- a/plugins/jasperreports/pom.xml
+++ b/plugins/jasperreports/pom.xml
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>net.sf.jasperreports</groupId>
             <artifactId>jasperreports</artifactId>
-            <version>6.21.3</version>
+            <version>6.21.5</version>
             <scope>provided</scope>
             <exclusions>
                 <!-- not necessary to compile and it force dependency convergence issues -->

--- a/plugins/spring/README.md
+++ b/plugins/spring/README.md
@@ -4,3 +4,11 @@ You will find more details in [documentation](https://struts.apache.org/plugins/
 
 ## Installation
 Just drop this plugin JAR into `WEB-INF/lib` folder or add it as a Maven dependency.
+
+
+## Struts & Spring Compatibility Matrix
+
+| Struts Plugin Version | Compatible Spring Version  | Spring OSS End of Life (EOL)                |
+|:----------------------|:---------------------------|:--------------------------------------------|
+| **7.1.1**             | 6.2.x                      | 2026-06 (Commercial 2032-06-30)             |
+| **7.1.1**             | 7.0.8 (Jakarta EE 11 only) | 2027-07 (Commercial 2028-07-31) |

--- a/pom.xml
+++ b/pom.xml
@@ -208,11 +208,11 @@
             </build>
         </profile>
         <profile>
-        <!-- -DNVD_NIST_APIKEY=${yourkey} so that owasp runs via api -->
+        <!-- -DNIST_NVD_API_KEY=${yourkey} so that owasp runs via api -->
         <id>owasp-nvd-api</id>
         <activation>
             <property>
-                <name>NVD_NIST_APIKEY</name>
+                <name>NIST_NVD_API_KEY</name>
             </property>
         </activation>
         <build>
@@ -225,7 +225,7 @@
                         <suppressionFiles>owasp-suppressions.xml</suppressionFiles>
                         <failBuildOnCVSS>0</failBuildOnCVSS>
                         <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
-                        <nvdApiKey>${NVD_NIST_APIKEY}</nvdApiKey>
+                        <nvdApiKey>${NIST_NVD_API_KEY}</nvdApiKey>
                         <skip>${owasp.skip}</skip>
                     </configuration>
                 </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,9 @@
         <!-- Maven plugin -->
         <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
         <maven-surefire-plugin.version>3.5.6</maven-surefire-plugin.version>
-        
+        <dependencycheck.version>12.2.2</dependencycheck.version>
+        <owasp.skip>false</owasp.skip>
+
         <!-- dependency versions in alphanumeric order -->
         <asm.version>9.10.1</asm.version>
         <byte-buddy.version>1.18.11</byte-buddy.version>
@@ -125,7 +127,7 @@
         <log4j2.version>2.26.1</log4j2.version>
         <mockito.version>5.23.0</mockito.version>
         <ognl.version>3.4.11</ognl.version>
-        <spring.version>6.2.12</spring.version>
+        <spring.version>6.2.19</spring.version>
         <struts-annotations.version>2.0</struts-annotations.version>
         <velocity-tools.version>3.1</velocity-tools.version>
         <webjars-bootstrap.version>5.3.7</webjars-bootstrap.version>
@@ -162,8 +164,8 @@
         <profile>
             <id>jakartaee11</id>
             <properties>
-                <jakarta-ee.version>11.0.0-M5</jakarta-ee.version>
-                <spring.version>7.0.5</spring.version>
+                <jakarta-ee.version>11.0.0</jakarta-ee.version>
+                <spring.version>7.0.8</spring.version>
             </properties>
         </profile>
         <profile>
@@ -173,14 +175,80 @@
                     <plugin>
                         <groupId>org.owasp</groupId>
                         <artifactId>dependency-check-maven</artifactId>
+                        <version>${dependencycheck.version}</version>
                         <executions>
                             <execution>
-                                <phase>verify</phase>
+                                <phase>initialize</phase>
                                 <goals>
                                     <goal>check</goal>
                                 </goals>
                             </execution>
                         </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>dependency-update-only</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.owasp</groupId>
+                        <artifactId>dependency-check-maven</artifactId>
+                        <version>${dependencycheck.version}</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>update-only</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+        <!-- -DNVD_NIST_APIKEY=${yourkey} so that owasp runs via api -->
+        <id>owasp-nvd-api</id>
+        <activation>
+            <property>
+                <name>NVD_NIST_APIKEY</name>
+            </property>
+        </activation>
+        <build>
+            <plugins>
+                <plugin>
+                    <groupId>org.owasp</groupId>
+                    <artifactId>dependency-check-maven</artifactId>
+                    <version>${dependencycheck.version}</version>
+                    <configuration>
+                        <suppressionFiles>owasp-suppressions.xml</suppressionFiles>
+                        <failBuildOnCVSS>0</failBuildOnCVSS>
+                        <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
+                        <nvdApiKey>${NVD_NIST_APIKEY}</nvdApiKey>
+                        <skip>${owasp.skip}</skip>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </build>
+    </profile>
+
+        <profile>
+            <!-- -Powasp-nvd-mirror so that owasp runs via mirror -->
+            <id>owasp-nvd-mirror</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.owasp</groupId>
+                        <artifactId>dependency-check-maven</artifactId>
+                        <version>${dependencycheck.version}</version>
+                        <configuration>
+                            <suppressionFiles>owasp-suppressions.xml</suppressionFiles>
+                            <failBuildOnCVSS>0</failBuildOnCVSS>
+                            <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
+                            <nvdDatafeedUrl>https://dependency-check.github.io/DependencyCheck_Builder/nvd_cache/nvdcve-{0}.json.gz</nvdDatafeedUrl>
+                            <skip>${owasp.skip}</skip>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/src/etc/project-suppression.xml
+++ b/src/etc/project-suppression.xml
@@ -19,167 +19,55 @@
 -->
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
     <suppress>
-        <notes><![CDATA[file name: struts-core-1.3.8.jar]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.apache\.struts/struts\-core@.*$</packageUrl>
+        <notes><![CDATA[
+    file name: jasperreports-*.jar
+    https://community.jaspersoft.com/knowledgebase/faq/update-details-about-the-java-vulnerability-r4897/
+    One way to prevent such an attack would be to make sure the parent Java application runs on Java 17 or later, where this type of attack is blocked by some changes made to the Java platform itself.
+    ]]></notes>
+        <cve>CVE-2025-10492</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[false positive due to naming to close to apache tiles
+        cpe:2.3:a:apache:tiles:*:*:*:*:*:*:*:* versions from (including) 2.0]]></notes>
+        <cve>CVE-2023-49735</cve>
         <cpe>cpe:/a:apache:struts</cpe>
     </suppress>
     <suppress>
-        <notes><![CDATA[file name: struts-core-1.3.8.jar]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.apache\.struts/struts\-core@.*$</packageUrl>
-        <vulnerabilityName>CVE-2011-5057</vulnerabilityName>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[file name: struts-core-1.3.8.jar]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.apache\.struts/struts\-core@.*$</packageUrl>
-        <vulnerabilityName>CVE-2012-0391</vulnerabilityName>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[file name: struts-core-1.3.8.jar]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.apache\.struts/struts\-core@.*$</packageUrl>
-        <vulnerabilityName>CVE-2012-0392</vulnerabilityName>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[file name: struts-core-1.3.8.jar]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.apache\.struts/struts\-core@.*$</packageUrl>
-        <vulnerabilityName>CVE-2012-0393</vulnerabilityName>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[file name: struts-core-1.3.8.jar]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.apache\.struts/struts\-core@.*$</packageUrl>
-        <vulnerabilityName>CVE-2012-0394</vulnerabilityName>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[file name: struts-core-1.3.8.jar]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.apache\.struts/struts\-core@.*$</packageUrl>
-        <vulnerabilityName>CVE-2012-0838</vulnerabilityName>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[file name: struts-core-1.3.8.jar]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.apache\.struts/struts\-core@.*$</packageUrl>
-        <vulnerabilityName>CVE-2013-1965</vulnerabilityName>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[file name: struts-core-1.3.8.jar]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.apache\.struts/struts\-core@.*$</packageUrl>
-        <vulnerabilityName>CVE-2013-1966</vulnerabilityName>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[file name: struts-core-1.3.8.jar]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.apache\.struts/struts\-core@.*$</packageUrl>
-        <vulnerabilityName>CVE-2013-2115</vulnerabilityName>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[file name: struts-core-1.3.8.jar]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.apache\.struts/struts\-core@.*$</packageUrl>
-        <vulnerabilityName>CVE-2013-2134</vulnerabilityName>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[file name: struts-core-1.3.8.jar]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.apache\.struts/struts\-core@.*$</packageUrl>
-        <vulnerabilityName>CVE-2013-2135</vulnerabilityName>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[file name: struts-core-1.3.8.jar]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.apache\.struts/struts\-core@.*$</packageUrl>
-        <vulnerabilityName>CVE-2014-0094</vulnerabilityName>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[file name: struts-core-1.3.8.jar]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.apache\.struts/struts\-core@.*$</packageUrl>
-        <vulnerabilityName>CVE-2014-0113</vulnerabilityName>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[file name: struts-core-1.3.8.jar]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.apache\.struts/struts\-core@.*$</packageUrl>
-        <vulnerabilityName>CVE-2015-5169</vulnerabilityName>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[file name: struts-core-1.3.8.jar]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.apache\.struts/struts\-core@.*$</packageUrl>
-        <vulnerabilityName>CVE-2016-0785</vulnerabilityName>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[file name: struts-core-1.3.8.jar]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.apache\.struts/struts\-core@.*$</packageUrl>
-        <vulnerabilityName>CVE-2016-4003</vulnerabilityName>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[file name: struts-annotations-1.0.6.jar]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.apache\.struts/struts\-annotations@.*$</packageUrl>
-        <cpe>cpe:/a:apache:struts</cpe>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[file name: struts-tiles-1.3.8.jar]]></notes>
-        <gav regex="true">^org\.apache\.struts:struts\-tiles\:1\.3\.8.*$</gav>
-        <cpe>cpe:/a:apache:struts</cpe>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[file name: struts-taglib-1.3.8.jar]]></notes>
-        <gav regex="true">^org\.apache\.struts:struts\-taglib\:1\.3\.8.*$</gav>
-        <cpe>cpe:/a:apache:struts</cpe>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[file name: dom4j-1.1.jar]]></notes>
-        <packageUrl regex="true">^pkg:maven/dom4j/dom4j@.*$</packageUrl>
-        <vulnerabilityName>CVE-2018-1000632</vulnerabilityName>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[file name: bsh-2.0b4.jar]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.beanshell/bsh@.*$</packageUrl>
-        <vulnerabilityName>CVE-2016-2510</vulnerabilityName>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[ file name: plexus-utils-1.2.jar]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.codehaus\.plexus/plexus\-utils@.*$</packageUrl>
-        <cpe>cpe:/a:plexus-utils_project:plexus-utils</cpe>
-        <cve>CVE-2022-4244</cve>
-        <cve>CVE-2022-4245</cve>
-        <cve>CVE-2017-1000487</cve>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[ file name: plexus-container-default-1.0-alpha-10.jar]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.codehaus\.plexus\/plexus\-container\-default@.*$</packageUrl>
-        <cpe>cpe:/a:plexus-utils_project:plexus-utils</cpe>
-        <cve>CVE-2022-4244</cve>
-        <cve>CVE-2022-4245</cve>
-    </suppress>
-    <!-- TestNG -->
-    <suppress>
-        <notes><![CDATA[file name: guava-19.0.jar]]></notes>
-        <packageUrl regex="true">^pkg:maven/com\.google\.guava/guava@.*$</packageUrl>
-        <cve>CVE-2018-10237</cve>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[file name: snakeyaml-1.21.jar]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml@.*$</packageUrl>
-        <cve>CVE-2017-18640</cve>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[file name: testng-7.1.0.jar: jquery-3.4.1.min.js]]></notes>
+        <notes><![CDATA[apps showcase demos with jquery-2.1.4.min.js]]></notes>
         <packageUrl regex="true">^pkg:javascript/jquery@.*$</packageUrl>
         <cve>CVE-2020-11022</cve>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[file name: testng-7.1.0.jar: jquery-3.4.1.min.js]]></notes>
-        <packageUrl regex="true">^pkg:javascript/jquery@.*$</packageUrl>
         <cve>CVE-2020-11023</cve>
+        <cve>CVE-2015-9251</cve>
+        <cve>CVE-2019-11358</cve>
+        <vulnerabilityName>jquery issue: 11974</vulnerabilityName>
+        <vulnerabilityName>jquery issue: 162</vulnerabilityName>
     </suppress>
     <suppress>
-        <notes><![CDATA[file name: testng-7.5.jar]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.testng/testng@.*$</packageUrl>
-        <cve>CVE-2022-4065</cve>
+        <notes><![CDATA[apps showcase demos with Bootstrap v3.3.4]]></notes>
+<!--        <packageUrl regex="true">^pkg:javascript/bootstrap@.*$</packageUrl>-->
+        <sha1>253711c6d825de55a8360552573be950da180614</sha1>
+        <cve>CVE-2016-10735</cve>
+        <cve>CVE-2018-14040</cve>
+        <cve>CVE-2018-14041</cve>
+        <cve>CVE-2018-14042</cve>
+        <cve>CVE-2018-20676</cve>
+        <cve>CVE-2018-20677</cve>
+        <cve>CVE-2019-8331</cve>
+        <cve>CVE-2024-6485</cve>
+        <vulnerabilityName>Bootstrap before 4.0.0 is end-of-life and no longer maintained.</vulnerabilityName>
     </suppress>
     <suppress>
-        <notes><![CDATA[file name: spring-core-4.3.30.RELEASE.jar, spring-aop-4.3.30.RELEASE.jar]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-.*@.*$</packageUrl>
-        <cve>CVE-2022-22965</cve>
-        <cve>CVE-2022-22950</cve>
-        <cve>CVE-2022-22968</cve>
-        <cve>CVE-2022-22970</cve>
+        <notes><![CDATA[
+    file name: httpcore-4.4.16.jar
+    ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.httpcomponents/httpcore@.*$</packageUrl>
+        <cve>CVE-2026-54399</cve>
     </suppress>
     <suppress>
-        <notes><![CDATA[file name: spring-web-5.3.23.jar]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-web@.*$</packageUrl>
-        <cve>CVE-2016-1000027</cve>
+        <notes><![CDATA[
+    file name: httpcore-4.4.16.jar
+    ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.httpcomponents/httpcore@.*$</packageUrl>
+        <cve>CVE-2026-54428</cve>
     </suppress>
 </suppressions>


### PR DESCRIPTION
[Library updates:](https://github.com/apache/struts/commit/4322579a011b128225dc092d660b562ddf328112) 

* profile jakartaee11: jakarta-ee from 11.0.0-M5 to 11.0.0
* Spring Version from 6.2.12 to 7.0.7 **(we are 2 months off OSS EOL for 6.2.x)**
* struts2-jasperreports-plugin: jasperreports from 6.21.3 to 6.21.5
* struts2-jasperreports7-plugin: jasperreports from 7.0.4 to 7.0.6
* profile jakartaee11: jakarta-ee from 11.0.0-M5 to 11.0.0

Dependancy suppression cleanup

[Sonar github workflow to be skipped if secret is not found](https://github.com/apache/struts/commit/1094328ec3de2eeb35de269a92d36aef48e28f19)

---

## Struts & Spring Compatibility Matrix

| Struts Plugin Version | Compatible Spring Version  | Spring OSS End of Life (EOL) |
|:----------------------|:---------------------------|:-----------------------------|
| **7.1.1**             | 6.2.x                      | 2026-06                      |
| **7.1.1**             | 7.0.7 (Jakarta EE 11 only) | 2027-06                      |