### PR TITLE
WW-5635 Avoid logging sensitive token values in TokenHelper

### DIFF
--- a/core/src/main/java/org/apache/struts2/util/TokenHelper.java
+++ b/core/src/main/java/org/apache/struts2/util/TokenHelper.java
@@ -18,6 +18,7 @@
  */
 package org.apache.struts2.util;
 
+import org.apache.struts2.dispatcher.Dispatcher;
 import org.apache.struts2.ActionContext;
 import org.apache.struts2.text.LocalizedTextProvider;
 import org.apache.logging.log4j.LogManager;
@@ -191,8 +192,9 @@ public class TokenHelper {
                         normalizeSpace(token)
                 }));
             }
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Token mismatch detail - token name [{}], form token [{}], session token [{}]",
+            Dispatcher dispatcher = Dispatcher.getInstance();
+            if (dispatcher != null && dispatcher.isDevMode()) {
+                LOG.warn("Token mismatch detail - token name [{}], form token [{}], session token [{}]",
                         normalizeSpace(tokenName), normalizeSpace(token), sessionToken);
             }
 

--- a/core/src/main/java/org/apache/struts2/util/TokenHelper.java
+++ b/core/src/main/java/org/apache/struts2/util/TokenHelper.java
@@ -29,6 +29,7 @@ import java.math.BigInteger;
 import java.security.SecureRandom;
 import java.util.Map;
 import java.util.Random;
