### PR TITLE
WW-5627 Gate CookieInterceptor through ParameterAuthorizer

### DIFF
--- a/core/src/main/java/org/apache/struts2/StrutsConstants.java
+++ b/core/src/main/java/org/apache/struts2/StrutsConstants.java
@@ -559,6 +559,14 @@ public final class StrutsConstants {
     public static final String STRUTS_PARAMETER_AUTHORIZER = "struts.parameterAuthorizer";
 
     /**
+     * The {@link org.apache.struts2.interceptor.parameter.ParameterAllowlister} implementation class.
+     * Override to provide a custom allowlister for non-OGNL parameter targets.
+     *
+     * @since 7.2.0
+     */
+    public static final String STRUTS_PARAMETER_ALLOWLISTER = "struts.parameterAllowlister";
+
+    /**
      * Enables evaluation of OGNL expressions
      *
      * @since 6.0.0

--- a/core/src/main/java/org/apache/struts2/config/StrutsBeanSelectionProvider.java
+++ b/core/src/main/java/org/apache/struts2/config/StrutsBeanSelectionProvider.java
@@ -73,6 +73,7 @@ import org.apache.struts2.url.UrlDecoder;
 import org.apache.struts2.url.UrlEncoder;
 import org.apache.struts2.util.ContentTypeMatcher;
 import org.apache.struts2.util.PatternMatcher;
+import org.apache.struts2.interceptor.parameter.ParameterAllowlister;
 import org.apache.struts2.interceptor.parameter.ParameterAuthorizer;
 import org.apache.struts2.util.ProxyService;
 import org.apache.struts2.util.TextParser;
@@ -448,6 +449,7 @@ public class StrutsBeanSelectionProvider extends AbstractBeanSelectionProvider {
         alias(ProxyCacheFactory.class, StrutsConstants.STRUTS_PROXY_CACHE_FACTORY, builder, props, Scope.SINGLETON);
         alias(ProxyService.class, StrutsConstants.STRUTS_PROXYSERVICE, builder, props, Scope.SINGLETON);
         alias(ParameterAuthorizer.class, StrutsConstants.STRUTS_PARAMETER_AUTHORIZER, builder, props, Scope.SINGLETON);
+        alias(ParameterAllowlister.class, StrutsConstants.STRUTS_PARAMETER_ALLOWLISTER, builder, props, Scope.SINGLETON);
 
         alias(SecurityMemberAccess.class, StrutsConstants.STRUTS_MEMBER_ACCESS, builder, props, Scope.PROTOTYPE);
         alias(OgnlGuard.class, StrutsConstants.STRUTS_OGNL_GUARD, builder, props, Scope.SINGLETON);

--- a/core/src/main/java/org/apache/struts2/config/impl/DefaultConfiguration.java
+++ b/core/src/main/java/org/apache/struts2/config/impl/DefaultConfiguration.java
@@ -92,6 +92,8 @@ import org.apache.struts2.ognl.SecurityMemberAccess;
 import org.apache.struts2.ognl.accessor.CompoundRootAccessor;
 import org.apache.struts2.ognl.accessor.RootAccessor;
 import org.apache.struts2.ognl.accessor.XWorkMethodAccessor;
+import org.apache.struts2.interceptor.parameter.OgnlParameterAllowlister;
+import org.apache.struts2.interceptor.parameter.ParameterAllowlister;
 import org.apache.struts2.interceptor.parameter.StrutsParameterAuthorizer;
 import org.apache.struts2.interceptor.parameter.ParameterAuthorizer;
 import org.apache.struts2.util.StrutsProxyService;
@@ -409,6 +411,7 @@ public class DefaultConfiguration implements Configuration {
                 .factory(ProxyCacheFactory.class, StrutsProxyCacheFactory.class, Scope.SINGLETON)
                 .factory(ProxyService.class, StrutsProxyService.class, Scope.SINGLETON)
                 .factory(ParameterAuthorizer.class, StrutsParameterAuthorizer.class, Scope.SINGLETON)
+                .factory(ParameterAllowlister.class, OgnlParameterAllowlister.class, Scope.SINGLETON)
                 .factory(OgnlUtil.class, Scope.SINGLETON)
                 .factory(SecurityMemberAccess.class, Scope.PROTOTYPE)
                 .factory(OgnlGuard.class, StrutsOgnlGuard.class, Scope.SINGLETON)

--- a/core/src/main/java/org/apache/struts2/interceptor/CookieInterceptor.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/CookieInterceptor.java
@@ -26,6 +26,8 @@ import org.apache.struts2.ActionInvocation;
 import org.apache.struts2.ServletActionContext;
 import org.apache.struts2.action.CookiesAware;
 import org.apache.struts2.inject.Inject;
+import org.apache.struts2.interceptor.parameter.ParameterAllowlister;
+import org.apache.struts2.interceptor.parameter.ParameterAuthorizer;
 import org.apache.struts2.security.AcceptedPatternsChecker;
 import org.apache.struts2.security.ExcludedPatternsChecker;
 import org.apache.struts2.util.TextParseUtil;
@@ -187,6 +189,8 @@ public class CookieInterceptor extends AbstractInterceptor {
 
     private ExcludedPatternsChecker excludedPatternsChecker;
     private AcceptedPatternsChecker acceptedPatternsChecker;
+    private ParameterAuthorizer parameterAuthorizer;
+    private ParameterAllowlister parameterAllowlister;
 
     @Inject
     public void setExcludedPatternsChecker(ExcludedPatternsChecker excludedPatternsChecker) {
@@ -197,6 +201,16 @@ public class CookieInterceptor extends AbstractInterceptor {
     public void setAcceptedPatternsChecker(AcceptedPatternsChecker acceptedPatternsChecker) {
         this.acceptedPatternsChecker = acceptedPatternsChecker;
         this.acceptedPatternsChecker.setAcceptedPatterns(ACCEPTED_PATTERN);
+    }
+
+    @Inject
+    public void setParameterAuthorizer(ParameterAuthorizer parameterAuthorizer) {
+        this.parameterAuthorizer = parameterAuthorizer;
+    }
+
+    @Inject
+    public void setParameterAllowlister(ParameterAllowlister parameterAllowlister) {
+        this.parameterAllowlister = parameterAllowlister;
     }
 
     /**
@@ -234,6 +248,8 @@ public class CookieInterceptor extends AbstractInterceptor {
     public String intercept(ActionInvocation invocation) throws Exception {
         LOG.debug("start interception");
 
+        final Object action = invocation.getAction();
+
         // contains selected cookies
         final Map<String, String> cookiesMap = new LinkedHashMap<>();
 
@@ -248,9 +264,9 @@ public class CookieInterceptor extends AbstractInterceptor {
                 if (isAcceptableName(name)) {
                     if (cookiesNameSet.contains("*")) {
                         LOG.debug("Contains cookie name [*] in configured cookies name set, cookie with name [{}] with value [{}] will be injected", name, value);
-                        populateCookieValueIntoStack(name, value, cookiesMap, stack);
+                        populateCookieValueIntoStack(name, value, cookiesMap, stack, action);
                     } else if (cookiesNameSet.contains(cookie.getName())) {
-                        populateCookieValueIntoStack(name, value, cookiesMap, stack);
+                        populateCookieValueIntoStack(name, value, cookiesMap, stack, action);
                     }
                 } else {
                     LOG.warn("Cookie name [{}] with value [{}] was rejected!", name, value);
@@ -259,7 +275,7 @@ public class CookieInterceptor extends AbstractInterceptor {
         }
 
         // inject the cookiesMap, even if we don't have any cookies
-        injectIntoCookiesAwareAction(invocation.getAction(), cookiesMap);
+        injectIntoCookiesAwareAction(action, cookiesMap);
 
         return invocation.invoke();
     }
@@ -315,6 +331,29 @@ public class CookieInterceptor extends AbstractInterceptor {
     }
 
     /**
+     * Authorizes the cookie against {@link ParameterAuthorizer}, primes OGNL allowlist for any nested path via
+     * {@link ParameterAllowlister}, then delegates to the legacy {@link #populateCookieValueIntoStack(String, String,
+     * Map, ValueStack)} hook so existing subclass overrides continue to participate. Override this method to customize
+     * the authorization behavior itself.
+     *
+     * @param cookieName  cookie name (potentially an OGNL path; {@code ACCEPTED_PATTERN} restricts the character set)
+     * @param cookieValue cookie value
+     * @param cookiesMap  map of cookies populated for {@link org.apache.struts2.action.CookiesAware}
+     * @param stack       current request value stack
+     * @param action      the action instance from {@link ActionInvocation#getAction()}; used for {@code @StrutsParameter} target resolution
+     * @since 7.2.0
+     */
+    protected void populateCookieValueIntoStack(String cookieName, String cookieValue, Map<String, String> cookiesMap, ValueStack stack, Object action) {
+        Object target = parameterAuthorizer.resolveTarget(action);
+        if (!parameterAuthorizer.isAuthorized(cookieName, target, action)) {
+            LOG.debug("Cookie [{}] rejected by @StrutsParameter authorization on target [{}]", cookieName, target.getClass().getSimpleName());
+            return;
+        }
+        parameterAllowlister.allowlistAuthorizedPath(cookieName, target);
+        populateCookieValueIntoStack(cookieName, cookieValue, cookiesMap, stack);
+    }
+
+    /**
      * Hook that populate cookie value into value stack (hence the action)
      * if the criteria is satisfied (if the cookie value matches with those configured).
      *
@@ -322,7 +361,12 @@ public class CookieInterceptor extends AbstractInterceptor {
      * @param cookieValue cookie value
      * @param cookiesMap map of cookies
      * @param stack value stack
+     * @deprecated since 7.2.0. Override
+     * {@link #populateCookieValueIntoStack(String, String, Map, ValueStack, Object)} instead so cookie writes are
+     * authorized by {@link ParameterAuthorizer}. The default 5-arg implementation calls this method after the
+     * authorization gate, so existing overrides continue to receive only authorized cookies.
      */
+    @Deprecated(since = "7.2.0")
     protected void populateCookieValueIntoStack(String cookieName, String cookieValue, Map<String, String> cookiesMap, ValueStack stack) {
         if (cookiesValueSet.isEmpty() || cookiesValueSet.contains("*")) {
             // If the interceptor is configured to accept any cookie value

--- a/core/src/main/java/org/apache/struts2/interceptor/CookieInterceptor.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/CookieInterceptor.java
@@ -101,8 +101,16 @@ import java.util.Set;
  *
  * <ul>
  *     <li>
- *         populateCookieValueIntoStack - this method will decide if this cookie value is qualified
- *         to be populated into the value stack (hence into the action itself)
+ *         populateCookieValueIntoStack(name, value, map, stack, action) - the preferred extension point
+ *         since 7.2.0. The default implementation gates the cookie write through
+ *         {@link org.apache.struts2.interceptor.parameter.ParameterAuthorizer} and primes the OGNL allowlist via
+ *         {@link org.apache.struts2.interceptor.parameter.ParameterAllowlister} before delegating to the legacy
+ *         4-arg {@code populateCookieValueIntoStack}. Override here to customize the authorization behavior itself.
+ *     </li>
+ *     <li>
+ *         populateCookieValueIntoStack(name, value, map, stack) - <em>deprecated since 7.2.0</em>. The legacy
+ *         hook that performs the actual {@code stack.setValue}. Existing overrides continue to work and
+ *         automatically receive only authorized cookies via the 5-arg default.
  *     </li>
  *     <li>
  *         injectIntoCookiesAwareAction - this method will inject selected cookies (as a java.util.Map)

--- a/core/src/main/java/org/apache/struts2/interceptor/CookieInterceptor.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/CookieInterceptor.java
@@ -197,8 +197,8 @@ public class CookieInterceptor extends AbstractInterceptor {
 
     private ExcludedPatternsChecker excludedPatternsChecker;
     private AcceptedPatternsChecker acceptedPatternsChecker;
-    private ParameterAuthorizer parameterAuthorizer;
-    private ParameterAllowlister parameterAllowlister;
+    private transient ParameterAuthorizer parameterAuthorizer;
+    private transient ParameterAllowlister parameterAllowlister;
 
     @Inject
     public void setExcludedPatternsChecker(ExcludedPatternsChecker excludedPatternsChecker) {
@@ -351,6 +351,7 @@ public class CookieInterceptor extends AbstractInterceptor {
      * @param action      the action instance from {@link ActionInvocation#getAction()}; used for {@code @StrutsParameter} target resolution
      * @since 7.2.0
      */
+    @SuppressWarnings("deprecation") // intentional: delegating to the deprecated 4-arg form is the contract that lets existing subclass overrides participate
     protected void populateCookieValueIntoStack(String cookieName, String cookieValue, Map<String, String> cookiesMap, ValueStack stack, Object action) {
         Object target = parameterAuthorizer.resolveTarget(action);
         if (!parameterAuthorizer.isAuthorized(cookieName, target, action)) {

--- a/core/src/main/java/org/apache/struts2/interceptor/CookieInterceptor.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/CookieInterceptor.java
@@ -358,7 +358,7 @@ public class CookieInterceptor extends AbstractInterceptor {
             LOG.debug("Cookie [{}] rejected by @StrutsParameter authorization on target [{}]", cookieName, target.getClass().getSimpleName());
             return;
         }
-        parameterAllowlister.allowlistAuthorizedPath(cookieName, target);
+        parameterAllowlister.primeAllowlistForPath(cookieName, target);
         populateCookieValueIntoStack(cookieName, cookieValue, cookiesMap, stack);
     }
 

--- a/core/src/main/java/org/apache/struts2/interceptor/parameter/OgnlParameterAllowlister.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/parameter/OgnlParameterAllowlister.java
@@ -42,11 +42,18 @@ import static org.apache.struts2.security.DefaultAcceptedPatternsChecker.NESTING
 import static org.apache.struts2.security.DefaultAcceptedPatternsChecker.NESTING_CHARS_STR;
 
 /**
- * Default {@link ParameterAllowlister} that primes OGNL {@link ThreadAllowlist} for nested-path writes. Logic is
+ * Default {@link ParameterAllowlister}. Registers the root property's class (and generic type args for {@code depth >= 2})
+ * into the OGNL {@link ThreadAllowlist} so OGNL may introspect and traverse a nested path on the value stack. Logic is
  * extracted verbatim from {@code ParametersInterceptor.performOgnlAllowlisting} so the OGNL parameter and cookie
  * channels share a single implementation.
  *
- * <p>No-ops for depth-0 paths — root-level setters do not need allowlisting.</p>
+ * <p>No-ops when:
+ * <ul>
+ *   <li>{@code paramDepth == 0} — shallow setter; OGNL does not need to traverse</li>
+ *   <li>the root property has no {@code @StrutsParameter} annotation reachable via {@link java.beans.PropertyDescriptor}
+ *       or as a public field (e.g. a {@code ModelDriven} model whose properties are not individually annotated). A
+ *       {@code LOG.debug} surfaces this case so the gap between authorization and OGNL traversal is observable.</li>
+ * </ul>
  *
  * @since 7.2.0
  */
@@ -74,7 +81,7 @@ public class OgnlParameterAllowlister implements ParameterAllowlister {
     }
 
     @Override
-    public void allowlistAuthorizedPath(String parameterName, Object target) {
+    public void primeAllowlistForPath(String parameterName, Object target) {
         if (parameterName == null || parameterName.isEmpty() || target == null) {
             return;
         }
@@ -90,7 +97,14 @@ public class OgnlParameterAllowlister implements ParameterAllowlister {
         if (allowlistViaPropertyDescriptor(target, normalisedRootProperty, paramDepth)) {
             return;
         }
-        allowlistViaPublicField(target, normalisedRootProperty, paramDepth);
+        if (allowlistViaPublicField(target, normalisedRootProperty, paramDepth)) {
+            return;
+        }
+        // Authorization passed but no @StrutsParameter on the root property — e.g. ModelDriven model with no
+        // per-property annotations. OGNL won't be able to walk this nested path; surface the gap in logs.
+        LOG.debug("Parameter [{}] authorized but no @StrutsParameter on root property [{}] of [{}]; "
+                + "OGNL allowlist not primed and nested traversal may be blocked",
+                parameterName, normalisedRootProperty, ultimateClass(target).getSimpleName());
     }
 
     private boolean allowlistViaPropertyDescriptor(Object target, String rootProperty, long paramDepth) {
@@ -115,21 +129,22 @@ public class OgnlParameterAllowlister implements ParameterAllowlister {
         return true;
     }
 
-    private void allowlistViaPublicField(Object target, String rootProperty, long paramDepth) {
+    private boolean allowlistViaPublicField(Object target, String rootProperty, long paramDepth) {
         Class<?> targetClass = ultimateClass(target);
         Field field;
         try {
             field = targetClass.getDeclaredField(rootProperty);
         } catch (NoSuchFieldException e) {
-            return;
+            return false;
         }
         if (!Modifier.isPublic(field.getModifiers()) || getPermittedInjectionDepth(field) < paramDepth) {
-            return;
+            return false;
         }
         allowlistClass(field.getType());
         if (paramDepth >= 2) {
             allowlistParameterizedTypeArg(field.getGenericType());
         }
+        return true;
     }
 
     private void allowlistClass(Class<?> clazz) {

--- a/core/src/main/java/org/apache/struts2/interceptor/parameter/OgnlParameterAllowlister.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/parameter/OgnlParameterAllowlister.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.struts2.interceptor.parameter;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.struts2.inject.Inject;
+import org.apache.struts2.ognl.OgnlUtil;
+import org.apache.struts2.ognl.ThreadAllowlist;
+import org.apache.struts2.util.ProxyService;
+
+import java.beans.BeanInfo;
+import java.beans.IntrospectionException;
+import java.beans.PropertyDescriptor;
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.Optional;
+
+import static org.apache.commons.lang3.StringUtils.indexOfAny;
+import static org.apache.struts2.security.DefaultAcceptedPatternsChecker.NESTING_CHARS;
+import static org.apache.struts2.security.DefaultAcceptedPatternsChecker.NESTING_CHARS_STR;
+
+/**
+ * Default {@link ParameterAllowlister} that primes OGNL {@link ThreadAllowlist} for nested-path writes. Logic is
+ * extracted verbatim from {@code ParametersInterceptor.performOgnlAllowlisting} so the OGNL parameter and cookie
+ * channels share a single implementation.
+ *
+ * <p>No-ops for depth-0 paths — root-level setters do not need allowlisting.</p>
+ *
+ * @since 7.2.0
+ */
+public class OgnlParameterAllowlister implements ParameterAllowlister {
+
+    private static final Logger LOG = LogManager.getLogger(OgnlParameterAllowlister.class);
+
+    private OgnlUtil ognlUtil;
+    private ProxyService proxyService;
+    private ThreadAllowlist threadAllowlist;
+
+    @Inject
+    public void setOgnlUtil(OgnlUtil ognlUtil) {
+        this.ognlUtil = ognlUtil;
+    }
+
+    @Inject
+    public void setProxyService(ProxyService proxyService) {
+        this.proxyService = proxyService;
+    }
+
+    @Inject
+    public void setThreadAllowlist(ThreadAllowlist threadAllowlist) {
+        this.threadAllowlist = threadAllowlist;
+    }
+
+    @Override
+    public void allowlistAuthorizedPath(String parameterName, Object target) {
+        if (parameterName == null || parameterName.isEmpty() || target == null) {
+            return;
+        }
+        long paramDepth = parameterName.codePoints().mapToObj(c -> (char) c).filter(NESTING_CHARS::contains).count();
+        if (paramDepth == 0) {
+            return;
+        }
+
+        int nestingIndex = indexOfAny(parameterName, NESTING_CHARS_STR);
+        String rootProperty = nestingIndex == -1 ? parameterName : parameterName.substring(0, nestingIndex);
+        String normalisedRootProperty = Character.toLowerCase(rootProperty.charAt(0)) + rootProperty.substring(1);
+
+        BeanInfo beanInfo = getBeanInfo(target);
+        if (beanInfo != null) {
+            Optional<PropertyDescriptor> propDescOpt = Arrays.stream(beanInfo.getPropertyDescriptors())
+                    .filter(desc -> desc.getName().equals(normalisedRootProperty)).findFirst();
+            if (propDescOpt.isPresent()) {
+                PropertyDescriptor propDesc = propDescOpt.get();
+                Method relevantMethod = propDesc.getReadMethod();
+                if (relevantMethod != null && getPermittedInjectionDepth(relevantMethod) >= paramDepth) {
+                    allowlistClass(propDesc.getPropertyType());
+                    if (paramDepth >= 2) {
+                        allowlistParameterizedTypeArg(relevantMethod.getGenericReturnType());
+                    }
+                    return;
+                }
+            }
+        }
+
+        Class<?> targetClass = ultimateClass(target);
+        try {
+            Field field = targetClass.getDeclaredField(normalisedRootProperty);
+            if (Modifier.isPublic(field.getModifiers()) && getPermittedInjectionDepth(field) >= paramDepth) {
+                allowlistClass(field.getType());
+                if (paramDepth >= 2) {
+                    allowlistParameterizedTypeArg(field.getGenericType());
+                }
+            }
+        } catch (NoSuchFieldException e) {
+            // No public field by that name — nothing to allowlist.
+        }
+    }
+
+    private void allowlistClass(Class<?> clazz) {
+        threadAllowlist.allowClassHierarchy(clazz);
+    }
+
+    private void allowlistParameterizedTypeArg(Type genericType) {
+        if (!(genericType instanceof ParameterizedType pType)) {
+            return;
+        }
+        Type[] paramTypes = pType.getActualTypeArguments();
+        allowlistParamType(paramTypes[0]);
+        if (paramTypes.length > 1) {
+            allowlistParamType(paramTypes[1]);
+        }
+    }
+
+    private void allowlistParamType(Type paramType) {
+        if (paramType instanceof Class<?> clazz) {
+            allowlistClass(clazz);
+        }
+    }
+
+    private int getPermittedInjectionDepth(AnnotatedElement element) {
+        StrutsParameter annotation = element.getAnnotation(StrutsParameter.class);
+        return annotation == null ? -1 : annotation.depth();
+    }
+
+    private Class<?> ultimateClass(Object target) {
+        if (proxyService.isProxy(target)) {
+            return proxyService.ultimateTargetClass(target);
+        }
+        return target.getClass();
+    }
+
+    private BeanInfo getBeanInfo(Object target) {
+        Class<?> targetClass = ultimateClass(target);
+        try {
+            return ognlUtil.getBeanInfo(targetClass);
+        } catch (IntrospectionException e) {
+            LOG.warn("Error introspecting target {} for OGNL allowlisting", targetClass, e);
+            return null;
+        }
+    }
+}

--- a/core/src/main/java/org/apache/struts2/interceptor/parameter/OgnlParameterAllowlister.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/parameter/OgnlParameterAllowlister.java
@@ -87,34 +87,48 @@ public class OgnlParameterAllowlister implements ParameterAllowlister {
         String rootProperty = nestingIndex == -1 ? parameterName : parameterName.substring(0, nestingIndex);
         String normalisedRootProperty = Character.toLowerCase(rootProperty.charAt(0)) + rootProperty.substring(1);
 
-        BeanInfo beanInfo = getBeanInfo(target);
-        if (beanInfo != null) {
-            Optional<PropertyDescriptor> propDescOpt = Arrays.stream(beanInfo.getPropertyDescriptors())
-                    .filter(desc -> desc.getName().equals(normalisedRootProperty)).findFirst();
-            if (propDescOpt.isPresent()) {
-                PropertyDescriptor propDesc = propDescOpt.get();
-                Method relevantMethod = propDesc.getReadMethod();
-                if (relevantMethod != null && getPermittedInjectionDepth(relevantMethod) >= paramDepth) {
-                    allowlistClass(propDesc.getPropertyType());
-                    if (paramDepth >= 2) {
-                        allowlistParameterizedTypeArg(relevantMethod.getGenericReturnType());
-                    }
-                    return;
-                }
-            }
+        if (allowlistViaPropertyDescriptor(target, normalisedRootProperty, paramDepth)) {
+            return;
         }
+        allowlistViaPublicField(target, normalisedRootProperty, paramDepth);
+    }
 
+    private boolean allowlistViaPropertyDescriptor(Object target, String rootProperty, long paramDepth) {
+        BeanInfo beanInfo = getBeanInfo(target);
+        if (beanInfo == null) {
+            return false;
+        }
+        Optional<PropertyDescriptor> propDescOpt = Arrays.stream(beanInfo.getPropertyDescriptors())
+                .filter(desc -> desc.getName().equals(rootProperty)).findFirst();
+        if (propDescOpt.isEmpty()) {
+            return false;
+        }
+        PropertyDescriptor propDesc = propDescOpt.get();
+        Method relevantMethod = propDesc.getReadMethod();
+        if (relevantMethod == null || getPermittedInjectionDepth(relevantMethod) < paramDepth) {
+            return false;
+        }
+        allowlistClass(propDesc.getPropertyType());
+        if (paramDepth >= 2) {
+            allowlistParameterizedTypeArg(relevantMethod.getGenericReturnType());
+        }
+        return true;
+    }
+
+    private void allowlistViaPublicField(Object target, String rootProperty, long paramDepth) {
         Class<?> targetClass = ultimateClass(target);
+        Field field;
         try {
-            Field field = targetClass.getDeclaredField(normalisedRootProperty);
-            if (Modifier.isPublic(field.getModifiers()) && getPermittedInjectionDepth(field) >= paramDepth) {
-                allowlistClass(field.getType());
-                if (paramDepth >= 2) {
-                    allowlistParameterizedTypeArg(field.getGenericType());
-                }
-            }
+            field = targetClass.getDeclaredField(rootProperty);
         } catch (NoSuchFieldException e) {
-            // No public field by that name — nothing to allowlist.
+            return;
+        }
+        if (!Modifier.isPublic(field.getModifiers()) || getPermittedInjectionDepth(field) < paramDepth) {
+            return;
+        }
+        allowlistClass(field.getType());
+        if (paramDepth >= 2) {
+            allowlistParameterizedTypeArg(field.getGenericType());
         }
     }
 

--- a/core/src/main/java/org/apache/struts2/interceptor/parameter/ParameterAllowlister.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/parameter/ParameterAllowlister.java
@@ -19,23 +19,26 @@
 package org.apache.struts2.interceptor.parameter;
 
 /**
- * Service for priming downstream allowlists (e.g. the OGNL {@link org.apache.struts2.ognl.ThreadAllowlist}) for a
- * parameter path that has already been authorized by {@link ParameterAuthorizer}. Separated from the authorizer so
- * that the authorizer can remain side-effect-free and reusable from non-OGNL channels (Jackson, Juneau).
+ * Primes channel-specific runtime state required for an already-authorized parameter path to be walked by the
+ * value-stack — for example, registering the path's classes into the OGNL {@link org.apache.struts2.ognl.ThreadAllowlist}
+ * so OGNL may traverse them. Separated from {@link ParameterAuthorizer} so the authorization decision can remain
+ * side-effect-free and reusable from non-OGNL channels (Jackson, Juneau).
  *
- * <p>Implementations are expected to no-op when {@code parameterName} is depth-0 if their downstream engine does not
- * require root-level priming. Callers must have already verified authorization via
- * {@link ParameterAuthorizer#isAuthorized}; this service does NOT enforce annotations.</p>
+ * <p>Implementations MUST NOT repeat the authorization decision — that is owned by
+ * {@link ParameterAuthorizer#isAuthorized}. A no-op return (e.g. shallow paths, unannotated root) means "no priming
+ * needed or possible" and never "rejected": callers must not treat the absence of priming as a negative authorization
+ * signal.</p>
  *
  * @since 7.2.0
  */
 public interface ParameterAllowlister {
 
     /**
-     * Primes the underlying allowlist for an authorized parameter path.
+     * Primes the channel-specific allowlist for an authorized parameter path. Side-effect-only; no return value
+     * because a no-op is a valid outcome (see class-level javadoc).
      *
      * @param parameterName the parameter name (e.g. {@code "user.role"}, {@code "items[0].name"})
      * @param target        the object receiving the parameter value (the action, or the model for ModelDriven actions)
      */
-    void allowlistAuthorizedPath(String parameterName, Object target);
+    void primeAllowlistForPath(String parameterName, Object target);
 }

--- a/core/src/main/java/org/apache/struts2/interceptor/parameter/ParameterAllowlister.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/parameter/ParameterAllowlister.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.struts2.interceptor.parameter;
+
+/**
+ * Service for priming downstream allowlists (e.g. the OGNL {@link org.apache.struts2.ognl.ThreadAllowlist}) for a
+ * parameter path that has already been authorized by {@link ParameterAuthorizer}. Separated from the authorizer so
+ * that the authorizer can remain side-effect-free and reusable from non-OGNL channels (Jackson, Juneau).
+ *
+ * <p>Implementations are expected to no-op when {@code parameterName} is depth-0 if their downstream engine does not
+ * require root-level priming. Callers must have already verified authorization via
+ * {@link ParameterAuthorizer#isAuthorized}; this service does NOT enforce annotations.</p>
+ *
+ * @since 7.2.0
+ */
+public interface ParameterAllowlister {
+
+    /**
+     * Primes the underlying allowlist for an authorized parameter path.
+     *
+     * @param parameterName the parameter name (e.g. {@code "user.role"}, {@code "items[0].name"})
+     * @param target        the object receiving the parameter value (the action, or the model for ModelDriven actions)
+     */
+    void allowlistAuthorizedPath(String parameterName, Object target);
+}

--- a/core/src/main/java/org/apache/struts2/interceptor/parameter/ParametersInterceptor.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/parameter/ParametersInterceptor.java
@@ -66,7 +66,6 @@ import static java.lang.String.format;
 import static java.util.Collections.unmodifiableSet;
 import static java.util.stream.Collectors.joining;
 import static org.apache.commons.lang3.StringUtils.normalizeSpace;
-import static org.apache.struts2.security.DefaultAcceptedPatternsChecker.NESTING_CHARS;
 import static org.apache.struts2.util.DebugUtils.logWarningForFirstOccurrence;
 import static org.apache.struts2.util.DebugUtils.notifyDeveloperOfError;
 
@@ -379,20 +378,8 @@ public class ParametersInterceptor extends MethodFilterInterceptor {
             return false;
         }
 
-        // OGNL-specific allowlisting: only needed for nested params (depth >= 1)
-        long paramDepth = name.codePoints().mapToObj(c -> (char) c).filter(NESTING_CHARS::contains).count();
-        if (paramDepth >= 1) {
-            performOgnlAllowlisting(name, target, paramDepth);
-        }
+        parameterAllowlister.primeAllowlistForPath(name, target);
         return true;
-    }
-
-    /**
-     * Performs OGNL ThreadAllowlist side effects for an authorized parameter. This is specific to OGNL-based parameter
-     * injection and must NOT be shared with other input channels (JSON, REST).
-     */
-    private void performOgnlAllowlisting(String name, Object target, long paramDepth) {
-        parameterAllowlister.allowlistAuthorizedPath(name, target);
     }
 
     /**

--- a/core/src/main/java/org/apache/struts2/interceptor/parameter/ParametersInterceptor.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/parameter/ParametersInterceptor.java
@@ -65,10 +65,8 @@ import java.util.regex.Pattern;
 import static java.lang.String.format;
 import static java.util.Collections.unmodifiableSet;
 import static java.util.stream.Collectors.joining;
-import static org.apache.commons.lang3.StringUtils.indexOfAny;
 import static org.apache.commons.lang3.StringUtils.normalizeSpace;
 import static org.apache.struts2.security.DefaultAcceptedPatternsChecker.NESTING_CHARS;
-import static org.apache.struts2.security.DefaultAcceptedPatternsChecker.NESTING_CHARS_STR;
 import static org.apache.struts2.util.DebugUtils.logWarningForFirstOccurrence;
 import static org.apache.struts2.util.DebugUtils.notifyDeveloperOfError;
 
@@ -100,6 +98,7 @@ public class ParametersInterceptor extends MethodFilterInterceptor {
     private Set<Pattern> excludedValuePatterns = null;
     private Set<Pattern> acceptedValuePatterns = null;
     private ParameterAuthorizer parameterAuthorizer;
+    private ParameterAllowlister parameterAllowlister;
 
     @Inject
     public void setValueStackFactory(ValueStackFactory valueStackFactory) {
@@ -124,6 +123,11 @@ public class ParametersInterceptor extends MethodFilterInterceptor {
     @Inject
     public void setParameterAuthorizer(ParameterAuthorizer parameterAuthorizer) {
         this.parameterAuthorizer = parameterAuthorizer;
+    }
+
+    @Inject
+    public void setParameterAllowlister(ParameterAllowlister parameterAllowlister) {
+        this.parameterAllowlister = parameterAllowlister;
     }
 
     @Inject(StrutsConstants.STRUTS_DEVMODE)
@@ -388,40 +392,7 @@ public class ParametersInterceptor extends MethodFilterInterceptor {
      * injection and must NOT be shared with other input channels (JSON, REST).
      */
     private void performOgnlAllowlisting(String name, Object target, long paramDepth) {
-        int nestingIndex = indexOfAny(name, NESTING_CHARS_STR);
-        String rootProperty = nestingIndex == -1 ? name : name.substring(0, nestingIndex);
-        String normalisedRootProperty = Character.toLowerCase(rootProperty.charAt(0)) + rootProperty.substring(1);
-
-        BeanInfo beanInfo = getBeanInfo(target);
-        if (beanInfo != null) {
-            Optional<PropertyDescriptor> propDescOpt = Arrays.stream(beanInfo.getPropertyDescriptors())
-                    .filter(desc -> desc.getName().equals(normalisedRootProperty)).findFirst();
-            if (propDescOpt.isPresent()) {
-                PropertyDescriptor propDesc = propDescOpt.get();
-                Method relevantMethod = paramDepth == 0 ? propDesc.getWriteMethod() : propDesc.getReadMethod();
-                if (relevantMethod != null && getPermittedInjectionDepth(relevantMethod) >= paramDepth) {
-                    allowlistClass(propDesc.getPropertyType());
-                    if (paramDepth >= 2) {
-                        allowlistReturnTypeIfParameterized(relevantMethod);
-                    }
-                    return;
-                }
-            }
-        }
-
-        // Fallback: check public field
-        Class<?> targetClass = ultimateClass(target);
-        try {
-            Field field = targetClass.getDeclaredField(normalisedRootProperty);
-            if (Modifier.isPublic(field.getModifiers()) && getPermittedInjectionDepth(field) >= paramDepth) {
-                allowlistClass(field.getType());
-                if (paramDepth >= 2) {
-                    allowlistFieldIfParameterized(field);
-                }
-            }
-        } catch (NoSuchFieldException e) {
-            // No field to allowlist
-        }
+        parameterAllowlister.allowlistAuthorizedPath(name, target);
     }
 
     /**

--- a/core/src/main/java/org/apache/struts2/interceptor/parameter/ParametersInterceptor.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/parameter/ParametersInterceptor.java
@@ -98,7 +98,7 @@ public class ParametersInterceptor extends MethodFilterInterceptor {
     private Set<Pattern> excludedValuePatterns = null;
     private Set<Pattern> acceptedValuePatterns = null;
     private ParameterAuthorizer parameterAuthorizer;
-    private ParameterAllowlister parameterAllowlister;
+    private transient ParameterAllowlister parameterAllowlister;
 
     @Inject
     public void setValueStackFactory(ValueStackFactory valueStackFactory) {

--- a/core/src/main/resources/struts-beans.xml
+++ b/core/src/main/resources/struts-beans.xml
@@ -248,6 +248,9 @@
     <bean type="org.apache.struts2.interceptor.parameter.ParameterAuthorizer" name="struts"
           class="org.apache.struts2.interceptor.parameter.StrutsParameterAuthorizer" scope="singleton"/>
 
+    <bean type="org.apache.struts2.interceptor.parameter.ParameterAllowlister" name="struts"
+          class="org.apache.struts2.interceptor.parameter.OgnlParameterAllowlister" scope="singleton"/>
+
     <bean type="org.apache.struts2.url.QueryStringBuilder" name="strutsQueryStringBuilder"
           class="org.apache.struts2.url.StrutsQueryStringBuilder" scope="singleton"/>
     <bean type="org.apache.struts2.url.QueryStringParser" name="strutsQueryStringParser"

--- a/core/src/test/java/org/apache/struts2/interceptor/CookieInterceptorAnnotationTest.java
+++ b/core/src/test/java/org/apache/struts2/interceptor/CookieInterceptorAnnotationTest.java
@@ -21,6 +21,7 @@ package org.apache.struts2.interceptor;
 import jakarta.servlet.http.Cookie;
 import org.apache.struts2.ActionContext;
 import org.apache.struts2.ActionSupport;
+import org.apache.struts2.ModelDriven;
 import org.apache.struts2.ServletActionContext;
 import org.apache.struts2.StrutsInternalTestCase;
 import org.apache.struts2.action.Action;
@@ -28,7 +29,11 @@ import org.apache.struts2.interceptor.parameter.ParameterAuthorizer;
 import org.apache.struts2.interceptor.parameter.StrutsParameter;
 import org.apache.struts2.interceptor.parameter.StrutsParameterAuthorizer;
 import org.apache.struts2.mock.MockActionInvocation;
+import org.apache.struts2.util.ValueStack;
 import org.springframework.mock.web.MockHttpServletRequest;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class CookieInterceptorAnnotationTest extends StrutsInternalTestCase {
 
@@ -58,6 +63,101 @@ public class CookieInterceptorAnnotationTest extends StrutsInternalTestCase {
         assertNull(ActionContext.getContext().getValueStack().findValue("unannotated"));
     }
 
+    public void testRequireAnnotations_annotatedSetter_isInjected() throws Exception {
+        configureRequireAnnotations(true, false);
+        AnnotatedAction action = new AnnotatedAction();
+        invokeWithCookies(action, new Cookie("annotated", "v"));
+
+        assertEquals("v", action.getAnnotated());
+        assertEquals("v", ActionContext.getContext().getValueStack().findValue("annotated"));
+    }
+
+    public void testRequireAnnotations_annotatedNestedPath_isInjected() throws Exception {
+        configureRequireAnnotations(true, false);
+        AnnotatedAction action = new AnnotatedAction();
+        action.setNested(new NestedBean());
+        invokeWithCookies(action, new Cookie("nested.field", "v"));
+
+        assertEquals("v", action.getNested().getField());
+    }
+
+    public void testRequireAnnotations_unannotatedNestedPath_isSkipped() throws Exception {
+        configureRequireAnnotations(true, false);
+        AnnotatedAction action = new AnnotatedAction();
+        action.setUnannotatedNested(new NestedBean());
+        invokeWithCookies(action, new Cookie("unannotatedNested.field", "v"));
+
+        assertNull(action.getUnannotatedNested().getField());
+    }
+
+    public void testRequireAnnotations_transitionMode_exemptsDepthZero() throws Exception {
+        configureRequireAnnotations(true, true);
+        AnnotatedAction action = new AnnotatedAction();
+        invokeWithCookies(action, new Cookie("unannotated", "v"));
+
+        assertEquals("v", action.getUnannotated());
+    }
+
+    public void testDefaultConfig_unannotatedSetter_stillInjected() throws Exception {
+        configureRequireAnnotations(false, false);
+        AnnotatedAction action = new AnnotatedAction();
+        invokeWithCookies(action, new Cookie("unannotated", "v"));
+
+        assertEquals("v", action.getUnannotated());
+    }
+
+    public void testRequireAnnotations_modelDriven_exemptsModel() throws Exception {
+        configureRequireAnnotations(true, false);
+        ModelDrivenAction action = new ModelDrivenAction();
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setCookies(new Cookie("name", "v"));
+        ServletActionContext.setRequest(request);
+        // ModelDriven contract: the model is pushed on top of the action.
+        ActionContext.getContext().getValueStack().push(action);
+        ActionContext.getContext().getValueStack().push(action.getModel());
+
+        MockActionInvocation invocation = new MockActionInvocation();
+        invocation.setAction(action);
+        invocation.setInvocationContext(ActionContext.getContext());
+        invocation.setResultCode(Action.SUCCESS);
+
+        interceptor.intercept(invocation);
+
+        assertEquals("v", action.getModel().getName());
+    }
+
+    public void testSubclassOverridingDeprecatedHook_stillSeesAuthorizationGate() throws Exception {
+        configureRequireAnnotations(true, false);
+        AtomicInteger calls = new AtomicInteger();
+        @SuppressWarnings("deprecation")
+        CookieInterceptor subclass = new CookieInterceptor() {
+            @Override
+            protected void populateCookieValueIntoStack(String name, String value, Map<String, String> map, ValueStack stack) {
+                calls.incrementAndGet();
+                super.populateCookieValueIntoStack(name, value, map, stack);
+            }
+        };
+        container.inject(subclass);
+        subclass.setCookiesName("*");
+
+        AnnotatedAction action = new AnnotatedAction();
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.setCookies(new Cookie("annotated", "ok"), new Cookie("unannotated", "blocked"));
+        ServletActionContext.setRequest(req);
+        ActionContext.getContext().getValueStack().push(action);
+
+        MockActionInvocation invocation = new MockActionInvocation();
+        invocation.setAction(action);
+        invocation.setInvocationContext(ActionContext.getContext());
+        invocation.setResultCode(Action.SUCCESS);
+        subclass.intercept(invocation);
+
+        assertEquals("ok", action.getAnnotated());
+        assertNull(action.getUnannotated());
+        assertEquals("4-arg hook should be invoked exactly once (only for the authorized cookie)", 1, calls.get());
+    }
+
     private void configureRequireAnnotations(boolean require, boolean transitionMode) {
         StrutsParameterAuthorizer authorizer = (StrutsParameterAuthorizer) container.getInstance(ParameterAuthorizer.class);
         authorizer.setRequireAnnotations(Boolean.toString(require));
@@ -81,6 +181,8 @@ public class CookieInterceptorAnnotationTest extends StrutsInternalTestCase {
     public static class AnnotatedAction extends ActionSupport {
         private String annotated;
         private String unannotated;
+        private NestedBean nested;
+        private NestedBean unannotatedNested;
 
         @StrutsParameter
         public void setAnnotated(String v) { this.annotated = v; }
@@ -88,5 +190,30 @@ public class CookieInterceptorAnnotationTest extends StrutsInternalTestCase {
 
         public void setUnannotated(String v) { this.unannotated = v; }
         public String getUnannotated() { return unannotated; }
+
+        @StrutsParameter(depth = 1)
+        public NestedBean getNested() { return nested; }
+        public void setNested(NestedBean nested) { this.nested = nested; }
+
+        public NestedBean getUnannotatedNested() { return unannotatedNested; }
+        public void setUnannotatedNested(NestedBean v) { this.unannotatedNested = v; }
+    }
+
+    public static class NestedBean {
+        private String field;
+        public String getField() { return field; }
+        public void setField(String f) { this.field = f; }
+    }
+
+    public static class ModelDrivenAction extends ActionSupport implements ModelDriven<Model> {
+        private final Model model = new Model();
+        @Override
+        public Model getModel() { return model; }
+    }
+
+    public static class Model {
+        private String name;
+        public String getName() { return name; }
+        public void setName(String n) { this.name = n; }
     }
 }

--- a/core/src/test/java/org/apache/struts2/interceptor/CookieInterceptorAnnotationTest.java
+++ b/core/src/test/java/org/apache/struts2/interceptor/CookieInterceptorAnnotationTest.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.struts2.interceptor;
+
+import jakarta.servlet.http.Cookie;
+import org.apache.struts2.ActionContext;
+import org.apache.struts2.ActionSupport;
+import org.apache.struts2.ServletActionContext;
+import org.apache.struts2.StrutsInternalTestCase;
+import org.apache.struts2.action.Action;
+import org.apache.struts2.interceptor.parameter.ParameterAuthorizer;
+import org.apache.struts2.interceptor.parameter.StrutsParameter;
+import org.apache.struts2.interceptor.parameter.StrutsParameterAuthorizer;
+import org.apache.struts2.mock.MockActionInvocation;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+public class CookieInterceptorAnnotationTest extends StrutsInternalTestCase {
+
+    private CookieInterceptor interceptor;
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        interceptor = container.inject(CookieInterceptor.class);
+        interceptor.setCookiesName("*");
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        // Reset shared singleton state — flags flipped on the container's StrutsParameterAuthorizer
+        // would otherwise leak across tests in the same JVM run.
+        configureRequireAnnotations(false, false);
+        super.tearDown();
+    }
+
+    public void testRequireAnnotations_unannotatedSetter_isSkipped() throws Exception {
+        configureRequireAnnotations(true, false);
+        AnnotatedAction action = new AnnotatedAction();
+        invokeWithCookies(action, new Cookie("unannotated", "v"));
+
+        assertNull("unannotated setter must not be populated", action.getUnannotated());
+        assertNull(ActionContext.getContext().getValueStack().findValue("unannotated"));
+    }
+
+    private void configureRequireAnnotations(boolean require, boolean transitionMode) {
+        StrutsParameterAuthorizer authorizer = (StrutsParameterAuthorizer) container.getInstance(ParameterAuthorizer.class);
+        authorizer.setRequireAnnotations(Boolean.toString(require));
+        authorizer.setRequireAnnotationsTransitionMode(Boolean.toString(transitionMode));
+    }
+
+    private void invokeWithCookies(Object action, Cookie... cookies) throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setCookies(cookies);
+        ServletActionContext.setRequest(request);
+        ActionContext.getContext().getValueStack().push(action);
+
+        MockActionInvocation invocation = new MockActionInvocation();
+        invocation.setAction(action);
+        invocation.setInvocationContext(ActionContext.getContext());
+        invocation.setResultCode(Action.SUCCESS);
+
+        interceptor.intercept(invocation);
+    }
+
+    public static class AnnotatedAction extends ActionSupport {
+        private String annotated;
+        private String unannotated;
+
+        @StrutsParameter
+        public void setAnnotated(String v) { this.annotated = v; }
+        public String getAnnotated() { return annotated; }
+
+        public void setUnannotated(String v) { this.unannotated = v; }
+        public String getUnannotated() { return unannotated; }
+    }
+}

--- a/core/src/test/java/org/apache/struts2/interceptor/CookieInterceptorTest.java
+++ b/core/src/test/java/org/apache/struts2/interceptor/CookieInterceptorTest.java
@@ -43,6 +43,15 @@ import static org.easymock.EasyMock.verify;
 
 public class CookieInterceptorTest extends StrutsInternalTestCase {
 
+    /**
+     * These tests construct {@link CookieInterceptor} via {@code new} rather than the DI container, so the
+     * {@code @StrutsParameter} authorization gate added in WW-5627 has no injected services. We supply explicit
+     * pass-through lambdas to mirror the default-config behavior these tests assume ({@code requireAnnotations=false}).
+     */
+    private static void disableAuthorizationGate(CookieInterceptor interceptor) {
+        interceptor.setParameterAuthorizer((name, target, action) -> true);
+        interceptor.setParameterAllowlister((name, target) -> {});
+    }
 
     public void testIntercepDefault() throws Exception {
         MockHttpServletRequest request = new MockHttpServletRequest();
@@ -68,6 +77,7 @@ public class CookieInterceptorTest extends StrutsInternalTestCase {
         CookieInterceptor interceptor = new CookieInterceptor();
         interceptor.setExcludedPatternsChecker(new DefaultExcludedPatternsChecker());
         interceptor.setAcceptedPatternsChecker(new DefaultAcceptedPatternsChecker());
+        disableAuthorizationGate(interceptor);
 
         interceptor.intercept(invocation);
 
@@ -105,6 +115,7 @@ public class CookieInterceptorTest extends StrutsInternalTestCase {
         CookieInterceptor interceptor = new CookieInterceptor();
         interceptor.setExcludedPatternsChecker(new DefaultExcludedPatternsChecker());
         interceptor.setAcceptedPatternsChecker(new DefaultAcceptedPatternsChecker());
+        disableAuthorizationGate(interceptor);
         interceptor.setCookiesName("*");
         interceptor.setCookiesValue("*");
         interceptor.intercept(invocation);
@@ -147,6 +158,7 @@ public class CookieInterceptorTest extends StrutsInternalTestCase {
         CookieInterceptor interceptor = new CookieInterceptor();
         interceptor.setExcludedPatternsChecker(new DefaultExcludedPatternsChecker());
         interceptor.setAcceptedPatternsChecker(new DefaultAcceptedPatternsChecker());
+        disableAuthorizationGate(interceptor);
         interceptor.setCookiesName("cookie1, cookie2, cookie3");
         interceptor.setCookiesValue("cookie1value, cookie2value, cookie3value");
         interceptor.intercept(invocation);
@@ -188,6 +200,7 @@ public class CookieInterceptorTest extends StrutsInternalTestCase {
         CookieInterceptor interceptor = new CookieInterceptor();
         interceptor.setExcludedPatternsChecker(new DefaultExcludedPatternsChecker());
         interceptor.setAcceptedPatternsChecker(new DefaultAcceptedPatternsChecker());
+        disableAuthorizationGate(interceptor);
         interceptor.setCookiesName("cookie1, cookie3");
         interceptor.setCookiesValue("cookie1value, cookie2value, cookie3value");
         interceptor.intercept(invocation);
@@ -230,6 +243,7 @@ public class CookieInterceptorTest extends StrutsInternalTestCase {
         CookieInterceptor interceptor = new CookieInterceptor();
         interceptor.setExcludedPatternsChecker(new DefaultExcludedPatternsChecker());
         interceptor.setAcceptedPatternsChecker(new DefaultAcceptedPatternsChecker());
+        disableAuthorizationGate(interceptor);
         interceptor.setCookiesName("cookie1, cookie3");
         interceptor.setCookiesValue("*");
         interceptor.intercept(invocation);
@@ -271,6 +285,7 @@ public class CookieInterceptorTest extends StrutsInternalTestCase {
         CookieInterceptor interceptor = new CookieInterceptor();
         interceptor.setExcludedPatternsChecker(new DefaultExcludedPatternsChecker());
         interceptor.setAcceptedPatternsChecker(new DefaultAcceptedPatternsChecker());
+        disableAuthorizationGate(interceptor);
         interceptor.setCookiesName("cookie1, cookie3");
         interceptor.setCookiesValue("");
         interceptor.intercept(invocation);
@@ -313,6 +328,7 @@ public class CookieInterceptorTest extends StrutsInternalTestCase {
         CookieInterceptor interceptor = new CookieInterceptor();
         interceptor.setExcludedPatternsChecker(new DefaultExcludedPatternsChecker());
         interceptor.setAcceptedPatternsChecker(new DefaultAcceptedPatternsChecker());
+        disableAuthorizationGate(interceptor);
         interceptor.setCookiesName("cookie1, cookie3");
         interceptor.setCookiesValue("cookie1value");
         interceptor.intercept(invocation);
@@ -395,6 +411,7 @@ public class CookieInterceptorTest extends StrutsInternalTestCase {
         excludedPatternsChecker.setAdditionalExcludePatterns(".*(^|\\.|\\[|'|\")class(\\.|\\[|'|\").*");
         interceptor.setExcludedPatternsChecker(excludedPatternsChecker);
         interceptor.setAcceptedPatternsChecker(new DefaultAcceptedPatternsChecker());
+        disableAuthorizationGate(interceptor);
         interceptor.setCookiesName("*");
 
         MockActionInvocation invocation = new MockActionInvocation();
@@ -441,6 +458,7 @@ public class CookieInterceptorTest extends StrutsInternalTestCase {
         };
         interceptor.setExcludedPatternsChecker(new DefaultExcludedPatternsChecker());
         interceptor.setAcceptedPatternsChecker(new DefaultAcceptedPatternsChecker());
+        disableAuthorizationGate(interceptor);
         interceptor.setCookiesName("*");
 
         MockActionInvocation invocation = new MockActionInvocation();

--- a/core/src/test/java/org/apache/struts2/interceptor/parameter/OgnlParameterAllowlisterTest.java
+++ b/core/src/test/java/org/apache/struts2/interceptor/parameter/OgnlParameterAllowlisterTest.java
@@ -31,7 +31,6 @@ import org.junit.Test;
 
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import static org.apache.struts2.ognl.OgnlCacheFactory.CacheType.LRU;
@@ -105,7 +104,6 @@ public class OgnlParameterAllowlisterTest {
     public static class TargetWithAnnotatedNestedBean {
         private NestedBean nested;
         private List<NestedBean> things;
-        private Map<String, NestedBean> mapping;
 
         @StrutsParameter(depth = 1)
         public NestedBean getNested() { return nested; }

--- a/core/src/test/java/org/apache/struts2/interceptor/parameter/OgnlParameterAllowlisterTest.java
+++ b/core/src/test/java/org/apache/struts2/interceptor/parameter/OgnlParameterAllowlisterTest.java
@@ -62,42 +62,42 @@ public class OgnlParameterAllowlisterTest {
     @Test
     public void depthZero_isNoOp() {
         var target = new TargetWithAnnotatedNestedBean();
-        allowlister.allowlistAuthorizedPath("simple", target);
+        allowlister.primeAllowlistForPath("simple", target);
         assertThat(threadAllowlist.classes).isEmpty();
     }
 
     @Test
     public void nestedProperty_allowlistsPropertyType() {
         var target = new TargetWithAnnotatedNestedBean();
-        allowlister.allowlistAuthorizedPath("nested.field", target);
+        allowlister.primeAllowlistForPath("nested.field", target);
         assertThat(threadAllowlist.classes).contains(NestedBean.class);
     }
 
     @Test
     public void parameterizedReturn_allowlistsTypeArguments() {
         var target = new TargetWithAnnotatedNestedBean();
-        allowlister.allowlistAuthorizedPath("things[0].field", target);
+        allowlister.primeAllowlistForPath("things[0].field", target);
         assertThat(threadAllowlist.classes).contains(List.class, NestedBean.class);
     }
 
     @Test
     public void publicField_isAllowlistedWhenNoGetter() {
         var target = new TargetWithAnnotatedPublicField();
-        allowlister.allowlistAuthorizedPath("publicNested.field", target);
+        allowlister.primeAllowlistForPath("publicNested.field", target);
         assertThat(threadAllowlist.classes).contains(NestedBean.class);
     }
 
     @Test
     public void unmatchedRoot_isNoOp() {
         var target = new TargetWithAnnotatedNestedBean();
-        allowlister.allowlistAuthorizedPath("unknownRoot.field", target);
+        allowlister.primeAllowlistForPath("unknownRoot.field", target);
         assertThat(threadAllowlist.classes).isEmpty();
     }
 
     @Test
     public void unannotatedNested_isNoOp() {
         var target = new TargetWithUnannotatedNested();
-        allowlister.allowlistAuthorizedPath("unannotated.field", target);
+        allowlister.primeAllowlistForPath("unannotated.field", target);
         assertThat(threadAllowlist.classes).isEmpty();
     }
 

--- a/core/src/test/java/org/apache/struts2/interceptor/parameter/OgnlParameterAllowlisterTest.java
+++ b/core/src/test/java/org/apache/struts2/interceptor/parameter/OgnlParameterAllowlisterTest.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.struts2.interceptor.parameter;
+
+import org.apache.struts2.ognl.DefaultOgnlBeanInfoCacheFactory;
+import org.apache.struts2.ognl.DefaultOgnlExpressionCacheFactory;
+import org.apache.struts2.ognl.OgnlUtil;
+import org.apache.struts2.ognl.StrutsOgnlGuard;
+import org.apache.struts2.ognl.StrutsProxyCacheFactory;
+import org.apache.struts2.ognl.ThreadAllowlist;
+import org.apache.struts2.util.StrutsProxyService;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.apache.struts2.ognl.OgnlCacheFactory.CacheType.LRU;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class OgnlParameterAllowlisterTest {
+
+    private OgnlParameterAllowlister allowlister;
+    private RecordingThreadAllowlist threadAllowlist;
+
+    @Before
+    public void setUp() {
+        threadAllowlist = new RecordingThreadAllowlist();
+        allowlister = new OgnlParameterAllowlister();
+        var ognlUtil = new OgnlUtil(
+                new DefaultOgnlExpressionCacheFactory<>(String.valueOf(1000), LRU.toString()),
+                new DefaultOgnlBeanInfoCacheFactory<>(String.valueOf(1000), LRU.toString()),
+                new StrutsOgnlGuard());
+        allowlister.setOgnlUtil(ognlUtil);
+        allowlister.setProxyService(new StrutsProxyService(new StrutsProxyCacheFactory<>("1000", "basic")));
+        allowlister.setThreadAllowlist(threadAllowlist);
+    }
+
+    @After
+    public void tearDown() {
+        threadAllowlist.clear();
+    }
+
+    @Test
+    public void depthZero_isNoOp() {
+        var target = new TargetWithAnnotatedNestedBean();
+        allowlister.allowlistAuthorizedPath("simple", target);
+        assertThat(threadAllowlist.classes).isEmpty();
+    }
+
+    @Test
+    public void nestedProperty_allowlistsPropertyType() {
+        var target = new TargetWithAnnotatedNestedBean();
+        allowlister.allowlistAuthorizedPath("nested.field", target);
+        assertThat(threadAllowlist.classes).contains(NestedBean.class);
+    }
+
+    @Test
+    public void parameterizedReturn_allowlistsTypeArguments() {
+        var target = new TargetWithAnnotatedNestedBean();
+        allowlister.allowlistAuthorizedPath("things[0].field", target);
+        assertThat(threadAllowlist.classes).contains(List.class, NestedBean.class);
+    }
+
+    @Test
+    public void publicField_isAllowlistedWhenNoGetter() {
+        var target = new TargetWithAnnotatedPublicField();
+        allowlister.allowlistAuthorizedPath("publicNested.field", target);
+        assertThat(threadAllowlist.classes).contains(NestedBean.class);
+    }
+
+    @Test
+    public void unmatchedRoot_isNoOp() {
+        var target = new TargetWithAnnotatedNestedBean();
+        allowlister.allowlistAuthorizedPath("unknownRoot.field", target);
+        assertThat(threadAllowlist.classes).isEmpty();
+    }
+
+    @Test
+    public void unannotatedNested_isNoOp() {
+        var target = new TargetWithUnannotatedNested();
+        allowlister.allowlistAuthorizedPath("unannotated.field", target);
+        assertThat(threadAllowlist.classes).isEmpty();
+    }
+
+    public static class TargetWithAnnotatedNestedBean {
+        private NestedBean nested;
+        private List<NestedBean> things;
+        private Map<String, NestedBean> mapping;
+
+        @StrutsParameter(depth = 1)
+        public NestedBean getNested() { return nested; }
+        public void setNested(NestedBean nested) { this.nested = nested; }
+
+        @StrutsParameter(depth = 2)
+        public List<NestedBean> getThings() { return things; }
+        public void setThings(List<NestedBean> things) { this.things = things; }
+    }
+
+    public static class TargetWithAnnotatedPublicField {
+        @StrutsParameter(depth = 1)
+        public NestedBean publicNested;
+    }
+
+    public static class TargetWithUnannotatedNested {
+        private NestedBean unannotated;
+        public NestedBean getUnannotated() { return unannotated; }
+        public void setUnannotated(NestedBean v) { this.unannotated = v; }
+    }
+
+    public static class NestedBean {
+        private String field;
+        public String getField() { return field; }
+        public void setField(String f) { this.field = f; }
+    }
+
+    private static final class RecordingThreadAllowlist extends ThreadAllowlist {
+        final Set<Class<?>> classes = new HashSet<>();
+
+        @Override
+        public void allowClass(Class<?> clazz) {
+            classes.add(clazz);
+            super.allowClass(clazz);
+        }
+
+        @Override
+        public void allowClassHierarchy(Class<?> clazz) {
+            classes.add(clazz);
+            super.allowClassHierarchy(clazz);
+        }
+
+        void clear() {
+            classes.clear();
+            clearAllowlist();
+        }
+    }
+}

--- a/core/src/test/java/org/apache/struts2/interceptor/parameter/StrutsParameterAnnotationTest.java
+++ b/core/src/test/java/org/apache/struts2/interceptor/parameter/StrutsParameterAnnotationTest.java
@@ -84,6 +84,12 @@ public class StrutsParameterAnnotationTest {
         this.parameterAuthorizer = parameterAuthorizer;
         parametersInterceptor.setParameterAuthorizer(parameterAuthorizer);
 
+        var parameterAllowlister = new OgnlParameterAllowlister();
+        parameterAllowlister.setOgnlUtil(ognlUtil);
+        parameterAllowlister.setProxyService(proxyService);
+        parameterAllowlister.setThreadAllowlist(threadAllowlist);
+        parametersInterceptor.setParameterAllowlister(parameterAllowlister);
+
         NotExcludedAcceptedPatternsChecker checker = mock(NotExcludedAcceptedPatternsChecker.class);
         when(checker.isAccepted(anyString())).thenReturn(IsAccepted.yes(""));
         when(checker.isExcluded(anyString())).thenReturn(IsExcluded.no(Set.of()));


### PR DESCRIPTION
## Summary

Fixes [WW-5627](https://issues.apache.org/jira/browse/WW-5627) — `CookieInterceptor.populateCookieValueIntoStack` calls `stack.setValue` directly (`CookieInterceptor.java:339,348` pre-fix), bypassing `StrutsParameterAuthorizer` so cookies write to action setters that are not annotated with `@StrutsParameter` even when `struts.parameters.requireAnnotations=true`.

This PR retrofits the `@StrutsParameter` enforcement onto the cookie input channel:

- New `ParameterAllowlister` interface (extension point) + default `OgnlParameterAllowlister` impl extracted from `ParametersInterceptor.performOgnlAllowlisting`. Mirrors the `ParameterAuthorizer` pair from WW-5626. Apps can swap implementations via `<constant name="struts.parameterAllowlister" value="..."/>`.
- `ParametersInterceptor` delegates to the new component (pure refactor, all 35 existing tests pass unchanged).
- `CookieInterceptor` adds a new `protected void populateCookieValueIntoStack(name, value, map, stack, action)` extension hook. The default impl runs `parameterAuthorizer.isAuthorized` → `parameterAllowlister.allowlistAuthorizedPath` → existing 4-arg form. The 4-arg form is `@Deprecated(since="7.2.0")` with body unchanged, so existing subclass overrides automatically inherit the gate.
- DI registration in `struts-beans.xml`, `StrutsBeanSelectionProvider`, and `DefaultConfiguration.bootstrapFactories()`.

**Default-config invariant:** when `struts.parameters.requireAnnotations=false` (the 7.x default), `ParameterAuthorizer.isAuthorized` short-circuits to `true`, so existing apps see no behavior change. Only opt-in apps see cookies gated.

## Behavior matrix

| Config | Cookie name | Setter `@StrutsParameter`? | Outcome |
|---|---|---|---|
| `requireAnnotations=false` (default) | any | any | Injected (unchanged) |
| `requireAnnotations=true` | `flatName` | yes | Injected |
| `requireAnnotations=true` | `flatName` | no | Skipped, debug log |
| `requireAnnotations=true` | `user.role` | yes (depth ≥1) | Injected; `ThreadAllowlist` primed |
| `requireAnnotations=true` | `user.role` | no / depth too low | Skipped, debug log |
| `requireAnnotations=true`, transition | `flatName` | no | Injected (depth-0 exemption) |
| `requireAnnotations=true`, ModelDriven model | any | n/a | Injected against model |

## Migration notes (for the Confluence wiki)

> **Behavior change for `struts.parameters.requireAnnotations=true` adopters:** `CookieInterceptor` now enforces `@StrutsParameter` annotations on action setters when `struts.parameters.requireAnnotations=true`. Apps using `<param name="cookiesName">*</param>` together with annotation enforcement must annotate any setter intended to receive cookie values, or that cookie will be silently skipped (debug-logged). No change for the default config.

## Stacking

Stacked on top of `WW-5626-approach-c` (where `ParameterAuthorizer` and `StrutsParameterAuthorizer` were introduced). When WW-5626 merges to `main`, this PR's base will be retargeted automatically.

## Test plan

- [x] `mvn test -DskipAssembly -pl core` — 2952/2952 green.
- [x] `mvn test -DskipAssembly -pl plugins/json` — 125/125 green (transitive contract sanity).
- [x] New: `OgnlParameterAllowlisterTest` (6 unit tests).
- [x] New: `CookieInterceptorAnnotationTest` (8 tests covering the full behavior matrix above, including subclass-override-of-deprecated-hook gets the gate, ModelDriven exemption, transition mode).
- [x] Existing `CookieInterceptorTest` (9 tests) updated to wire pass-through lambdas via a `disableAuthorizationGate(...)` helper since those tests construct `CookieInterceptor` via `new` rather than the container.
- [x] Existing `ParametersInterceptorTest`, `ActionMappingParametersInterceptorTest`, `StaticParametersInterceptorTest`, `StrutsParameterAnnotationTest` all green after the refactor.

## Out of scope (separate Jira candidates)

- `ScopeInterceptor` (`ScopeInterceptor.java:306,328`) has the same `stack.setValue` pattern from session/application scope — likely warrants its own ticket.
- `ParametersInterceptor.hasValidAnnotated*` helpers (lines 432–548) appear to be dead post-WW-5626 (only `StrutsParameterAuthorizer`'s versions are reached at runtime). Cleanup is a separate audit.
- `ParameterNameAware` consultation in `CookieInterceptor` — not currently consulted; adding it would be a larger behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)