### PR TITLE
WW-4858 Cover nested-leaf accepted-name and include patterns in JSON filtering

### DIFF
--- a/plugins/json/src/test/java/org/apache/struts2/json/JSONInterceptorTest.java
+++ b/plugins/json/src/test/java/org/apache/struts2/json/JSONInterceptorTest.java
@@ -770,6 +770,31 @@ public class JSONInterceptorTest extends StrutsTestCase {
         assertEquals(0, action.getBean().getIntField());
     }
 
+    public void testAcceptedNamePatternRejectsNestedKey() throws Exception {
+        this.request.setContent("{\"bean\": {\"stringField\": \"keep\", \"intField\": 42}}".getBytes());
+        this.request.addHeader("Content-Type", "application/json");
+
+        JSONInterceptor interceptor = createInterceptor();
+        org.apache.struts2.security.DefaultAcceptedPatternsChecker accepted =
+                new org.apache.struts2.security.DefaultAcceptedPatternsChecker();
+        // Accept the intermediate node "bean" and the nested leaf "bean.stringField", but not
+        // "bean.intField". The intermediate node must itself match an accepted pattern, otherwise
+        // the whole subtree is dropped before the leaf is ever visited (accepted name patterns are
+        // raw full-match regexes with no hierarchy expansion, unlike include patterns).
+        accepted.setAcceptedPatterns("bean(\\.stringField)?");
+        interceptor.setAcceptedPatterns(accepted);
+        TestAction action = new TestAction();
+
+        this.invocation.setAction(action);
+        this.invocation.getStack().push(action);
+
+        interceptor.intercept(this.invocation);
+
+        assertNotNull(action.getBean());
+        assertEquals("keep", action.getBean().getStringField());
+        assertEquals(0, action.getBean().getIntField());
+    }
+
     public void testExcludedValuePatternRejectsListElement() throws Exception {
         this.request.setContent("{\"list\": [\"good\", \"badvalue\"]}".getBytes());
         this.request.addHeader("Content-Type", "application/json");
@@ -903,6 +928,28 @@ public class JSONInterceptorTest extends StrutsTestCase {
 
         assertEquals("a", action.getFoo());
         assertEquals("b", action.getBar());
+    }
+
+    public void testIncludePropertiesAppliedToNestedInputWhenEnabled() throws Exception {
+        this.request.setContent("{\"bean\": {\"stringField\": \"keep\", \"intField\": 42}}".getBytes());
+        this.request.addHeader("Content-Type", "application/json");
+
+        JSONInterceptor interceptor = createInterceptor();
+        interceptor.setApplyPropertyFiltersToInput(true);
+        // Include patterns expand across the hierarchy: "bean.stringField" compiles patterns for
+        // both the intermediate node "bean" and the leaf "bean.stringField", so the nested leaf
+        // populates while the excluded sibling "bean.intField" is dropped.
+        interceptor.setIncludeProperties("bean\\.stringField");
+        TestAction action = new TestAction();
+
+        this.invocation.setAction(action);
+        this.invocation.getStack().push(action);
+
+        interceptor.intercept(this.invocation);
+
+        assertNotNull(action.getBean());
+        assertEquals("keep", action.getBean().getStringField());
+        assertEquals(0, action.getBean().getIntField());
     }
 
     @Override


### PR DESCRIPTION
Fixes [WW-4858](https://issues.apache.org/jira/browse/WW-4858)

## What & why

Follow-up test coverage for the JSON parameter-filtering work in #1773. That PR
tested the flat-key cases and a nested *excluded* name pattern, but left the
nested-leaf behaviour of **accepted-name** and **include** patterns uncovered.
These two paths behave differently through `JSONInterceptor`'s recursive
tree-walk, and the difference is easy to regress silently:

- **Accepted name patterns** (`AcceptedPatternsChecker`) are raw full-match
  regexes with **no hierarchy expansion**. The intermediate node (`bean`) must
  itself match an accepted pattern, otherwise the entire subtree is dropped
  before the leaf (`bean.stringField`) is ever visited.
- **Include patterns** (`includeProperties`, via `JSONUtil.processIncludePatterns`)
  **do** expand across the hierarchy: `bean.stringField` compiles patterns for
  both the intermediate `bean` and the leaf, so the nested leaf populates while
  the excluded sibling `bean.intField` is dropped.

## Tests added (`JSONInterceptorTest`)

- `testAcceptedNamePatternRejectsNestedKey`
- `testIncludePropertiesAppliedToNestedInputWhenEnabled`

Both document the intermediate-node semantics in comments so the divergence is
explicit rather than surprising.

## Testing

`mvn test -pl plugins/json -DskipAssembly -Dtest=JSONInterceptorTest` — 40 tests, all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)