+import static org.apache.commons.lang3.StringUtils.normalizeSpace;
 
 /**
  * TokenHelper
@@ -186,10 +187,10 @@ public class TokenHelper {
         if (!token.equals(sessionToken)) {
             if (LOG.isWarnEnabled()) {
                 LocalizedTextProvider localizedTextProvider = ActionContext.getContext().getContainer().getInstance(LocalizedTextProvider.class);
-                LOG.warn(localizedTextProvider.findText(TokenHelper.class, "struts.internal.invalid.token", ActionContext.getContext().getLocale(), "Form token {0} does not match the session token {1}.", new Object[]{
-                        token, sessionToken
-                }));
-            }
+                LOG.warn(localizedTextProvider.findText(TokenHelper.class, "struts.internal.invalid.token", ActionContext.getContext().getLocale(), "The provided form token does not match the expected session token.", new Object[0]));
+			}   
+            LOG.debug("Token mismatch for token name [{}]: form token present [{}], session token present [{}]",    
+                    normalizeSpace(tokenName), token != null, sessionToken != null);
 
             return false;
         }

--- a/core/src/main/java/org/apache/struts2/util/TokenHelper.java
+++ b/core/src/main/java/org/apache/struts2/util/TokenHelper.java
@@ -187,10 +187,14 @@ public class TokenHelper {
         if (!token.equals(sessionToken)) {
             if (LOG.isWarnEnabled()) {
                 LocalizedTextProvider localizedTextProvider = ActionContext.getContext().getContainer().getInstance(LocalizedTextProvider.class);
-                LOG.warn(localizedTextProvider.findText(TokenHelper.class, "struts.internal.invalid.token", ActionContext.getContext().getLocale(), "The provided form token does not match the expected session token.", new Object[0]));
-			}   
-            LOG.debug("Token mismatch for token name [{}]: form token present [{}], session token present [{}]",    
-                    normalizeSpace(tokenName), token != null, sessionToken != null);
+                LOG.warn(localizedTextProvider.findText(TokenHelper.class, "struts.internal.invalid.token", ActionContext.getContext().getLocale(), "Form token {0} does not match the expected session token.", new Object[]{
+                        normalizeSpace(token)
+                }));
+            }
+            if (ActionContext.getContext().isDevMode()) {
+                LOG.warn("Token mismatch detail - token name [{}], form token [{}], session token [{}]",
+                        normalizeSpace(tokenName), normalizeSpace(token), sessionToken);
+            }
 
             return false;
         }

--- a/core/src/main/java/org/apache/struts2/util/TokenHelper.java
+++ b/core/src/main/java/org/apache/struts2/util/TokenHelper.java
@@ -191,8 +191,8 @@ public class TokenHelper {
                         normalizeSpace(token)
                 }));
             }
-            if (ActionContext.getContext().isDevMode()) {
-                LOG.warn("Token mismatch detail - token name [{}], form token [{}], session token [{}]",
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Token mismatch detail - token name [{}], form token [{}], session token [{}]",
                         normalizeSpace(tokenName), normalizeSpace(token), sessionToken);
             }
 

--- a/core/src/main/resources/org/apache/struts2/struts-messages.properties
+++ b/core/src/main/resources/org/apache/struts2/struts-messages.properties
@@ -20,7 +20,7 @@
 # See https://issues.apache.org/jira/browse/WW-4195 for more details!
 
 struts.messages.invalid.token=The form has already been processed or no token was supplied, please try again.
-struts.internal.invalid.token=The provided form token does not match the expected session token.
+struts.internal.invalid.token=Form token {0} does not match the expected session token.
 
 struts.messages.bypass.request=Bypassing {0}/{1}
 struts.messages.current.file=File {0} {1} {2} {3}

--- a/core/src/main/resources/org/apache/struts2/struts-messages.properties
+++ b/core/src/main/resources/org/apache/struts2/struts-messages.properties
@@ -20,7 +20,7 @@
 # See https://issues.apache.org/jira/browse/WW-4195 for more details!
 
 struts.messages.invalid.token=The form has already been processed or no token was supplied, please try again.
-struts.internal.invalid.token=Form token {0} does not match the session token {1}.
+struts.internal.invalid.token=The provided form token does not match the expected session token.
 
 struts.messages.bypass.request=Bypassing {0}/{1}
 struts.messages.current.file=File {0} {1} {2} {3}

--- a/core/src/main/resources/org/apache/struts2/struts-messages_da.properties
+++ b/core/src/main/resources/org/apache/struts2/struts-messages_da.properties
@@ -17,7 +17,7 @@
 # under the License.
 #
 struts.messages.invalid.token=Denne form er allerede blevet behandlet eller der mangler en token, venligst pr\u00F8v igen.
-struts.internal.invalid.token=Form token {0} passer ikke med den token som findes i session {1}.
+struts.internal.invalid.token=Den angivne form-token passer ikke med den forventede session-token.
 
 struts.messages.bypass.request=Springer over {0}/{1}
 struts.messages.current.file=Fil {0} {1} {2} {3}

--- a/core/src/main/resources/org/apache/struts2/struts-messages_da.properties
+++ b/core/src/main/resources/org/apache/struts2/struts-messages_da.properties
@@ -17,7 +17,7 @@
 # under the License.
 #
 struts.messages.invalid.token=Denne form er allerede blevet behandlet eller der mangler en token, venligst pr\u00F8v igen.
-struts.internal.invalid.token=Den angivne form-token passer ikke med den forventede session-token.
+struts.internal.invalid.token=Form token {0} passer ikke med den forventede session-token.
 
 struts.messages.bypass.request=Springer over {0}/{1}
 struts.messages.current.file=Fil {0} {1} {2} {3}

--- a/core/src/main/resources/org/apache/struts2/struts-messages_de.properties
+++ b/core/src/main/resources/org/apache/struts2/struts-messages_de.properties
@@ -17,7 +17,7 @@
 # under the License.
 #
 struts.messages.invalid.token=Das Formular wurde bereits verarbeitet oder es wurde kein Token angegeben, bitte versuchen Sie es erneut.
-struts.internal.invalid.token=Das Formular Token {0} stimmt nicht mit dem Session Token {1} \u00FCberein.
+struts.internal.invalid.token=Das bereitgestellte Formular-Token stimmt nicht mit dem erwarteten Session-Token \u00FCberein.
 
 struts.messages.bypass.request=\u00DCberspringe {0}/{1}
 struts.messages.current.file=Datei {0} {1} {2} {3}

--- a/core/src/main/resources/org/apache/struts2/struts-messages_de.properties
+++ b/core/src/main/resources/org/apache/struts2/struts-messages_de.properties
@@ -17,7 +17,7 @@
 # under the License.
 #
 struts.messages.invalid.token=Das Formular wurde bereits verarbeitet oder es wurde kein Token angegeben, bitte versuchen Sie es erneut.
-struts.internal.invalid.token=Das bereitgestellte Formular-Token stimmt nicht mit dem erwarteten Session-Token \u00FCberein.
+struts.internal.invalid.token=Das Formular-Token {0} stimmt nicht mit dem erwarteten Session-Token \u00FCberein.
 
 struts.messages.bypass.request=\u00DCberspringe {0}/{1}
 struts.messages.current.file=Datei {0} {1} {2} {3}

--- a/core/src/main/resources/org/apache/struts2/struts-messages_en.properties
+++ b/core/src/main/resources/org/apache/struts2/struts-messages_en.properties
@@ -21,7 +21,7 @@
 # See https://issues.apache.org/jira/browse/WW-4195 for more details!
 
 struts.messages.invalid.token=The form has already been processed or no token was supplied, please try again.
-struts.internal.invalid.token=The provided form token does not match the expected session token.
+struts.internal.invalid.token=Form token {0} does not match the expected session token.
 
 struts.messages.bypass.request=Bypassing {0}/{1}
 struts.messages.current.file=File {0} {1} {2} {3}

--- a/core/src/main/resources/org/apache/struts2/struts-messages_en.properties
+++ b/core/src/main/resources/org/apache/struts2/struts-messages_en.properties
@@ -21,7 +21,7 @@
 # See https://issues.apache.org/jira/browse/WW-4195 for more details!
 
 struts.messages.invalid.token=The form has already been processed or no token was supplied, please try again.
-struts.internal.invalid.token=Form token {0} does not match the session token {1}.
+struts.internal.invalid.token=The provided form token does not match the expected session token.
 
 struts.messages.bypass.request=Bypassing {0}/{1}
 struts.messages.current.file=File {0} {1} {2} {3}

--- a/core/src/main/resources/org/apache/struts2/struts-messages_pl.properties
+++ b/core/src/main/resources/org/apache/struts2/struts-messages_pl.properties
@@ -17,7 +17,7 @@
 # under the License.
 #
 struts.messages.invalid.token=Formularz zosta\u0142 ju\u017C przetworzony lub nie za\u0142\u0105czono tokena, spr\u00F3buj ponownie.
-struts.internal.invalid.token=Token formularza {0} nie pasuje do tokena sesji {1}.
+struts.internal.invalid.token=Podany token formularza nie pasuje do oczekiwanego tokena sesji.
 
 struts.messages.bypass.request=Omijanie {0}/{1}
 struts.messages.current.file=Plik {0} {1} {2} {3}

--- a/core/src/main/resources/org/apache/struts2/struts-messages_pl.properties
+++ b/core/src/main/resources/org/apache/struts2/struts-messages_pl.properties
@@ -17,7 +17,7 @@
 # under the License.
 #
 struts.messages.invalid.token=Formularz zosta\u0142 ju\u017C przetworzony lub nie za\u0142\u0105czono tokena, spr\u00F3buj ponownie.
-struts.internal.invalid.token=Podany token formularza nie pasuje do oczekiwanego tokena sesji.
+struts.internal.invalid.token=Token formularza {0} nie pasuje do oczekiwanego tokena sesji.
 
 struts.messages.bypass.request=Omijanie {0}/{1}
 struts.messages.current.file=Plik {0} {1} {2} {3}

--- a/core/src/main/resources/org/apache/struts2/struts-messages_pt.properties
+++ b/core/src/main/resources/org/apache/struts2/struts-messages_pt.properties
@@ -17,7 +17,7 @@
 # under the License.
 #
 struts.messages.invalid.token=O formulario j\u00E1 foi processado ou nenhum token foi gerado, por favor tente novamente.
-struts.internal.invalid.token=O token do formul\u00E1rio fornecido \u00E9 diferente do token de sess\u00E3o esperado.
+struts.internal.invalid.token=O token do formul\u00E1rio {0} \u00E9 diferente do token de sess\u00E3o esperado.
 
 struts.messages.bypass.request=Ignorando {0}/ {1}
 struts.messages.current.file=Arquivo {0} {1} {2} {3}

--- a/core/src/main/resources/org/apache/struts2/struts-messages_pt.properties
+++ b/core/src/main/resources/org/apache/struts2/struts-messages_pt.properties
@@ -17,7 +17,7 @@
 # under the License.
 #
 struts.messages.invalid.token=O formulario j\u00E1 foi processado ou nenhum token foi gerado, por favor tente novamente.
-struts.internal.invalid.token=O token do formul\u00E1rio {0} \u00E9 diferente do token de sess\u00E3o {1}.
+struts.internal.invalid.token=O token do formul\u00E1rio fornecido \u00E9 diferente do token de sess\u00E3o esperado.
 
 struts.messages.bypass.request=Ignorando {0}/ {1}
 struts.messages.current.file=Arquivo {0} {1} {2} {3}


### PR DESCRIPTION
## Summary

When `TokenHelper.validToken()` detects a CSRF token mismatch, the WARN-level log message currently includes both the user-submitted form token and the server-side session token in cleartext. Since the session token is only removed on a successful match, the logged value remains a live credential — visible to anyone with access to application logs.

This change keeps the form token in the WARN message (with `normalizeSpace()` sanitization) and logs full token detail only when devMode is enabled via `Dispatcher.getInstance().isDevMode()`, consistent with how `ParametersInterceptor` already handles user-supplied values elsewhere in the codebase.

## Changes

**TokenHelper.java**
- WARN log keeps the form token with `normalizeSpace()` sanitization, session token is redacted
- Full token detail (including session token) is logged at WARN level only when devMode is enabled via Dispatcher, with null guard
- `Dispatcher` and `normalizeSpace` imports added

**6 i18n properties files**
- `struts-messages.properties`, `_en`, `_da`, `_de`, `_pl`, `_pt` — updated `struts.internal.invalid.token` to use `{0}` (form token only), removed `{1}` (session token)

## What is NOT changed
- Token generation, entropy, and session storage
- The `equals()` comparison and token-removal-on-success logic
- User-facing error messages (`struts.messages.invalid.token` — separate key, untouched)
- Return values from `validToken()` and interceptor result codes

JIRA: https://issues.apache.org/jira/browse/WW-5635

Submitter email- thearunmanni@gmail.com