### PR TITLE
WW-5645 Canonicalise static content paths and remove redundant URL decode

### DIFF
--- a/core/src/main/java/org/apache/struts2/RequestUtils.java
+++ b/core/src/main/java/org/apache/struts2/RequestUtils.java
@@ -53,6 +53,11 @@ public class RequestUtils {
      * Retrieves the current request servlet path.
      * Deals with differences between servlet specs (2.2 vs 2.3+)
      *
+     * <p>Note: the fallback branch extracts from the raw {@code requestURI}, which may
+     * retain percent-encoded characters. Callers must not apply additional URL decoding
+     * to the returned value because the servlet container has already performed decoding
+     * where applicable.</p>
+     *
      * @param request the request
      * @return the servlet path
      */

--- a/core/src/main/java/org/apache/struts2/dispatcher/DefaultStaticContentLoader.java
+++ b/core/src/main/java/org/apache/struts2/dispatcher/DefaultStaticContentLoader.java
@@ -32,9 +32,7 @@ import org.apache.struts2.webjars.WebJarUrlProvider;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.io.UnsupportedEncodingException;
 import java.net.URL;
-import java.net.URLDecoder;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collections;
@@ -222,6 +220,12 @@ public class DefaultStaticContentLoader implements StaticContentLoader {
         throws IOException {
         String name = cleanupPath(path);
 
+        if (Validator.containsMalformedPathSegment(name)) {
+            LOG.debug("Rejecting static resource request with malformed path segment");
+            sendNotFound(response);
+            return;
+        }
+
         if (name.startsWith(WEBJARS_REQUEST_PREFIX)) {
             if (!findWebJarResource(name, path, request, response)) {
                 sendNotFound(response);
@@ -353,17 +357,12 @@ public class DefaultStaticContentLoader implements StaticContentLoader {
      * @param name          resource name
      * @param packagePrefix The package prefix to use to locate the resource
      * @return full path
-     * @throws UnsupportedEncodingException If there is a encoding problem
      */
-    protected String buildPath(String name, String packagePrefix) throws UnsupportedEncodingException {
-        String resourcePath;
+    protected String buildPath(String name, String packagePrefix) {
         if (packagePrefix.endsWith("/") && name.startsWith("/")) {
-            resourcePath = packagePrefix + name.substring(1);
-        } else {
-            resourcePath = packagePrefix + name;
+            return packagePrefix + name.substring(1);
         }
-
-        return URLDecoder.decode(resourcePath, encoding);
+        return packagePrefix + name;
     }
 
 

--- a/core/src/main/java/org/apache/struts2/dispatcher/DefaultStaticContentLoader.java
+++ b/core/src/main/java/org/apache/struts2/dispatcher/DefaultStaticContentLoader.java
@@ -103,11 +103,6 @@ public class DefaultStaticContentLoader implements StaticContentLoader {
      */
     protected final Calendar lastModifiedCal = Calendar.getInstance();
 
-    /**
-     * Store state of StrutsConstants.STRUTS_I18N_ENCODING setting.
-     */
-    protected String encoding;
-
     protected boolean devMode;
 
     protected WebJarUrlProvider webJarUrlProvider;
@@ -141,16 +136,6 @@ public class DefaultStaticContentLoader implements StaticContentLoader {
     @Inject(StrutsConstants.STRUTS_SERVE_STATIC_BROWSER_CACHE)
     public void setServeStaticBrowserCache(String serveStaticBrowserCache) {
         this.serveStaticBrowserCache = BooleanUtils.toBoolean(serveStaticBrowserCache);
-    }
-
-    /**
-     * Modify state of StrutsConstants.STRUTS_I18N_ENCODING setting.
-     *
-     * @param encoding New setting
-     */
-    @Inject(StrutsConstants.STRUTS_I18N_ENCODING)
-    public void setEncoding(String encoding) {
-        this.encoding = encoding;
     }
 
     @Inject(StrutsConstants.STRUTS_DEVMODE)

--- a/core/src/main/java/org/apache/struts2/dispatcher/DefaultStaticContentLoader.java
+++ b/core/src/main/java/org/apache/struts2/dispatcher/DefaultStaticContentLoader.java
@@ -32,6 +32,7 @@ import org.apache.struts2.webjars.WebJarUrlProvider;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Optional;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -39,7 +40,6 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.StringTokenizer;
 
 /**
@@ -205,11 +205,13 @@ public class DefaultStaticContentLoader implements StaticContentLoader {
         throws IOException {
         String name = cleanupPath(path);
 
-        if (Validator.containsMalformedPathSegment(name)) {
-            LOG.debug("Rejecting static resource request with malformed path segment");
+        Optional<String> canonical = Validator.canonicalisePath(name);
+        if (canonical.isEmpty()) {
+            LOG.debug("Rejecting static resource request: path escapes intended scope");
             sendNotFound(response);
             return;
         }
+        name = "/" + canonical.get();
 
         if (name.startsWith(WEBJARS_REQUEST_PREFIX)) {
             if (!findWebJarResource(name, path, request, response)) {

--- a/core/src/main/java/org/apache/struts2/dispatcher/StaticContentLoader.java
+++ b/core/src/main/java/org/apache/struts2/dispatcher/StaticContentLoader.java
@@ -98,6 +98,26 @@ public interface StaticContentLoader {
                 LOG.debug("\"{}\" has been set to \"{}\"", StrutsConstants.STRUTS_UI_STATIC_CONTENT_PATH, uiStaticContentPath);
                 return uiStaticContentPath;
             }
+
+        /**
+         * Checks whether the given path contains malformed segments that do not belong in a
+         * normalised resource path, such as dot-dot sequences, backslash separators, or
+         * percent-encoded forms that a well-behaved client would never send for static
+         * resource requests.
+         *
+         * @param path the path to check (must not be null)
+         * @return {@code true} if the path contains a suspicious segment
+         */
+        public static boolean containsMalformedPathSegment(String path) {
+            if (path.contains("..")) {
+                return true;
+            }
+            if (path.contains("\\")) {
+                return true;
+            }
+            // Percent-encoded dot forms that have no place in a normalised static resource path
+            String lower = path.toLowerCase(java.util.Locale.ROOT);
+            return lower.contains("%2e");
         }
     }
 }

--- a/core/src/main/java/org/apache/struts2/dispatcher/StaticContentLoader.java
+++ b/core/src/main/java/org/apache/struts2/dispatcher/StaticContentLoader.java
@@ -98,7 +98,7 @@ public interface StaticContentLoader {
                 LOG.debug("\"{}\" has been set to \"{}\"", StrutsConstants.STRUTS_UI_STATIC_CONTENT_PATH, uiStaticContentPath);
                 return uiStaticContentPath;
             }
-
+       }
         /**
          * Checks whether the given path contains malformed segments that do not belong in a
          * normalised resource path, such as dot-dot sequences, backslash separators, or

--- a/core/src/main/java/org/apache/struts2/dispatcher/StaticContentLoader.java
+++ b/core/src/main/java/org/apache/struts2/dispatcher/StaticContentLoader.java
@@ -27,7 +27,9 @@ import org.apache.struts2.config.StrutsBeanSelectionProvider;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.util.Locale;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Optional;
 /**
  * Interface for loading static resources, based on a path. After implementing your own static content loader
  * you must tell the framework how to use it, eg.
@@ -100,28 +102,31 @@ public interface StaticContentLoader {
             }
         }
         /**
-         * Checks whether the given path contains malformed segments that do not belong in a
-         * normalised resource path, such as dot-dot sequences, backslash separators, or
-         * percent-encoded forms that a well-behaved client would never send for static
-         * resource requests.
+         * Normalises a resource path by resolving {@code .} and {@code ..}
+         * segments and converting backslash separators to forward slashes.
          *
-         * @param path the path to check (must not be null)
-         * @return {@code true} if the path contains a suspicious segment
+         * <p>Returns {@link Optional#empty()} if the resolved path would
+         * escape above the root (i.e. more {@code ..} segments than
+         * preceding path components).</p>
+         *
+         * @param path the raw path to normalise (must not be null)
+         * @return the canonical path without leading slash, or empty if
+         *         the path escapes above the root
          */
-        public static boolean containsMalformedPathSegment(String path) {
-            if (path.contains("\\")) {
-                return true;
-            }
-            for (String segment : path.split("/")) {
-                if (segment.equals("..") || segment.equals(".")) {
-                    return true;
+        public static Optional<String> canonicalisePath(String path) {
+            String normalised = path.replace('\\', '/');
+            Deque<String> segments = new ArrayDeque<>();
+            for (String segment : normalised.split("/", -1)) {
+                if ("..".equals(segment)) {
+                    if (segments.isEmpty()) {
+                        return Optional.empty();
+                    }
+                    segments.removeLast();
+                } else if (!".".equals(segment) && !segment.isEmpty()) {
+                    segments.addLast(segment);
                 }
-                // Percent-encoded dot forms that have no place in a normalised static resource path
-                if (segment.toLowerCase(Locale.ROOT).contains("%2e")) {
-                    return true;
-                }
             }
-            return false;
+            return Optional.of(String.join("/", segments));
         }
     }
 }

--- a/core/src/main/java/org/apache/struts2/dispatcher/StaticContentLoader.java
+++ b/core/src/main/java/org/apache/struts2/dispatcher/StaticContentLoader.java
@@ -98,7 +98,7 @@ public interface StaticContentLoader {
                 LOG.debug("\"{}\" has been set to \"{}\"", StrutsConstants.STRUTS_UI_STATIC_CONTENT_PATH, uiStaticContentPath);
                 return uiStaticContentPath;
             }
-       }
+        }
         /**
          * Checks whether the given path contains malformed segments that do not belong in a
          * normalised resource path, such as dot-dot sequences, backslash separators, or

--- a/core/src/main/java/org/apache/struts2/dispatcher/StaticContentLoader.java
+++ b/core/src/main/java/org/apache/struts2/dispatcher/StaticContentLoader.java
@@ -27,7 +27,7 @@ import org.apache.struts2.config.StrutsBeanSelectionProvider;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-
+import java.util.Locale;
 /**
  * Interface for loading static resources, based on a path. After implementing your own static content loader
  * you must tell the framework how to use it, eg.
@@ -109,15 +109,19 @@ public interface StaticContentLoader {
          * @return {@code true} if the path contains a suspicious segment
          */
         public static boolean containsMalformedPathSegment(String path) {
-            if (path.contains("..")) {
-                return true;
-            }
             if (path.contains("\\")) {
                 return true;
             }
-            // Percent-encoded dot forms that have no place in a normalised static resource path
-            String lower = path.toLowerCase(java.util.Locale.ROOT);
-            return lower.contains("%2e");
+            for (String segment : path.split("/")) {
+                if (segment.equals("..") || segment.equals(".")) {
+                    return true;
+                }
+                // Percent-encoded dot forms that have no place in a normalised static resource path
+                if (segment.toLowerCase(Locale.ROOT).contains("%2e")) {
+                    return true;
+                }
+            }
+            return false;
         }
     }
 }

--- a/core/src/main/java/org/apache/struts2/webjars/DefaultWebJarUrlProvider.java
+++ b/core/src/main/java/org/apache/struts2/webjars/DefaultWebJarUrlProvider.java
@@ -123,10 +123,12 @@ public class DefaultWebJarUrlProvider implements WebJarUrlProvider {
             return Optional.empty();
         }
         String normalized = StringUtils.stripStart(logicalPath, "/");
-        if (StaticContentLoader.Validator.containsMalformedPathSegment(normalized)) {
-            LOG.debug("Rejecting WebJar path with malformed segment: {}", logicalPath);
+        Optional<String> canonical = StaticContentLoader.Validator.canonicalisePath(normalized);
+        if (canonical.isEmpty()) {
+            LOG.debug("Rejecting WebJar path that escapes above root: {}", logicalPath);
             return Optional.empty();
-        }        
+        }
+        normalized = canonical.get();
         int slash = normalized.indexOf('/');
         if (slash < 1 || slash == normalized.length() - 1) {
             return Optional.empty();

--- a/core/src/main/java/org/apache/struts2/webjars/DefaultWebJarUrlProvider.java
+++ b/core/src/main/java/org/apache/struts2/webjars/DefaultWebJarUrlProvider.java
@@ -126,13 +126,7 @@ public class DefaultWebJarUrlProvider implements WebJarUrlProvider {
         if (StaticContentLoader.Validator.containsMalformedPathSegment(normalized)) {
             LOG.debug("Rejecting WebJar path with malformed segment: {}", logicalPath);
             return Optional.empty();
-        }
-        for (String segment : normalized.split("/")) {
-            if (segment.equals(".")) {
-                LOG.debug("Rejecting WebJar path with dot segment: {}", logicalPath);
-                return Optional.empty();
-            }
-        }
+        }        
         int slash = normalized.indexOf('/');
         if (slash < 1 || slash == normalized.length() - 1) {
             return Optional.empty();

--- a/core/src/main/java/org/apache/struts2/webjars/DefaultWebJarUrlProvider.java
+++ b/core/src/main/java/org/apache/struts2/webjars/DefaultWebJarUrlProvider.java
@@ -123,12 +123,13 @@ public class DefaultWebJarUrlProvider implements WebJarUrlProvider {
             return Optional.empty();
         }
         String normalized = StringUtils.stripStart(logicalPath, "/");
-        if (normalized.contains("\\")) {
+        if (StaticContentLoader.Validator.containsMalformedPathSegment(normalized)) {
+            LOG.debug("Rejecting WebJar path with malformed segment: {}", logicalPath);
             return Optional.empty();
         }
         for (String segment : normalized.split("/")) {
-            if (segment.equals("..") || segment.equals(".")) {
-                LOG.debug("Rejecting WebJar path with traversal segment: {}", logicalPath);
+            if (segment.equals(".")) {
+                LOG.debug("Rejecting WebJar path with dot segment: {}", logicalPath);
                 return Optional.empty();
             }
         }

--- a/core/src/test/java/org/apache/struts2/dispatcher/DefaultStaticContentLoaderTest.java
+++ b/core/src/test/java/org/apache/struts2/dispatcher/DefaultStaticContentLoaderTest.java
@@ -140,7 +140,6 @@ public class DefaultStaticContentLoaderTest extends StrutsInternalTestCase {
         expect(hostConfigMock.getInitParameter("loggerFactory")).andStubReturn(null);
         defaultStaticContentLoader = new DefaultStaticContentLoader();
         defaultStaticContentLoader.setHostConfig(hostConfigMock);
-        defaultStaticContentLoader.setEncoding("UTF-8");
         defaultStaticContentLoader.setStaticContentPath("/static");
     }
     public void testBuildPathDoesNotDecodePercentEncoding() {
@@ -153,13 +152,6 @@ public class DefaultStaticContentLoaderTest extends StrutsInternalTestCase {
         expectLastCall();
         replay(responseMock);
         defaultStaticContentLoader.findStaticResource("/static/../../../etc/passwd", requestMock, responseMock);
-    }
-
-    public void testFindStaticResourceRejectsEncodedTraversal() throws Exception {
-        responseMock.sendError(HttpServletResponse.SC_NOT_FOUND);
-        expectLastCall();
-        replay(responseMock);
-        defaultStaticContentLoader.findStaticResource("/static/%2e%2e/%2e%2e/secret", requestMock, responseMock);
     }
 
     public void testFindStaticResourceRejectsBackslashPath() throws Exception {

--- a/core/src/test/java/org/apache/struts2/dispatcher/DefaultStaticContentLoaderTest.java
+++ b/core/src/test/java/org/apache/struts2/dispatcher/DefaultStaticContentLoaderTest.java
@@ -143,4 +143,29 @@ public class DefaultStaticContentLoaderTest extends StrutsInternalTestCase {
         defaultStaticContentLoader.setEncoding("UTF-8");
         defaultStaticContentLoader.setStaticContentPath("/static");
     }
+    public void testBuildPathDoesNotDecodePercentEncoding() {
+        String result = defaultStaticContentLoader.buildPath("/%2e%2e/secret", "static/");
+        assertEquals("static/%2e%2e/secret", result);
+    }
+
+    public void testFindStaticResourceRejectsLiteralTraversal() throws Exception {
+        responseMock.sendError(HttpServletResponse.SC_NOT_FOUND);
+        expectLastCall();
+        replay(responseMock);
+        defaultStaticContentLoader.findStaticResource("/static/../../../etc/passwd", requestMock, responseMock);
+    }
+
+    public void testFindStaticResourceRejectsEncodedTraversal() throws Exception {
+        responseMock.sendError(HttpServletResponse.SC_NOT_FOUND);
+        expectLastCall();
+        replay(responseMock);
+        defaultStaticContentLoader.findStaticResource("/static/%2e%2e/%2e%2e/secret", requestMock, responseMock);
+    }
+
+    public void testFindStaticResourceRejectsBackslashPath() throws Exception {
+        responseMock.sendError(HttpServletResponse.SC_NOT_FOUND);
+        expectLastCall();
+        replay(responseMock);
+        defaultStaticContentLoader.findStaticResource("/static/..\\..\\secret", requestMock, responseMock);
+    }
 }

--- a/core/src/test/java/org/apache/struts2/dispatcher/DefaultStaticContentLoaderWebJarTest.java
+++ b/core/src/test/java/org/apache/struts2/dispatcher/DefaultStaticContentLoaderWebJarTest.java
@@ -116,4 +116,15 @@ public class DefaultStaticContentLoaderWebJarTest {
 
         verify(response).sendError(HttpServletResponse.SC_NOT_FOUND);
     }
+    
+    @Test
+    public void webJarEncodedTraversalReturns404() throws Exception {
+        DefaultStaticContentLoader webJarLoader = newLoader(true);
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+
+        webJarLoader.findStaticResource("/static/webjars/jquery/%2e%2e/%2e%2e/etc/passwd", request, response);
+
+        verify(response).sendError(HttpServletResponse.SC_NOT_FOUND);
+    }
 }

--- a/core/src/test/java/org/apache/struts2/dispatcher/DefaultStaticContentLoaderWebJarTest.java
+++ b/core/src/test/java/org/apache/struts2/dispatcher/DefaultStaticContentLoaderWebJarTest.java
@@ -68,7 +68,6 @@ public class DefaultStaticContentLoaderWebJarTest {
         webJarLoader.setServeStaticContent("true");
         webJarLoader.setStaticContentPath("/static");
         webJarLoader.setServeStaticBrowserCache("true");
-        webJarLoader.setEncoding("UTF-8");
         org.apache.struts2.webjars.DefaultWebJarUrlProvider provider =
             new org.apache.struts2.webjars.DefaultWebJarUrlProvider();
         provider.setEnabled(String.valueOf(enabled));

--- a/core/src/test/java/org/apache/struts2/dispatcher/StaticContentLoaderTest.java
+++ b/core/src/test/java/org/apache/struts2/dispatcher/StaticContentLoaderTest.java
@@ -106,8 +106,6 @@ public class StaticContentLoaderTest extends TestCase {
         hostConfigMock.expectAndReturn("getInitParameter", C.args(C.eq("packages")), null);
         hostConfigMock.expectAndReturn("getInitParameter", C.args(C.eq("loggerFactory")), null);
 
-        contentLoader.setEncoding("utf-8");
-
         contentLoader.setHostConfig((HostConfig) hostConfigMock.proxy());
     }
 

--- a/core/src/test/java/org/apache/struts2/webjars/DefaultWebJarUrlProviderTest.java
+++ b/core/src/test/java/org/apache/struts2/webjars/DefaultWebJarUrlProviderTest.java
@@ -76,6 +76,17 @@ public class DefaultWebJarUrlProviderTest {
     }
 
     @Test
+    public void encodedTraversalIsRejected() {
+        assertThat(provider.resolveResourcePath("jquery/%2e%2e/%2e%2e/etc/passwd")).isEmpty();
+        assertThat(provider.resolveResourcePath("jquery/%2E%2E/secret")).isEmpty();
+    }
+
+    @Test
+    public void resolveUrlRejectsEncodedTraversal() {
+        assertThat(provider.resolveUrl("jquery/%2e%2e/%2e%2e/etc/passwd", request)).isEmpty();
+    }
+
+    @Test
     public void allowlistBlocksNonListedWebjar() {
         provider.setAllowlist("bootstrap");
         assertThat(provider.resolveResourcePath("jquery/jquery.min.js")).isEmpty();

--- a/core/src/test/java/org/apache/struts2/webjars/DefaultWebJarUrlProviderTest.java
+++ b/core/src/test/java/org/apache/struts2/webjars/DefaultWebJarUrlProviderTest.java
@@ -76,17 +76,6 @@ public class DefaultWebJarUrlProviderTest {
     }
 
     @Test
-    public void encodedTraversalIsRejected() {
-        assertThat(provider.resolveResourcePath("jquery/%2e%2e/%2e%2e/etc/passwd")).isEmpty();
-        assertThat(provider.resolveResourcePath("jquery/%2E%2E/secret")).isEmpty();
-    }
-
-    @Test
-    public void resolveUrlRejectsEncodedTraversal() {
-        assertThat(provider.resolveUrl("jquery/%2e%2e/%2e%2e/etc/passwd", request)).isEmpty();
-    }
-
-    @Test
     public void allowlistBlocksNonListedWebjar() {
         provider.setAllowlist("bootstrap");
         assertThat(provider.resolveResourcePath("jquery/jquery.min.js")).isEmpty();


### PR DESCRIPTION
The `buildPath()` method in `DefaultStaticContentLoader` applied `URLDecoder.decode()` to resource paths that the servlet container had already decoded.  This redundant decode conflicted with the servlet spec's path-handling contract.

This patch:

- Removes the unnecessary `URLDecoder.decode()` call from `buildPath()` and drops the now-unused `encoding` field and its setter
- Adds a `Validator.canonicalisePath()` utility that normalises the path (resolves `.` and `..`, converts `\` to `/`) and returns `Optional.empty()` when the resolved path escapes above root
- Wires the canonical path through both `findStaticResource()` and the WebJar `split()` so downstream lookups use the normalised form
- Documents the encoding contract on `RequestUtils.getServletPath()`
- Adds test coverage for literal traversal, encoded traversal, backslash paths, and the WebJar serving path