### PR TITLE
ci(owasp): cap job timeout and disable NVD auto-update in check step

### DIFF
--- a/.github/workflows/owasp.yml
+++ b/.github/workflows/owasp.yml
@@ -61,13 +61,15 @@ jobs:
             nvd-cache-${{ runner.os }}-
 
       - name: OWASP Dependency check update cache via NIST_NVD_API_KEY
+        id: nvd-api-update
         if: ${{ env.HAVE_NIST_NVD_API_KEY == 'true' }}
+        continue-on-error: true
         run:  mvn -N -V -DskipAssembly -Dmaven.test.skip=true -Powasp-nvd-api -Pdependency-update-only --no-transfer-progress
         env:
           NIST_NVD_API_KEY: ${{ secrets.NIST_NVD_API_KEY}}
 
       - name: OWASP Dependency check update cache via Mirror
-        if: ${{ env.HAVE_NIST_NVD_API_KEY == 'false' }}
+        if: ${{ env.HAVE_NIST_NVD_API_KEY == 'false' || steps.nvd-api-update.outcome == 'failure' }}
         run:  mvn -N -V -DskipAssembly -Dmaven.test.skip=true -Powasp-nvd-mirror -Pdependency-update-only --no-transfer-progress
 
       - name: Cache NVD Database

--- a/.github/workflows/owasp.yml
+++ b/.github/workflows/owasp.yml
@@ -37,6 +37,7 @@ jobs:
   owasp:
     name: OWASP
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     env:
       HAVE_NIST_NVD_API_KEY: ${{ secrets.NIST_NVD_API_KEY != '' }}
     steps:
@@ -77,7 +78,7 @@ jobs:
           key: nvd-cache-${{ runner.os }}-owasp-${{ github.run_id }}
 
       - name: OWASP check (Without running tests)
-        run: mvn -B org.owasp:dependency-check-maven:aggregate -Pdependency-check -Pjakartaee11 --no-transfer-progress
+        run: mvn -B org.owasp:dependency-check-maven:aggregate -Pdependency-check -Pjakartaee11 -DautoUpdate=false --no-transfer-progress
 
       - name: Upload Dependency Check reports
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Problem

The **OWASP checkup** workflow fails intermittently, sometimes with no reason other than timeouts (as seen in #1667). Root cause is external: the NIST NVD feed is unreliable (see [dependency-check#8633](https://github.com/dependency-check/DependencyCheck/issues/8633)) — even **with** an API key the update can exhaust its retries and fail, and without one it is heavily rate-limited and stalls.

Contributing config issues:
1. The job had **no timeout**, so a hung NVD download dragged toward the 6-hour GitHub Actions default.
2. The `OWASP check` step carried neither the mirror datafeed URL nor the API key, so on cache staleness/miss it synced **directly against NIST**.
3. The mirror datafeed was used **only when no API key was present**, so apache/struts always took the flaky API path and never fell back to the mirror.

## Changes

- **`timeout-minutes: 30`** on the `owasp` job so a stuck download fails fast.
- **`-DautoUpdate=false`** on the check step so it reads only the NVD cache populated by the update-only step, never phoning NIST directly.
- **Mirror fallback**: the API-key update step is now `continue-on-error`, and the mirror datafeed update runs when no API key is configured **or** when the API update fails. This makes the reliable mirror the automatic fallback instead of a no-key-only path.

## Verification

Confirmed on this PR's CI that the API update step was the failing step (`NvdApiRetryExceededException`, retries exhausted) on the API-key path — which the mirror fallback now covers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)