### PR TITLE
WW-5591 Mark XWorkObjectPropertyAccessor as deprecated

### DIFF
--- a/core/src/main/java/org/apache/struts2/ognl/accessor/XWorkObjectPropertyAccessor.java
+++ b/core/src/main/java/org/apache/struts2/ognl/accessor/XWorkObjectPropertyAccessor.java
@@ -26,7 +26,9 @@ import ognl.OgnlException;
 
 /**
  * @author Gabe
+ * @deprecated since 7.3.0, this accessor is no longer used by the framework and will be removed in a future version.
  */
+@Deprecated(since = "7.3.0", forRemoval = true)
 public class XWorkObjectPropertyAccessor extends ObjectPropertyAccessor {
     @Override
     public Object getProperty(OgnlContext context, Object target, Object oname) throws OgnlException {


### PR DESCRIPTION
Marks `XWorkObjectPropertyAccessor` as deprecated for removal — the class has no references anywhere in the codebase (no Java usage, no container/OGNL registration, no tests), so it can be removed in a future version.

Follows the existing deprecation convention (`@deprecated` Javadoc + `@Deprecated(since, forRemoval)`), e.g. `OgnlReflectionContextFactory`.

Fixes [WW-5591](https://issues.apache.org/jira/browse/WW-5591)

🤖 Generated with [Claude Code](https://claude.com/claude-code)