### PR TITLE
Fix CSP style-src nonce policy and escape unsafe HTML output paths

### DIFF
--- a/core/src/main/java/org/apache/struts2/interceptor/csp/CspSettings.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/csp/CspSettings.java
@@ -35,6 +35,7 @@ public interface CspSettings {
     String CSP_REPORT_HEADER = "Content-Security-Policy-Report-Only";
     String OBJECT_SRC = "object-src";
     String SCRIPT_SRC = "script-src";
+    String STYLE_SRC = "style-src";
     String BASE_URI = "base-uri";
     String REPORT_URI = "report-uri";
     String REPORT_TO = "report-to";

--- a/core/src/main/java/org/apache/struts2/interceptor/csp/DefaultCspSettings.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/csp/DefaultCspSettings.java
@@ -110,6 +110,10 @@ public class DefaultCspSettings implements CspSettings {
                 .append(format(" 'nonce-%s' ", nonceValue))
                 .append(format("'%s' ", STRICT_DYNAMIC))
                 .append(format("%s %s; ", HTTP, HTTPS))
+                .append(STYLE_SRC)
+                .append(format(" 'nonce-%s' ", nonceValue))
+                .append(format("'%s' ", STRICT_DYNAMIC))
+                .append(format("%s %s; ", HTTP, HTTPS))
                 .append(BASE_URI)
                 .append(format(" '%s'; ", NONE));
 

--- a/core/src/main/java/org/apache/struts2/result/ServletRedirectResult.java
+++ b/core/src/main/java/org/apache/struts2/result/ServletRedirectResult.java
@@ -33,6 +33,8 @@ import org.apache.struts2.dispatcher.mapper.ActionMapper;
 import org.apache.struts2.dispatcher.mapper.ActionMapping;
 import org.apache.struts2.url.QueryStringBuilder;
 
+import org.apache.commons.text.StringEscapeUtils;
+
 import java.io.IOException;
 import java.io.Serial;
 import java.net.MalformedURLException;
@@ -248,7 +250,7 @@ public class ServletRedirectResult extends StrutsResultSupport implements Reflec
                 response.setStatus(statusCode);
                 response.setHeader("Location", finalLocation);
                 try {
-                    response.getWriter().write(finalLocation);
+                    response.getWriter().write(StringEscapeUtils.escapeHtml4(finalLocation));
                 } finally {
                     response.getWriter().close();
                 }

--- a/core/src/main/resources/template/html5/radiomap.ftl
+++ b/core/src/main/resources/template/html5/radiomap.ftl
@@ -64,7 +64,7 @@ file for it's localized value.  This is then used as a label -->
 </#if>
 <input type="radio"<#rt/>
 <#if attributes.name?has_content>
- name="${attributes.name?no_esc}"<#rt/>
+ name="${attributes.name?replace('"', '&#34;')?no_esc}"<#rt/>
 </#if>
  id="${attributes.id}${itemKeyStr?replace(".", "_")}"<#rt/>
 <#if tag.contains(attributes.nameValue!'', itemKey)>

--- a/core/src/main/resources/template/simple/radiomap.ftl
+++ b/core/src/main/resources/template/simple/radiomap.ftl
@@ -63,7 +63,7 @@
     </#if>
 <input type="radio"<#rt/>
 <#if attributes.name?has_content>
- name="${attributes.name?no_esc}"<#rt/>
+ name="${attributes.name?replace('"', '&#34;')?no_esc}"<#rt/>
 </#if>
  id="${attributes.id}${itemKeyStr?replace(".", "_")}"<#rt/>
 <#if tag.contains(attributes.nameValue!'', itemKey)>

--- a/core/src/test/java/org/apache/struts2/interceptor/CspInterceptorTest.java
+++ b/core/src/test/java/org/apache/struts2/interceptor/CspInterceptorTest.java
@@ -240,23 +240,26 @@ public class CspInterceptorTest extends StrutsInternalTestCase {
     public void checkHeader(String reportUri, String reportTo, boolean enforcingMode) {
         String expectedCspHeader;
         if (Strings.isEmpty(reportUri)) {
-            expectedCspHeader = String.format("%s '%s'; %s 'nonce-%s' '%s' %s %s; %s '%s'; ",
+            expectedCspHeader = String.format("%s '%s'; %s 'nonce-%s' '%s' %s %s; %s 'nonce-%s' '%s' %s %s; %s '%s'; ",
                     CspSettings.OBJECT_SRC, CspSettings.NONE,
                     CspSettings.SCRIPT_SRC, session.getAttribute("nonce"), CspSettings.STRICT_DYNAMIC, CspSettings.HTTP, CspSettings.HTTPS,
+                    CspSettings.STYLE_SRC, session.getAttribute("nonce"), CspSettings.STRICT_DYNAMIC, CspSettings.HTTP, CspSettings.HTTPS,
                     CspSettings.BASE_URI, CspSettings.NONE
             );
         } else {
             if (Strings.isEmpty(reportTo)) {
-                expectedCspHeader = String.format("%s '%s'; %s 'nonce-%s' '%s' %s %s; %s '%s'; %s %s; ",
+                expectedCspHeader = String.format("%s '%s'; %s 'nonce-%s' '%s' %s %s; %s 'nonce-%s' '%s' %s %s; %s '%s'; %s %s; ",
                         CspSettings.OBJECT_SRC, CspSettings.NONE,
                         CspSettings.SCRIPT_SRC, session.getAttribute("nonce"), CspSettings.STRICT_DYNAMIC, CspSettings.HTTP, CspSettings.HTTPS,
+                        CspSettings.STYLE_SRC, session.getAttribute("nonce"), CspSettings.STRICT_DYNAMIC, CspSettings.HTTP, CspSettings.HTTPS,
                         CspSettings.BASE_URI, CspSettings.NONE,
                         CspSettings.REPORT_URI, reportUri
                 );
             } else {
-                expectedCspHeader = String.format("%s '%s'; %s 'nonce-%s' '%s' %s %s; %s '%s'; %s %s; %s %s; ",
+                expectedCspHeader = String.format("%s '%s'; %s 'nonce-%s' '%s' %s %s; %s 'nonce-%s' '%s' %s %s; %s '%s'; %s %s; %s %s; ",
                         CspSettings.OBJECT_SRC, CspSettings.NONE,
                         CspSettings.SCRIPT_SRC, session.getAttribute("nonce"), CspSettings.STRICT_DYNAMIC, CspSettings.HTTP, CspSettings.HTTPS,
+                        CspSettings.STYLE_SRC, session.getAttribute("nonce"), CspSettings.STRICT_DYNAMIC, CspSettings.HTTP, CspSettings.HTTPS,
                         CspSettings.BASE_URI, CspSettings.NONE,
                         CspSettings.REPORT_URI, reportUri,
                         CspSettings.REPORT_TO, reportTo


### PR DESCRIPTION
This PR fixes three framework-side output safety issues related to CSP policy generation and HTML escaping.

All existing tests pass after the changes.

## Fix 1: radiomap.ftl attribute escaping

### Problem

`radiomap.ftl` used:

```ftl
${attributes.name?no_esc}
```

without pre-sanitizing `"` characters.

Unlike other form templates, this bypassed FreeMarker auto-escaping entirely and allowed a double quote to break out of the HTML attribute context.

### Fix

Escape only double quotes before `?no_esc`:

```ftl
${attributes.name?replace('"', '&#34;')?no_esc}
```

Single quotes are intentionally preserved because Struts OGNL map syntax may legitimately contain them:

```text
myMap['key']
```

Files changed:

* `template/simple/radiomap.ftl`
* `template/html5/radiomap.ftl`

---

## Fix 2: CSP policy missing `style-src`

### Problem

The framework propagates CSP nonces to generated `<link>` and `<script>` tags, but the default CSP policy only defined:

```text
script-src 'nonce-...'
```

No `style-src` directive existed, meaning style nonces were not enforced by browsers.

### Fix

Added:

* `STYLE_SRC` constant to `CspSettings`
* `style-src 'nonce-...' ...` directive generation in `DefaultCspSettings`

Also updated CSP interceptor tests to validate the new policy format.

Files changed:

* `CspSettings.java`
* `DefaultCspSettings.java`
* `CspInterceptorTest.java`

---

## Fix 3: unescaped redirect body output

### Problem

`ServletRedirectResult` wrote the raw redirect URL directly into the HTML response body when using non-302 status codes:

```java
response.getWriter().write(finalLocation);
```

Since `finalLocation` may contain OGNL-evaluated values, framework-controlled HTML output should always be escaped before rendering.

### Fix

Escape the response body output using Apache Commons Text:

```java
StringEscapeUtils.escapeHtml4(finalLocation)
```

The `Location` response header itself remains unchanged.

Files changed:

* `ServletRedirectResult.java`
