### PR TITLE
WW-5646 Modernize path normalization in Include component

### DIFF
--- a/core/src/main/java/org/apache/struts2/components/Include.java
+++ b/core/src/main/java/org/apache/struts2/components/Include.java
@@ -50,6 +50,7 @@ import java.util.Map;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.StringTokenizer;
+import java.util.Iterator;
 
 /**
  * <!-- START SNIPPET: javadoc -->
@@ -223,8 +224,9 @@ public class Include extends Component {
 
             StringBuilder flatPathBuffer = new StringBuilder();
 
-            for (String segment : segments) {
-                flatPathBuffer.append("/").append(segment);
+            Iterator<String> it = segments.descendingIterator();
+            while (it.hasNext()) {
+                flatPathBuffer.append("/").append(it.next());
             }
 
             returnValue = flatPathBuffer.length() > 0 ? flatPathBuffer.toString() : "/";

--- a/core/src/main/java/org/apache/struts2/components/Include.java
+++ b/core/src/main/java/org/apache/struts2/components/Include.java
@@ -47,7 +47,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Stack;
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.StringTokenizer;
 
 /**
@@ -203,7 +204,7 @@ public class Include extends Component {
         // .. is illegal in an absolute path according to the Servlet Spec and will cause
         // known problems on Orion application servers.
         if (returnValue.contains("..")) {
-            Stack<String> stack = new Stack<>();
+            Deque<String> segments = new ArrayDeque<>();
             StringTokenizer pathParts = new StringTokenizer(returnValue.replace('\\', '/'), "/");
 
             while (pathParts.hasMoreTokens()) {
@@ -211,20 +212,22 @@ public class Include extends Component {
 
                 if (!part.equals(".")) {
                     if (part.equals("..")) {
-                        stack.pop();
+                        if (!segments.isEmpty()) {
+                            segments.pop();
+                        }
                     } else {
-                        stack.push(part);
+                        segments.push(part);
                     }
                 }
             }
 
             StringBuilder flatPathBuffer = new StringBuilder();
 
-            for (int i = 0; i < stack.size(); i++) {
-                flatPathBuffer.append("/").append(stack.elementAt(i));
+            for (String segment : segments) {
+                flatPathBuffer.append("/").append(segment);
             }
 
-            returnValue = flatPathBuffer.toString();
+            returnValue = flatPathBuffer.length() > 0 ? flatPathBuffer.toString() : "/";
         }
 
         return returnValue;

--- a/core/src/test/java/org/apache/struts2/views/jsp/IncludeTagTest.java
+++ b/core/src/test/java/org/apache/struts2/views/jsp/IncludeTagTest.java
@@ -220,6 +220,18 @@ public class IncludeTagTest extends AbstractTagTest {
                 strutsBodyTagsAreReflectionEqual(tag, freshTag));
     }
 
+    public void testGetContextRelativePathExcessDotDot() {
+        // Excess ".." segments beyond root should be silently clamped, not throw EmptyStackException
+        String result = Include.getContextRelativePath(request, "/../../../other/resource.jsp");
+        assertEquals("/other/resource.jsp", result);
+    }
+
+    public void testGetContextRelativePathAllDotDot() {
+        // All segments are ".." - should resolve to root
+        String result = Include.getContextRelativePath(request, "/a/../../..");
+        assertEquals("/", result);
+    }
+
     public void testIncludeSetUseResponseEncodingTrue() throws Exception {
         // TODO: If possible in future mock-test an actual content-includes with various encodings
         //   while setting the response encoding to match.  Doesn't appear to be possible


### PR DESCRIPTION
The path normalization logic in Include.getContextRelativePath() used the 
legacy java.util.Stack class and did not handle the edge case where 
dot-dot segments exceed the available path depth.

This patch:
- Replaces java.util.Stack with ArrayDeque (recommended since JDK 6)
- Adds an isEmpty() guard before pop() to handle excess dot-dot gracefully
- Uses enhanced for-loop instead of indexed elementAt() iteration
- Adds test coverage for edge case dot-dot paths