### PR TITLE
WW-5580 Use Configuration.VERSION_2_3_34 for FreeMarker config

### DIFF
--- a/core/src/main/java/org/apache/struts2/views/freemarker/FreemarkerManager.java
+++ b/core/src/main/java/org/apache/struts2/views/freemarker/FreemarkerManager.java
@@ -358,7 +358,7 @@ public class FreemarkerManager {
     }
 
     protected Version getFreemarkerVersion(ServletContext servletContext) {
-        Version incompatibleImprovements = Configuration.VERSION_2_3_33;
+        Version incompatibleImprovements = Configuration.VERSION_2_3_34;
 
         String incompatibleImprovementsParam = servletContext.getInitParameter("freemarker." + Configuration.INCOMPATIBLE_IMPROVEMENTS_KEY_SNAKE_CASE);
         if (incompatibleImprovementsParam != null) {

--- a/core/src/test/java/org/apache/struts2/views/freemarker/FreemarkerManagerTest.java
+++ b/core/src/test/java/org/apache/struts2/views/freemarker/FreemarkerManagerTest.java
@@ -97,7 +97,7 @@ public class FreemarkerManagerTest extends StrutsInternalTestCase {
         tpl.process(model, out);
 
         // then
-        assertEquals(Configuration.VERSION_2_3_33, configuration.getIncompatibleImprovements());
+        assertEquals(Configuration.VERSION_2_3_34, configuration.getIncompatibleImprovements());
         assertEquals("<input type=\"text\" onclick=\"this.alert('It&#39;s an error message')\"/>", out.toString());
     }
 


### PR DESCRIPTION
Aligns FreeMarker's `incompatible_improvements` setting in `FreemarkerManager` with the FreeMarker 2.3.34 dependency already declared in the build (it was still pinned to `VERSION_2_3_33`).

### Risk

None at runtime. FreeMarker 2.3.34 declares `Configuration.VERSION_2_3_34` as an incompatible-improvements break-point, but nothing in 2.3.34 gates behaviour on it:

- `_VersionInts` defines `V_2_3_33` but no `V_2_3_34`
- the only version comparisons (`BeansWrapper`, `ClassIntrospectorBuilder`) cap at 2.3.33
- the `setIncompatibleImprovements` javadoc change list stops at 2.3.33

So this is purely keeping the setting in sync with the dependency.

### Tests

`testIncompatibleImprovementsByOverriding` intentionally stays on `VERSION_2_3_33` — it now asserts a value that differs from the default, so it actually exercises the override path (previously it matched the default and passed trivially).

All 26 tests in `org.apache.struts2.views.freemarker.**` pass, including the template rendering/auto-escaping test.

Fixes [WW-5580](https://issues.apache.org/jira/browse/WW-5580)

🤖 Generated with [Claude Code](https://claude.com/claude-code)