### PR TITLE
WW-5636 Harden redirect URL escaping in non-302 response body

### DIFF
--- a/core/src/main/java/org/apache/struts2/result/ServletRedirectResult.java
+++ b/core/src/main/java/org/apache/struts2/result/ServletRedirectResult.java
@@ -26,6 +26,7 @@ import org.apache.struts2.util.reflection.ReflectionException;
 import org.apache.struts2.util.reflection.ReflectionExceptionHandler;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.struts2.dispatcher.Dispatcher;
@@ -248,7 +249,7 @@ public class ServletRedirectResult extends StrutsResultSupport implements Reflec
                 response.setStatus(statusCode);
                 response.setHeader("Location", finalLocation);
                 try {
-                    response.getWriter().write(finalLocation);
+                    response.getWriter().write(StringEscapeUtils.escapeHtml4(finalLocation));
                 } finally {
                     response.getWriter().close();
                 }

--- a/core/src/test/java/org/apache/struts2/result/ServletRedirectResultTest.java
+++ b/core/src/test/java/org/apache/struts2/result/ServletRedirectResultTest.java
@@ -47,6 +47,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static jakarta.servlet.http.HttpServletResponse.SC_OK;
 import static jakarta.servlet.http.HttpServletResponse.SC_SEE_OTHER;
 import static org.easymock.EasyMock.createControl;
 import static org.easymock.EasyMock.createMock;
@@ -141,6 +142,33 @@ public class ServletRedirectResultTest extends StrutsInternalTestCase implements
             fail();
         }
         assertEquals("/context/bar/foo.jsp", writer.toString());
+    }
+
+    public void testStatusCode200LocationIsHtmlEscapedInBody() {
+        String maliciousLocation = "/bar/foo.jsp?next=<script>alert(1)</script>&x=1";
+        String expandedLocation = "/context" + maliciousLocation;
+        String expectedBody = "/context/bar/foo.jsp?next=&lt;script&gt;alert(1)&lt;/script&gt;&amp;x=1";
+
+        view.setLocation(maliciousLocation);
+        view.setStatusCode(SC_OK);
+        responseMock.expectAndReturn("encodeRedirectURL", expandedLocation, expandedLocation);
+        responseMock.expect("setStatus", C.args(C.eq(SC_OK)));
+        responseMock.expect("setHeader", C.args(C.eq("Location"), C.eq(expandedLocation)));
+        StringWriter writer = new StringWriter();
+        responseMock.matchAndReturn("getWriter", new PrintWriter(writer));
+
+        try {
+            view.execute(ai);
+            requestMock.verify();
+            responseMock.verify();
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail();
+      }
+
+        assertEquals(expectedBody, writer.toString());
+        assertFalse("response body must not contain a raw <script> tag",
+            writer.toString().contains("<script>"));
     }
 
     public void testAbsoluteRedirectAnchor() {


### PR DESCRIPTION
## Summary
ServletRedirectResult.sendRedirect() writes the redirect target URL
directly to the response body for any statusCode != 302 (e.g. 301, 303,
307, 308, or misconfigured 200), without HTML encoding. Since the servlet
container defaults Content-Type to text/html, this is a reflected XSS
sink when user-controlled content reaches finalLocation via OGNL
expression evaluation (parse=true, the default).

PostbackResult.java (line 108) in the same package already uses
StringEscapeUtils.escapeHtml4() for the identical pattern — this aligns
ServletRedirectResult with the existing convention.

## Changes
- HTML-escape finalLocation before writing to response body in sendRedirect()
- Location header is intentionally left unescaped (required for valid redirect)
- New test verifies <script> payload is escaped in body while Location header keeps raw URL

## References
- CWE-79: Improper Neutralization of Input During Web Page Generation
- Comparable fix: PostbackResult.java line 108 (same codebase)