### PR TITLE
WW-5640 Rename DefaultWebJarUrlProvider to StrutsWebJarUrlProvider

### DIFF
--- a/core/src/main/java/org/apache/struts2/webjars/StrutsWebJarUrlProvider.java
+++ b/core/src/main/java/org/apache/struts2/webjars/StrutsWebJarUrlProvider.java
@@ -37,9 +37,9 @@ import java.util.Set;
  * Default {@link WebJarUrlProvider} backed by a singleton {@link WebJarVersionLocator}
  * (from {@code webjars-locator-lite}). Thread-safe.
  */
-public class DefaultWebJarUrlProvider implements WebJarUrlProvider {
+public class StrutsWebJarUrlProvider implements WebJarUrlProvider {
 
-    private static final Logger LOG = LogManager.getLogger(DefaultWebJarUrlProvider.class);
+    private static final Logger LOG = LogManager.getLogger(StrutsWebJarUrlProvider.class);
 
     private static final String WEBJARS_URL_SEGMENT = "/webjars/";
 

--- a/core/src/main/resources/struts-beans.xml
+++ b/core/src/main/resources/struts-beans.xml
@@ -208,7 +208,7 @@
     <bean type="org.apache.struts2.dispatcher.StaticContentLoader"
           class="org.apache.struts2.dispatcher.DefaultStaticContentLoader" name="struts"/>
     <bean type="org.apache.struts2.webjars.WebJarUrlProvider"
-          class="org.apache.struts2.webjars.DefaultWebJarUrlProvider" name="struts"/>
+          class="org.apache.struts2.webjars.StrutsWebJarUrlProvider" name="struts"/>
     <bean type="org.apache.struts2.UnknownHandlerManager"
           class="org.apache.struts2.DefaultUnknownHandlerManager" name="struts"/>
 

--- a/core/src/test/java/org/apache/struts2/dispatcher/DefaultStaticContentLoaderWebJarTest.java
+++ b/core/src/test/java/org/apache/struts2/dispatcher/DefaultStaticContentLoaderWebJarTest.java
@@ -68,8 +68,8 @@ public class DefaultStaticContentLoaderWebJarTest {
         webJarLoader.setServeStaticContent("true");
         webJarLoader.setStaticContentPath("/static");
         webJarLoader.setServeStaticBrowserCache("true");
-        org.apache.struts2.webjars.DefaultWebJarUrlProvider provider =
-            new org.apache.struts2.webjars.DefaultWebJarUrlProvider();
+        org.apache.struts2.webjars.StrutsWebJarUrlProvider provider =
+            new org.apache.struts2.webjars.StrutsWebJarUrlProvider();
         provider.setEnabled(String.valueOf(enabled));
         provider.setAllowlist("");
         provider.setStaticContentPath("/static");

--- a/core/src/test/java/org/apache/struts2/webjars/StrutsWebJarUrlProviderTest.java
+++ b/core/src/test/java/org/apache/struts2/webjars/StrutsWebJarUrlProviderTest.java
@@ -26,14 +26,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class DefaultWebJarUrlProviderTest {
+public class StrutsWebJarUrlProviderTest {
 
-    private DefaultWebJarUrlProvider provider;
+    private StrutsWebJarUrlProvider provider;
     private HttpServletRequest request;
 
     @Before
     public void setUp() {
-        provider = new DefaultWebJarUrlProvider();
+        provider = new StrutsWebJarUrlProvider();
         provider.setEnabled("true");
         provider.setAllowlist("");
         provider.setStaticContentPath("/static");


### PR DESCRIPTION
Renames `DefaultWebJarUrlProvider` to `StrutsWebJarUrlProvider`, adopting the `Struts*` prefix convention for the framework's default implementation of `WebJarUrlProvider` instead of `Default*`.

Pure rename — no behavioral change. The bean definition in `struts-beans.xml` and all test references were updated accordingly.

Fixes [WW-5640](https://issues.apache.org/jira/browse/WW-5640)

🤖 Generated with [Claude Code](https://claude.com/claude-code)