### PR TITLE
fix(core): enforce class-level HTTP method annotations for wildcard-resolved unannotated methods

### DIFF
--- a/core/src/main/java/org/apache/struts2/interceptor/httpmethod/HttpMethodInterceptor.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/httpmethod/HttpMethodInterceptor.java
@@ -90,7 +90,8 @@ public class HttpMethodInterceptor extends AbstractInterceptor {
                     invocation.getProxy().getMethod(), AllowedHttpMethod.class.getSimpleName(), request.getMethod());
                 return doIntercept(invocation, method);
             }
-        } else if (AnnotationUtils.isAnnotatedBy(action.getClass(), HTTP_METHOD_ANNOTATIONS)) {
+        }
+        if (AnnotationUtils.isAnnotatedBy(action.getClass(), HTTP_METHOD_ANNOTATIONS)) {
             LOG.debug("Action: {} annotated with: {}, checking if request: {} meets allowed methods!",
                 action, AllowedHttpMethod.class.getSimpleName(), request.getMethod());
             return doIntercept(invocation, action.getClass());

--- a/core/src/test/java/org/apache/struts2/interceptor/httpmethod/HttpMethodInterceptorTest.java
+++ b/core/src/test/java/org/apache/struts2/interceptor/httpmethod/HttpMethodInterceptorTest.java
@@ -273,6 +273,50 @@ public class HttpMethodInterceptorTest extends StrutsInternalTestCase {
         invocation.setProxy(actionProxy);
     }
 
+
+    /**
+     * Regression: wildcard-resolved method with NO method-level annotation on a class
+     * that has a class-level @AllowedHttpMethod(POST) — GET must be rejected.
+     * The WW-5535 fix introduced an if/else-if that made the class-level check
+     * unreachable when isMethodSpecified()=true and the method is unannotated.
+     */
+    public void testWildcardResolvedUnannotatedMethodRespectsClassLevelAnnotation() throws Exception {
+        // given — HttpMethodsTestAction has @AllowedHttpMethod(POST) at class level
+        // execute() inherited from ActionSupport has no method-level HTTP annotation
+        HttpMethodsTestAction action = new HttpMethodsTestAction();
+        prepareActionInvocation(action);
+        actionProxy.setMethod("execute");
+        actionProxy.setMethodSpecified(true); // simulates wildcard-resolved, not default
+
+        prepareRequest("get");
+
+        // when
+        String resultName = interceptor.intercept(invocation);
+
+        // then — class-level @AllowedHttpMethod(POST) must still be enforced
+        assertEquals("bad-request", resultName);
+    }
+
+    /**
+     * Counterpart: POST on wildcard-resolved unannotated method must succeed
+     * when the class allows POST via class-level annotation.
+     */
+    public void testWildcardResolvedUnannotatedMethodAllowsPostWithClassLevelAnnotation() throws Exception {
+        // given
+        HttpMethodsTestAction action = new HttpMethodsTestAction();
+        prepareActionInvocation(action);
+        actionProxy.setMethod("execute");
+        actionProxy.setMethodSpecified(true);
+
+        prepareRequest("post");
+
+        // when
+        String resultName = interceptor.intercept(invocation);
+
+        // then
+        assertEquals("success", resultName);
+    }
+
     private void prepareRequest(String httpMethod) {
         MockHttpServletRequest request = new MockHttpServletRequest(httpMethod, "/action");
         ActionContext.getContext().withServletRequest(request);


### PR DESCRIPTION
## Summary

Fixes a regression introduced by the WW-5535 fix (commit 4d2eb93) where class-level
HTTP method annotations are silently ignored for wildcard-resolved action methods that
carry no method-level annotation.

## Problem

`HttpMethodInterceptor.intercept()` uses an `if/else-if` structure that creates a dead
zone. After the WW-5535 fix made wildcard-resolved methods report `isMethodSpecified()=true`,
the class-level annotation branch became structurally unreachable for unannotated methods:

```java
if (invocation.getProxy().isMethodSpecified()) {
    Method method = action.getClass().getMethod(invocation.getProxy().getMethod());
    if (AnnotationUtils.isAnnotatedBy(method, HTTP_METHOD_ANNOTATIONS)) {
        return doIntercept(invocation, method);
    }
    // unannotated method falls through silently
} else if (AnnotationUtils.isAnnotatedBy(action.getClass(), HTTP_METHOD_ANNOTATIONS)) {
    return doIntercept(invocation, action.getClass()); // never reached
}
return invocation.invoke(); // no enforcement
```

**Affected scenario:**

```java
@HttpPost // intends to restrict all requests to POST
public class OrderAction extends ActionSupport {
    public String create() { ... } // no method-level annotation
}
```

```xml
<action name="order-*" class="com.example.OrderAction" method="{1}">
```

`GET /order-create` — resolves `create()` via wildcard, `isMethodSpecified()=true`,
method has no annotation, else-if never evaluated, `@HttpPost` on the class is ignored,
request proceeds.

## Fix

Convert `else if` to a standalone `if` so the class-level annotation check is always
evaluated as a fallback when the method carries no annotation. Method-level annotations
still take precedence (checked first). One-line change.

```java
if (invocation.getProxy().isMethodSpecified()) {
    Method method = action.getClass().getMethod(invocation.getProxy().getMethod());
    if (AnnotationUtils.isAnnotatedBy(method, HTTP_METHOD_ANNOTATIONS)) {
        return doIntercept(invocation, method);
    }
}
if (AnnotationUtils.isAnnotatedBy(action.getClass(), HTTP_METHOD_ANNOTATIONS)) {
    return doIntercept(invocation, action.getClass());
}
return invocation.invoke();
```

## Tests Added

Two regression tests in `HttpMethodInterceptorTest`:

- `testWildcardResolvedUnannotatedMethodRespectsClassLevelAnnotation` — GET rejected on
  a class annotated with `@AllowedHttpMethod(POST)` when the resolved method is unannotated
- `testWildcardResolvedUnannotatedMethodAllowsPostWithClassLevelAnnotation` — POST allowed
  on the same configuration

## Related

- Fixes regression introduced by: #1592
- Original issue: [WW-5535](https://issues.apache.org/jira/browse/WW-5535)