### PR TITLE
WW-5535 test(core): cover wildcard-resolved unannotated methods via real proxy

### DIFF
--- a/core/src/test/java/org/apache/struts2/interceptor/httpmethod/HttpMethodInterceptorTest.java
+++ b/core/src/test/java/org/apache/struts2/interceptor/httpmethod/HttpMethodInterceptorTest.java
@@ -19,12 +19,16 @@
 package org.apache.struts2.interceptor.httpmethod;
 
 import org.apache.struts2.ActionContext;
+import org.apache.struts2.ActionProxy;
+import org.apache.struts2.config.StrutsXmlConfigurationProvider;
 import org.apache.struts2.mock.MockActionInvocation;
 import org.apache.struts2.mock.MockActionProxy;
 import org.apache.struts2.HttpMethodsTestAction;
 import org.apache.struts2.StrutsInternalTestCase;
 import org.apache.struts2.TestAction;
 import org.springframework.mock.web.MockHttpServletRequest;
+
+import java.util.Map;
 
 public class HttpMethodInterceptorTest extends StrutsInternalTestCase {
 
@@ -316,6 +320,38 @@ public class HttpMethodInterceptorTest extends StrutsInternalTestCase {
 
         // then
         assertEquals("success", resultName);
+    }
+
+    /**
+     * Integration regression for WW-5535: exercise the full wildcard resolution path through
+     * a real {@link org.apache.struts2.DefaultActionProxy} (not a MockActionProxy).
+     * <p>
+     * Config: {@code <action name="Wild-*" class="HttpMethodsTestAction" method="{1}">} —
+     * URL {@code Wild-execute} resolves to method {@code execute()} inherited from
+     * {@code ActionSupport} (no method-level HTTP annotation). The class carries
+     * {@code @AllowedHttpMethod(POST)}, so GET must be rejected end-to-end.
+     */
+    public void testWildcardResolvedExecuteRejectsGetThroughRealProxy() throws Exception {
+        loadConfigurationProviders(new StrutsXmlConfigurationProvider(
+            "org/apache/struts2/config/providers/xwork-test-allowed-methods.xml"));
+
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/Wild-execute");
+        Map<String, Object> extraContext = ActionContext.of()
+            .withServletRequest(request)
+            .getContextMap();
+
+        ActionProxy proxy = actionProxyFactory.createActionProxy("", "Wild-execute", null, extraContext);
+
+        // sanity: confirms the WW-5535 fix in DefaultActionProxy.resolveMethod() is wired up
+        assertEquals("execute", proxy.getMethod());
+        assertTrue("Wildcard-resolved method must report isMethodSpecified()=true", proxy.isMethodSpecified());
+
+        HttpMethodInterceptor realInterceptor = new HttpMethodInterceptor();
+        String result = realInterceptor.intercept(proxy.getInvocation());
+
+        // class-level @AllowedHttpMethod(POST) must still be enforced even though the resolved
+        // method carries no method-level annotation — this is what #1690 fixed
+        assertEquals("bad-request", result);
     }
 
     private void prepareRequest(String httpMethod) {


### PR DESCRIPTION
## Summary

Closes the integration test gap identified in the [WW-5535 research](https://github.com/apache/struts/blob/main/thoughts/shared/research/2026-02-22-WW-5535-http-method-interceptor-wildcard.md): no test exercised `HttpMethodInterceptor` against a **real** `DefaultActionProxy` resolving a wildcard action with an unannotated method.

Together with the existing `MockActionProxy`-based regression tests, this locks in both halves of the fix:

- `DefaultActionProxy.resolveMethod()` sets `isMethodSpecified()=true` for wildcard-resolved methods — WW-5535 / #1592
- `HttpMethodInterceptor` falls back to class-level annotations when the resolved method is unannotated — #1690

## What the test does

Uses the existing `xwork-test-allowed-methods.xml`:

```xml
<action name="Wild-*" class="HttpMethodsTestAction" method="{1}">
```

`HttpMethodsTestAction` carries class-level `@AllowedHttpMethod(POST)`. URL `Wild-execute` resolves to `ActionSupport.execute()` — no method-level HTTP annotation. The integration test:

1. Creates a real proxy via `actionProxyFactory.createActionProxy("", "Wild-execute", null, ...)`
2. Asserts `proxy.getMethod() == "execute"` and `proxy.isMethodSpecified() == true` (sanity-checks the WW-5535 wiring)
3. Runs a real `HttpMethodInterceptor` against `proxy.getInvocation()` with a GET request
4. Asserts `bad-request` — class-level annotation still enforced

Only the negative (GET) case is covered: it returns before `invocation.invoke()`, so the test stays a focused integration check without dragging the whole interceptor stack in. The positive POST counterpart is already covered by the unit tests added in #1690.

Fixes [WW-5535](https://issues.apache.org/jira/browse/WW-5535) test gap.

## Test plan

- [x] \`mvn test -DskipAssembly -pl core -Dtest=HttpMethodInterceptorTest\` — 16/16 pass
- [x] CI green