### PR TITLE
WW-5585 Keep dynamic upload validation request-scoped

### DIFF
--- a/core/src/main/java/org/apache/struts2/DefaultActionInvocation.java
+++ b/core/src/main/java/org/apache/struts2/DefaultActionInvocation.java
@@ -41,6 +41,7 @@ import org.apache.struts2.util.ValueStackFactory;
 
 import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -258,17 +259,9 @@ public class DefaultActionInvocation implements ActionInvocation {
             if (interceptors.hasNext()) {
                 final InterceptorMapping interceptorMapping = interceptors.next();
                 Interceptor interceptor = interceptorMapping.getInterceptor();
-                if (interceptor instanceof WithLazyParams) {
-                    Map<String, String> params = interceptorMapping.getParams();
-
-                    proxy.getConfig().getInterceptors().stream()
-                            .filter(im -> im.getName().equals(interceptorMapping.getName()))
-                            .findFirst()
-                            .ifPresent(im -> params.putAll(im.getParams()));
-                    
-                    interceptor = lazyParamInjector.injectParams(interceptor, params, invocationContext);
-                }
-                if (interceptor instanceof ConditionalInterceptor conditionalInterceptor) {
+                if (interceptor instanceof WithLazyParams<?> withLazyParamsInterceptor) {
+                    resultCode = executeWithLazyParams(interceptorMapping, interceptor, withLazyParamsInterceptor);
+                } else if (interceptor instanceof ConditionalInterceptor conditionalInterceptor) {
                     resultCode = executeConditional(conditionalInterceptor);
                 } else {
                     LOG.debug("Executing normal interceptor: {}", interceptorMapping.getName());
@@ -310,6 +303,29 @@ public class DefaultActionInvocation implements ActionInvocation {
         }
 
         return resultCode;
+    }
+
+    protected <P> String executeWithLazyParams(InterceptorMapping interceptorMapping,
+                                               Interceptor interceptor,
+                                               WithLazyParams<P> withLazyParamsInterceptor) throws Exception {
+        P lazyParams = lazyParamInjector.injectParams(
+                withLazyParamsInterceptor,
+                new LinkedHashMap<>(interceptorMapping.getParams()),
+                invocationContext
+        );
+
+        if (interceptor instanceof ConditionalInterceptor conditionalInterceptor) {
+            if (conditionalInterceptor.shouldIntercept(this)) {
+                LOG.debug("Executing conditional interceptor: {}", conditionalInterceptor.getClass().getSimpleName());
+                return withLazyParamsInterceptor.intercept(this, lazyParams);
+            } else {
+                LOG.debug("Interceptor: {} is disabled, skipping to next", conditionalInterceptor.getClass().getSimpleName());
+                return this.invoke();
+            }
+        }
+
+        LOG.debug("Executing normal interceptor: {}", interceptorMapping.getName());
+        return withLazyParamsInterceptor.intercept(this, lazyParams);
     }
 
     protected String executeConditional(ConditionalInterceptor conditionalInterceptor) throws Exception {

--- a/core/src/main/java/org/apache/struts2/DefaultActionInvocation.java
+++ b/core/src/main/java/org/apache/struts2/DefaultActionInvocation.java
@@ -259,8 +259,10 @@ public class DefaultActionInvocation implements ActionInvocation {
             if (interceptors.hasNext()) {
                 final InterceptorMapping interceptorMapping = interceptors.next();
                 Interceptor interceptor = interceptorMapping.getInterceptor();
-                if (interceptor instanceof WithLazyParams<?> withLazyParamsInterceptor) {
-                    resultCode = executeWithLazyParams(interceptorMapping, interceptor, withLazyParamsInterceptor);
+                if (interceptor instanceof WithLazyParams.InvocationScoped<?> invocationScopedInterceptor) {
+                    resultCode = executeWithLazyParams(interceptorMapping, interceptor, invocationScopedInterceptor);
+                } else if (interceptor instanceof WithLazyParams) {
+                    resultCode = executeWithLazyParams(interceptorMapping, interceptor);
                 } else if (interceptor instanceof ConditionalInterceptor conditionalInterceptor) {
                     resultCode = executeConditional(conditionalInterceptor);
                 } else {
@@ -305,9 +307,20 @@ public class DefaultActionInvocation implements ActionInvocation {
         return resultCode;
     }
 
+    protected String executeWithLazyParams(InterceptorMapping interceptorMapping,
+                                           Interceptor interceptor) throws Exception {
+        lazyParamInjector.injectParams(
+                interceptor,
+                new LinkedHashMap<>(interceptorMapping.getParams()),
+                invocationContext
+        );
+
+        return executeLazyParamsInterceptor(interceptorMapping, interceptor);
+    }
+
     protected <P> String executeWithLazyParams(InterceptorMapping interceptorMapping,
                                                Interceptor interceptor,
-                                               WithLazyParams<P> withLazyParamsInterceptor) throws Exception {
+                                               WithLazyParams.InvocationScoped<P> withLazyParamsInterceptor) throws Exception {
         P lazyParams = lazyParamInjector.injectParams(
                 withLazyParamsInterceptor,
                 new LinkedHashMap<>(interceptorMapping.getParams()),
@@ -326,6 +339,22 @@ public class DefaultActionInvocation implements ActionInvocation {
 
         LOG.debug("Executing normal interceptor: {}", interceptorMapping.getName());
         return withLazyParamsInterceptor.intercept(this, lazyParams);
+    }
+
+    protected String executeLazyParamsInterceptor(InterceptorMapping interceptorMapping,
+                                                  Interceptor interceptor) throws Exception {
+        if (interceptor instanceof ConditionalInterceptor conditionalInterceptor) {
+            if (conditionalInterceptor.shouldIntercept(this)) {
+                LOG.debug("Executing conditional interceptor: {}", conditionalInterceptor.getClass().getSimpleName());
+                return interceptor.intercept(this);
+            } else {
+                LOG.debug("Interceptor: {} is disabled, skipping to next", conditionalInterceptor.getClass().getSimpleName());
+                return this.invoke();
+            }
+        }
+
+        LOG.debug("Executing normal interceptor: {}", interceptorMapping.getName());
+        return interceptor.intercept(this);
     }
 
     protected String executeConditional(ConditionalInterceptor conditionalInterceptor) throws Exception {

--- a/core/src/main/java/org/apache/struts2/factory/DefaultInterceptorFactory.java
+++ b/core/src/main/java/org/apache/struts2/factory/DefaultInterceptorFactory.java
@@ -68,12 +68,16 @@ public class DefaultInterceptorFactory implements InterceptorFactory {
                 throw new ConfigurationException("Class [" + interceptorClassName + "] does not implement Interceptor", interceptorConfig);
             }
 
-            if (interceptor instanceof WithLazyParams) {
+            if (interceptor instanceof WithLazyParams.InvocationScoped) {
                 reflectionProvider.setProperties(filterFactoryTimeParams(params), interceptor);
-                LOG.debug("Interceptor {} implements {} - expression parameters will be re-evaluated during action invocation",
+                LOG.debug("Interceptor {} implements {} - expression parameters will be re-evaluated into invocation-scoped lazy params",
                         interceptorClassName, WithLazyParams.class.getName());
             } else {
                 reflectionProvider.setProperties(params, interceptor);
+                if (interceptor instanceof WithLazyParams) {
+                    LOG.debug("Interceptor {} implements {} - expression parameters will be re-evaluated during action invocation",
+                            interceptorClassName, WithLazyParams.class.getName());
+                }
             }
 
             interceptor.init();

--- a/core/src/main/java/org/apache/struts2/factory/DefaultInterceptorFactory.java
+++ b/core/src/main/java/org/apache/struts2/factory/DefaultInterceptorFactory.java
@@ -68,10 +68,12 @@ public class DefaultInterceptorFactory implements InterceptorFactory {
                 throw new ConfigurationException("Class [" + interceptorClassName + "] does not implement Interceptor", interceptorConfig);
             }
 
-            reflectionProvider.setProperties(params, interceptor);
             if (interceptor instanceof WithLazyParams) {
+                reflectionProvider.setProperties(filterFactoryTimeParams(params), interceptor);
                 LOG.debug("Interceptor {} implements {} - expression parameters will be re-evaluated during action invocation",
                         interceptorClassName, WithLazyParams.class.getName());
+            } else {
+                reflectionProvider.setProperties(params, interceptor);
             }
 
             interceptor.init();
@@ -94,6 +96,20 @@ public class DefaultInterceptorFactory implements InterceptorFactory {
         }
 
         throw new ConfigurationException(message, cause, interceptorConfig);
+    }
+
+    private Map<String, String> filterFactoryTimeParams(Map<String, String> params) {
+        Map<String, String> eagerParams = new HashMap<>();
+        for (Map.Entry<String, String> entry : params.entrySet()) {
+            if (!containsLazyParamExpression(entry.getValue())) {
+                eagerParams.put(entry.getKey(), entry.getValue());
+            }
+        }
+        return eagerParams;
+    }
+
+    private boolean containsLazyParamExpression(String value) {
+        return value != null && value.contains("${") && value.contains("}");
     }
 
 }

--- a/core/src/main/java/org/apache/struts2/interceptor/AbstractFileUploadInterceptor.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/AbstractFileUploadInterceptor.java
@@ -18,7 +18,6 @@
  */
 package org.apache.struts2.interceptor;
 
-import org.apache.struts2.ActionContext;
 import org.apache.struts2.locale.LocaleProvider;
 import org.apache.struts2.locale.LocaleProviderFactory;
 import org.apache.struts2.text.TextProvider;
@@ -63,7 +62,6 @@ public abstract class AbstractFileUploadInterceptor extends AbstractInterceptor 
     private Long maximumSize;
     private Set<String> allowedTypesSet = Collections.emptySet();
     private Set<String> allowedExtensionsSet = Collections.emptySet();
-    private final ThreadLocal<UploadValidationPolicy> requestScopedUploadValidationPolicy = new ThreadLocal<>();
 
     private ContentTypeMatcher<Object> matcher;
     private Container container;
@@ -84,12 +82,7 @@ public abstract class AbstractFileUploadInterceptor extends AbstractInterceptor 
      * @param allowedExtensions A comma-delimited list of extensions
      */
     public void setAllowedExtensions(String allowedExtensions) {
-        Set<String> parsedAllowedExtensions = TextParseUtil.commaDelimitedStringToSet(allowedExtensions);
-        if (WithLazyParams.LazyParamInjector.isParamInjectionInProgress() && ActionContext.getContext() != null) {
-            getOrCreateRequestScopedUploadValidationPolicy().allowedExtensionsSet = parsedAllowedExtensions;
-        } else {
-            allowedExtensionsSet = parsedAllowedExtensions;
-        }
+        allowedExtensionsSet = parseCommaDelimitedSet(allowedExtensions);
     }
 
     /**
@@ -98,12 +91,7 @@ public abstract class AbstractFileUploadInterceptor extends AbstractInterceptor 
      * @param allowedTypes A comma-delimited list of types
      */
     public void setAllowedTypes(String allowedTypes) {
-        Set<String> parsedAllowedTypes = TextParseUtil.commaDelimitedStringToSet(allowedTypes);
-        if (WithLazyParams.LazyParamInjector.isParamInjectionInProgress() && ActionContext.getContext() != null) {
-            getOrCreateRequestScopedUploadValidationPolicy().allowedTypesSet = parsedAllowedTypes;
-        } else {
-            allowedTypesSet = parsedAllowedTypes;
-        }
+        allowedTypesSet = parseCommaDelimitedSet(allowedTypes);
     }
 
     /**
@@ -112,15 +100,7 @@ public abstract class AbstractFileUploadInterceptor extends AbstractInterceptor 
      * @param maximumSize The maximum size in bytes
      */
     public void setMaximumSize(Long maximumSize) {
-        if (WithLazyParams.LazyParamInjector.isParamInjectionInProgress() && ActionContext.getContext() != null) {
-            getOrCreateRequestScopedUploadValidationPolicy().maximumSize = maximumSize;
-        } else {
-            this.maximumSize = maximumSize;
-        }
-    }
-
-    protected void clearRequestScopedUploadValidationPolicy() {
-        requestScopedUploadValidationPolicy.remove();
+        this.maximumSize = maximumSize;
     }
 
     /**
@@ -134,7 +114,15 @@ public abstract class AbstractFileUploadInterceptor extends AbstractInterceptor 
      * @return true if the proposed file is acceptable by contentType and size.
      */
     protected boolean acceptFile(Object action, UploadedFile file, String originalFilename, String contentType, String inputName) {
-        UploadValidationPolicy validationPolicy = getUploadValidationPolicy();
+        return acceptFile(action, file, originalFilename, contentType, inputName, createUploadValidationPolicy());
+    }
+
+    protected boolean acceptFile(Object action,
+                                 UploadedFile file,
+                                 String originalFilename,
+                                 String contentType,
+                                 String inputName,
+                                 UploadValidationPolicy validationPolicy) {
         Set<String> errorMessages = new HashSet<>();
 
         ValidationAware validation = null;
@@ -186,21 +174,15 @@ public abstract class AbstractFileUploadInterceptor extends AbstractInterceptor 
         return NumberFormat.getNumberInstance(getLocaleProvider(action).getLocale()).format(maximumSize);
     }
 
-    private UploadValidationPolicy getUploadValidationPolicy() {
-        UploadValidationPolicy requestScopedPolicy = requestScopedUploadValidationPolicy.get();
-        if (requestScopedPolicy != null) {
-            return requestScopedPolicy;
-        }
+    protected UploadValidationPolicy createUploadValidationPolicy() {
         return new UploadValidationPolicy(maximumSize, allowedTypesSet, allowedExtensionsSet);
     }
 
-    private UploadValidationPolicy getOrCreateRequestScopedUploadValidationPolicy() {
-        UploadValidationPolicy requestScopedPolicy = requestScopedUploadValidationPolicy.get();
-        if (requestScopedPolicy == null) {
-            requestScopedPolicy = new UploadValidationPolicy(maximumSize, allowedTypesSet, allowedExtensionsSet);
-            requestScopedUploadValidationPolicy.set(requestScopedPolicy);
+    private Set<String> parseCommaDelimitedSet(String value) {
+        if (value == null || value.isBlank()) {
+            return Collections.emptySet();
         }
-        return requestScopedPolicy;
+        return TextParseUtil.commaDelimitedStringToSet(value);
     }
 
     /**
@@ -287,15 +269,31 @@ public abstract class AbstractFileUploadInterceptor extends AbstractInterceptor 
         }
     }
 
-    private static final class UploadValidationPolicy {
+    protected static class UploadValidationPolicy {
         private Long maximumSize;
-        private Set<String> allowedTypesSet;
-        private Set<String> allowedExtensionsSet;
+        private Set<String> allowedTypesSet = Collections.emptySet();
+        private Set<String> allowedExtensionsSet = Collections.emptySet();
 
         private UploadValidationPolicy(Long maximumSize, Set<String> allowedTypesSet, Set<String> allowedExtensionsSet) {
             this.maximumSize = maximumSize;
             this.allowedTypesSet = allowedTypesSet;
             this.allowedExtensionsSet = allowedExtensionsSet;
+        }
+
+        public void setMaximumSize(Long maximumSize) {
+            this.maximumSize = maximumSize;
+        }
+
+        public void setAllowedTypes(String allowedTypes) {
+            this.allowedTypesSet = allowedTypes == null || allowedTypes.isBlank()
+                    ? Collections.emptySet()
+                    : TextParseUtil.commaDelimitedStringToSet(allowedTypes);
+        }
+
+        public void setAllowedExtensions(String allowedExtensions) {
+            this.allowedExtensionsSet = allowedExtensions == null || allowedExtensions.isBlank()
+                    ? Collections.emptySet()
+                    : TextParseUtil.commaDelimitedStringToSet(allowedExtensions);
         }
     }
 

--- a/core/src/main/java/org/apache/struts2/interceptor/AbstractFileUploadInterceptor.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/AbstractFileUploadInterceptor.java
@@ -18,6 +18,7 @@
  */
 package org.apache.struts2.interceptor;
 
+import org.apache.struts2.ActionContext;
 import org.apache.struts2.locale.LocaleProvider;
 import org.apache.struts2.locale.LocaleProviderFactory;
 import org.apache.struts2.text.TextProvider;
@@ -62,6 +63,7 @@ public abstract class AbstractFileUploadInterceptor extends AbstractInterceptor 
     private Long maximumSize;
     private Set<String> allowedTypesSet = Collections.emptySet();
     private Set<String> allowedExtensionsSet = Collections.emptySet();
+    private final ThreadLocal<UploadValidationPolicy> requestScopedUploadValidationPolicy = new ThreadLocal<>();
 
     private ContentTypeMatcher<Object> matcher;
     private Container container;
@@ -82,7 +84,12 @@ public abstract class AbstractFileUploadInterceptor extends AbstractInterceptor 
      * @param allowedExtensions A comma-delimited list of extensions
      */
     public void setAllowedExtensions(String allowedExtensions) {
-        allowedExtensionsSet = TextParseUtil.commaDelimitedStringToSet(allowedExtensions);
+        Set<String> parsedAllowedExtensions = TextParseUtil.commaDelimitedStringToSet(allowedExtensions);
+        if (WithLazyParams.LazyParamInjector.isParamInjectionInProgress() && ActionContext.getContext() != null) {
+            getOrCreateRequestScopedUploadValidationPolicy().allowedExtensionsSet = parsedAllowedExtensions;
+        } else {
+            allowedExtensionsSet = parsedAllowedExtensions;
+        }
     }
 
     /**
@@ -91,7 +98,12 @@ public abstract class AbstractFileUploadInterceptor extends AbstractInterceptor 
      * @param allowedTypes A comma-delimited list of types
      */
     public void setAllowedTypes(String allowedTypes) {
-        allowedTypesSet = TextParseUtil.commaDelimitedStringToSet(allowedTypes);
+        Set<String> parsedAllowedTypes = TextParseUtil.commaDelimitedStringToSet(allowedTypes);
+        if (WithLazyParams.LazyParamInjector.isParamInjectionInProgress() && ActionContext.getContext() != null) {
+            getOrCreateRequestScopedUploadValidationPolicy().allowedTypesSet = parsedAllowedTypes;
+        } else {
+            allowedTypesSet = parsedAllowedTypes;
+        }
     }
 
     /**
@@ -100,7 +112,15 @@ public abstract class AbstractFileUploadInterceptor extends AbstractInterceptor 
      * @param maximumSize The maximum size in bytes
      */
     public void setMaximumSize(Long maximumSize) {
-        this.maximumSize = maximumSize;
+        if (WithLazyParams.LazyParamInjector.isParamInjectionInProgress() && ActionContext.getContext() != null) {
+            getOrCreateRequestScopedUploadValidationPolicy().maximumSize = maximumSize;
+        } else {
+            this.maximumSize = maximumSize;
+        }
+    }
+
+    protected void clearRequestScopedUploadValidationPolicy() {
+        requestScopedUploadValidationPolicy.remove();
     }
 
     /**
@@ -114,6 +134,7 @@ public abstract class AbstractFileUploadInterceptor extends AbstractInterceptor 
      * @return true if the proposed file is acceptable by contentType and size.
      */
     protected boolean acceptFile(Object action, UploadedFile file, String originalFilename, String contentType, String inputName) {
+        UploadValidationPolicy validationPolicy = getUploadValidationPolicy();
         Set<String> errorMessages = new HashSet<>();
 
         ValidationAware validation = null;
@@ -131,21 +152,21 @@ public abstract class AbstractFileUploadInterceptor extends AbstractInterceptor 
             return false;
         }
 
-        if (maximumSize != null && maximumSize < file.length()) {
+        if (validationPolicy.maximumSize != null && validationPolicy.maximumSize < file.length()) {
             String errMsg = getTextMessage(action, STRUTS_MESSAGES_ERROR_FILE_TOO_LARGE_KEY, new String[]{
-                inputName, originalFilename, file.getName(), "" + file.length(), getMaximumSizeStr(action)
+                inputName, originalFilename, file.getName(), "" + file.length(), getMaximumSizeStr(action, validationPolicy.maximumSize)
             });
             errorMessages.add(errMsg);
             LOG.warn(errMsg);
         }
-        if ((!allowedTypesSet.isEmpty()) && (!containsItem(allowedTypesSet, contentType))) {
+        if ((!validationPolicy.allowedTypesSet.isEmpty()) && (!containsItem(validationPolicy.allowedTypesSet, contentType))) {
             String errMsg = getTextMessage(action, STRUTS_MESSAGES_ERROR_CONTENT_TYPE_NOT_ALLOWED_KEY, new String[]{
                 inputName, originalFilename, file.getName(), contentType
             });
             errorMessages.add(errMsg);
             LOG.warn(errMsg);
         }
-        if ((!allowedExtensionsSet.isEmpty()) && (!hasAllowedExtension(allowedExtensionsSet, originalFilename))) {
+        if ((!validationPolicy.allowedExtensionsSet.isEmpty()) && (!hasAllowedExtension(validationPolicy.allowedExtensionsSet, originalFilename))) {
             String errMsg = getTextMessage(action, STRUTS_MESSAGES_ERROR_FILE_EXTENSION_NOT_ALLOWED_KEY, new String[]{
                 inputName, originalFilename, file.getName(), contentType
             });
@@ -161,8 +182,25 @@ public abstract class AbstractFileUploadInterceptor extends AbstractInterceptor 
         return errorMessages.isEmpty();
     }
 
-    private String getMaximumSizeStr(Object action) {
+    private String getMaximumSizeStr(Object action, Long maximumSize) {
         return NumberFormat.getNumberInstance(getLocaleProvider(action).getLocale()).format(maximumSize);
+    }
+
+    private UploadValidationPolicy getUploadValidationPolicy() {
+        UploadValidationPolicy requestScopedPolicy = requestScopedUploadValidationPolicy.get();
+        if (requestScopedPolicy != null) {
+            return requestScopedPolicy;
+        }
+        return new UploadValidationPolicy(maximumSize, allowedTypesSet, allowedExtensionsSet);
+    }
+
+    private UploadValidationPolicy getOrCreateRequestScopedUploadValidationPolicy() {
+        UploadValidationPolicy requestScopedPolicy = requestScopedUploadValidationPolicy.get();
+        if (requestScopedPolicy == null) {
+            requestScopedPolicy = new UploadValidationPolicy(maximumSize, allowedTypesSet, allowedExtensionsSet);
+            requestScopedUploadValidationPolicy.set(requestScopedPolicy);
+        }
+        return requestScopedPolicy;
     }
 
     /**
@@ -246,6 +284,18 @@ public abstract class AbstractFileUploadInterceptor extends AbstractInterceptor 
                 }
                 validation.addActionError(errorMessage);
             }
+        }
+    }
+
+    private static final class UploadValidationPolicy {
+        private Long maximumSize;
+        private Set<String> allowedTypesSet;
+        private Set<String> allowedExtensionsSet;
+
+        private UploadValidationPolicy(Long maximumSize, Set<String> allowedTypesSet, Set<String> allowedExtensionsSet) {
+            this.maximumSize = maximumSize;
+            this.allowedTypesSet = allowedTypesSet;
+            this.allowedExtensionsSet = allowedExtensionsSet;
         }
     }
 

--- a/core/src/main/java/org/apache/struts2/interceptor/ActionFileUploadInterceptor.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/ActionFileUploadInterceptor.java
@@ -202,69 +202,76 @@ import java.util.List;
  * @see UploadedFilesAware
  * @see AbstractFileUploadInterceptor
  */
-public class ActionFileUploadInterceptor extends AbstractFileUploadInterceptor implements WithLazyParams {
+public class ActionFileUploadInterceptor extends AbstractFileUploadInterceptor
+        implements WithLazyParams<AbstractFileUploadInterceptor.UploadValidationPolicy> {
 
     protected static final Logger LOG = LogManager.getLogger(ActionFileUploadInterceptor.class);
 
     @Override
     public String intercept(ActionInvocation invocation) throws Exception {
-        try {
-            HttpServletRequest request = invocation.getInvocationContext().getServletRequest();
-            MultiPartRequestWrapper multiWrapper = request instanceof HttpServletRequestWrapper wrapper
-                    ? findMultipartRequestWrapper(wrapper)
-                    : null;
+        return WithLazyParams.super.intercept(invocation);
+    }
 
-            if (multiWrapper == null) {
-                if (LOG.isDebugEnabled()) {
-                    ActionProxy proxy = invocation.getProxy();
-                    LOG.debug(getTextMessage(STRUTS_MESSAGES_BYPASS_REQUEST_KEY, new String[]{proxy.getNamespace(), proxy.getActionName()}));
-                }
-                return invocation.invoke();
+    @Override
+    public UploadValidationPolicy newLazyParams() {
+        return createUploadValidationPolicy();
+    }
+
+    @Override
+    public String intercept(ActionInvocation invocation, UploadValidationPolicy validationPolicy) throws Exception {
+        HttpServletRequest request = invocation.getInvocationContext().getServletRequest();
+        MultiPartRequestWrapper multiWrapper = request instanceof HttpServletRequestWrapper wrapper
+                ? findMultipartRequestWrapper(wrapper)
+                : null;
+
+        if (multiWrapper == null) {
+            if (LOG.isDebugEnabled()) {
+                ActionProxy proxy = invocation.getProxy();
+                LOG.debug(getTextMessage(STRUTS_MESSAGES_BYPASS_REQUEST_KEY, new String[]{proxy.getNamespace(), proxy.getActionName()}));
             }
-
-            if (!(invocation.getAction() instanceof UploadedFilesAware action)) {
-                LOG.debug("Action: {} doesn't implement: {}, ignoring file upload",
-                        invocation.getProxy().getActionName(),
-                        UploadedFilesAware.class.getSimpleName());
-                return invocation.invoke();
-            }
-
-            applyValidation(action, multiWrapper);
-
-            // bind allowed Files
-            Enumeration<String> fileParameterNames = multiWrapper.getFileParameterNames();
-            List<UploadedFile> acceptedFiles = new ArrayList<>();
-
-            while (fileParameterNames != null && fileParameterNames.hasMoreElements()) {
-                // get the value of this input tag
-                String inputName = fileParameterNames.nextElement();
-                UploadedFile[] uploadedFiles = multiWrapper.getFiles(inputName);
-
-                if (uploadedFiles == null || uploadedFiles.length == 0) {
-                    if (LOG.isWarnEnabled()) {
-                        LOG.warn(getTextMessage(action, STRUTS_MESSAGES_INVALID_FILE_KEY, new String[]{inputName}));
-                    }
-                } else {
-                    for (UploadedFile uploadedFile : uploadedFiles) {
-                        if (acceptFile(action, uploadedFile, uploadedFile.getOriginalName(), uploadedFile.getContentType(), inputName)) {
-                            acceptedFiles.add(uploadedFile);
-                        }
-                    }
-                }
-            }
-
-            if (acceptedFiles.isEmpty()) {
-                LOG.debug("No files have been uploaded/accepted");
-            } else {
-                LOG.debug("Passing: {} uploaded file(s) to action", acceptedFiles.size());
-                action.withUploadedFiles(acceptedFiles);
-            }
-
-            // invoke action
             return invocation.invoke();
-        } finally {
-            clearRequestScopedUploadValidationPolicy();
         }
+
+        if (!(invocation.getAction() instanceof UploadedFilesAware action)) {
+            LOG.debug("Action: {} doesn't implement: {}, ignoring file upload",
+                    invocation.getProxy().getActionName(),
+                    UploadedFilesAware.class.getSimpleName());
+            return invocation.invoke();
+        }
+
+        applyValidation(action, multiWrapper);
+
+        // bind allowed Files
+        Enumeration<String> fileParameterNames = multiWrapper.getFileParameterNames();
+        List<UploadedFile> acceptedFiles = new ArrayList<>();
+
+        while (fileParameterNames != null && fileParameterNames.hasMoreElements()) {
+            // get the value of this input tag
+            String inputName = fileParameterNames.nextElement();
+            UploadedFile[] uploadedFiles = multiWrapper.getFiles(inputName);
+
+            if (uploadedFiles == null || uploadedFiles.length == 0) {
+                if (LOG.isWarnEnabled()) {
+                    LOG.warn(getTextMessage(action, STRUTS_MESSAGES_INVALID_FILE_KEY, new String[]{inputName}));
+                }
+            } else {
+                for (UploadedFile uploadedFile : uploadedFiles) {
+                    if (acceptFile(action, uploadedFile, uploadedFile.getOriginalName(), uploadedFile.getContentType(), inputName, validationPolicy)) {
+                        acceptedFiles.add(uploadedFile);
+                    }
+                }
+            }
+        }
+
+        if (acceptedFiles.isEmpty()) {
+            LOG.debug("No files have been uploaded/accepted");
+        } else {
+            LOG.debug("Passing: {} uploaded file(s) to action", acceptedFiles.size());
+            action.withUploadedFiles(acceptedFiles);
+        }
+
+        // invoke action
+        return invocation.invoke();
     }
 
     /**

--- a/core/src/main/java/org/apache/struts2/interceptor/ActionFileUploadInterceptor.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/ActionFileUploadInterceptor.java
@@ -203,13 +203,13 @@ import java.util.List;
  * @see AbstractFileUploadInterceptor
  */
 public class ActionFileUploadInterceptor extends AbstractFileUploadInterceptor
-        implements WithLazyParams<AbstractFileUploadInterceptor.UploadValidationPolicy> {
+        implements WithLazyParams.InvocationScoped<AbstractFileUploadInterceptor.UploadValidationPolicy> {
 
     protected static final Logger LOG = LogManager.getLogger(ActionFileUploadInterceptor.class);
 
     @Override
     public String intercept(ActionInvocation invocation) throws Exception {
-        return WithLazyParams.super.intercept(invocation);
+        return WithLazyParams.InvocationScoped.super.intercept(invocation);
     }
 
     @Override

--- a/core/src/main/java/org/apache/struts2/interceptor/ActionFileUploadInterceptor.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/ActionFileUploadInterceptor.java
@@ -208,59 +208,63 @@ public class ActionFileUploadInterceptor extends AbstractFileUploadInterceptor i
 
     @Override
     public String intercept(ActionInvocation invocation) throws Exception {
-        HttpServletRequest request = invocation.getInvocationContext().getServletRequest();
-        MultiPartRequestWrapper multiWrapper = request instanceof HttpServletRequestWrapper wrapper
-                ? findMultipartRequestWrapper(wrapper)
-                : null;
+        try {
+            HttpServletRequest request = invocation.getInvocationContext().getServletRequest();
+            MultiPartRequestWrapper multiWrapper = request instanceof HttpServletRequestWrapper wrapper
+                    ? findMultipartRequestWrapper(wrapper)
+                    : null;
 
-        if (multiWrapper == null) {
-            if (LOG.isDebugEnabled()) {
-                ActionProxy proxy = invocation.getProxy();
-                LOG.debug(getTextMessage(STRUTS_MESSAGES_BYPASS_REQUEST_KEY, new String[]{proxy.getNamespace(), proxy.getActionName()}));
-            }
-            return invocation.invoke();
-        }
-
-        if (!(invocation.getAction() instanceof UploadedFilesAware action)) {
-            LOG.debug("Action: {} doesn't implement: {}, ignoring file upload",
-                    invocation.getProxy().getActionName(),
-                    UploadedFilesAware.class.getSimpleName());
-            return invocation.invoke();
-        }
-
-        applyValidation(action, multiWrapper);
-
-        // bind allowed Files
-        Enumeration<String> fileParameterNames = multiWrapper.getFileParameterNames();
-        List<UploadedFile> acceptedFiles = new ArrayList<>();
-
-        while (fileParameterNames != null && fileParameterNames.hasMoreElements()) {
-            // get the value of this input tag
-            String inputName = fileParameterNames.nextElement();
-            UploadedFile[] uploadedFiles = multiWrapper.getFiles(inputName);
-
-            if (uploadedFiles == null || uploadedFiles.length == 0) {
-                if (LOG.isWarnEnabled()) {
-                    LOG.warn(getTextMessage(action, STRUTS_MESSAGES_INVALID_FILE_KEY, new String[]{inputName}));
+            if (multiWrapper == null) {
+                if (LOG.isDebugEnabled()) {
+                    ActionProxy proxy = invocation.getProxy();
+                    LOG.debug(getTextMessage(STRUTS_MESSAGES_BYPASS_REQUEST_KEY, new String[]{proxy.getNamespace(), proxy.getActionName()}));
                 }
-            } else {
-                for (UploadedFile uploadedFile : uploadedFiles) {
-                    if (acceptFile(action, uploadedFile, uploadedFile.getOriginalName(), uploadedFile.getContentType(), inputName)) {
-                        acceptedFiles.add(uploadedFile);
+                return invocation.invoke();
+            }
+
+            if (!(invocation.getAction() instanceof UploadedFilesAware action)) {
+                LOG.debug("Action: {} doesn't implement: {}, ignoring file upload",
+                        invocation.getProxy().getActionName(),
+                        UploadedFilesAware.class.getSimpleName());
+                return invocation.invoke();
+            }
+
+            applyValidation(action, multiWrapper);
+
+            // bind allowed Files
+            Enumeration<String> fileParameterNames = multiWrapper.getFileParameterNames();
+            List<UploadedFile> acceptedFiles = new ArrayList<>();
+
+            while (fileParameterNames != null && fileParameterNames.hasMoreElements()) {
+                // get the value of this input tag
+                String inputName = fileParameterNames.nextElement();
+                UploadedFile[] uploadedFiles = multiWrapper.getFiles(inputName);
+
+                if (uploadedFiles == null || uploadedFiles.length == 0) {
+                    if (LOG.isWarnEnabled()) {
+                        LOG.warn(getTextMessage(action, STRUTS_MESSAGES_INVALID_FILE_KEY, new String[]{inputName}));
+                    }
+                } else {
+                    for (UploadedFile uploadedFile : uploadedFiles) {
+                        if (acceptFile(action, uploadedFile, uploadedFile.getOriginalName(), uploadedFile.getContentType(), inputName)) {
+                            acceptedFiles.add(uploadedFile);
+                        }
                     }
                 }
             }
-        }
 
-        if (acceptedFiles.isEmpty()) {
-            LOG.debug("No files have been uploaded/accepted");
-        } else {
-            LOG.debug("Passing: {} uploaded file(s) to action", acceptedFiles.size());
-            action.withUploadedFiles(acceptedFiles);
-        }
+            if (acceptedFiles.isEmpty()) {
+                LOG.debug("No files have been uploaded/accepted");
+            } else {
+                LOG.debug("Passing: {} uploaded file(s) to action", acceptedFiles.size());
+                action.withUploadedFiles(acceptedFiles);
+            }
 
-        // invoke action
-        return invocation.invoke();
+            // invoke action
+            return invocation.invoke();
+        } finally {
+            clearRequestScopedUploadValidationPolicy();
+        }
     }
 
     /**
@@ -285,4 +289,3 @@ public class ActionFileUploadInterceptor extends AbstractFileUploadInterceptor i
     }
 
 }
-

--- a/core/src/main/java/org/apache/struts2/interceptor/WithLazyParams.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/WithLazyParams.java
@@ -30,9 +30,6 @@ import java.util.Map;
 
 /**
  * Interceptors marked with this interface support dynamic parameter evaluation at action invocation time.
- * Static parameters are set during interceptor creation (factory time), while lazy expression parameters
- * are re-evaluated during each action invocation to resolve expressions like ${someValue} into an
- * invocation-scoped parameter holder.
  * <p>
  * This enables both:
  * <ul>
@@ -42,25 +39,33 @@ import java.util.Map;
  * <p>
  * The {@link Interceptor#init()} method is called after initial parameter setting, so interceptors
  * can rely on configured values during initialization. Expression parameters (containing ${...})
- * are re-evaluated at invocation time via {@link LazyParamInjector}.
+ * are re-evaluated at invocation time via {@link LazyParamInjector}. Interceptors that need
+ * invocation-scoped lazy parameter state should additionally implement {@link InvocationScoped}.
  *
  * @since 2.5.9
  */
-public interface WithLazyParams<P> extends Interceptor {
+public interface WithLazyParams {
 
     /**
-     * Creates the per-invocation holder used for lazily resolved interceptor params.
+     * Optional extension for interceptors that need lazy params isolated per invocation instead of
+     * being written back into the long-lived interceptor instance.
      */
-    P newLazyParams();
+    interface InvocationScoped<P> extends WithLazyParams, Interceptor {
 
-    /**
-     * Intercepts using the per-invocation lazy params resolved for the current request.
-     */
-    String intercept(ActionInvocation invocation, P lazyParams) throws Exception;
+        /**
+         * Creates the per-invocation holder used for lazily resolved interceptor params.
+         */
+        P newLazyParams();
 
-    @Override
-    default String intercept(ActionInvocation invocation) throws Exception {
-        return intercept(invocation, newLazyParams());
+        /**
+         * Intercepts using the per-invocation lazy params resolved for the current request.
+         */
+        String intercept(ActionInvocation invocation, P lazyParams) throws Exception;
+
+        @Override
+        default String intercept(ActionInvocation invocation) throws Exception {
+            return intercept(invocation, newLazyParams());
+        }
     }
 
     class LazyParamInjector {
@@ -84,13 +89,22 @@ public interface WithLazyParams<P> extends Interceptor {
             this.ognlUtil = ognlUtil;
         }
 
-        public <P> P injectParams(WithLazyParams<P> interceptor, Map<String, String> params, ActionContext invocationContext) {
+        public <P> P injectParams(InvocationScoped<P> interceptor, Map<String, String> params, ActionContext invocationContext) {
             P lazyParams = interceptor.newLazyParams();
+            injectParams(lazyParams, params, invocationContext);
+            return lazyParams;
+        }
+
+        public Interceptor injectParams(Interceptor interceptor, Map<String, String> params, ActionContext invocationContext) {
+            injectParams((Object) interceptor, params, invocationContext);
+            return interceptor;
+        }
+
+        private void injectParams(Object target, Map<String, String> params, ActionContext invocationContext) {
             for (Map.Entry<String, String> entry : params.entrySet()) {
                 Object paramValue = textParser.evaluate(new char[]{'$'}, entry.getValue(), valueEvaluator, TextParser.DEFAULT_LOOP_COUNT);
-                ognlUtil.setProperty(entry.getKey(), paramValue, lazyParams, invocationContext.getContextMap());
+                ognlUtil.setProperty(entry.getKey(), paramValue, target, invocationContext.getContextMap());
             }
-            return lazyParams;
         }
     }
 }

--- a/core/src/main/java/org/apache/struts2/interceptor/WithLazyParams.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/WithLazyParams.java
@@ -22,6 +22,7 @@ import org.apache.struts2.ActionInvocation;
 import org.apache.struts2.ActionContext;
 import org.apache.struts2.inject.Inject;
 import org.apache.struts2.ognl.OgnlUtil;
+import org.apache.struts2.ognl.ThreadAllowlist;
 import org.apache.struts2.util.TextParseUtil;
 import org.apache.struts2.util.TextParser;
 import org.apache.struts2.util.ValueStack;
@@ -72,6 +73,7 @@ public interface WithLazyParams {
 
         protected OgnlUtil ognlUtil;
         protected TextParser textParser;
+        protected ThreadAllowlist threadAllowlist;
         private final TextParseUtil.ParsedValueEvaluator valueEvaluator;
 
         public LazyParamInjector(final ValueStack valueStack) {
@@ -89,6 +91,11 @@ public interface WithLazyParams {
             this.ognlUtil = ognlUtil;
         }
 
+        @Inject
+        public void setThreadAllowlist(ThreadAllowlist threadAllowlist) {
+            this.threadAllowlist = threadAllowlist;
+        }
+
         public <P> P injectParams(InvocationScoped<P> interceptor, Map<String, String> params, ActionContext invocationContext) {
             P lazyParams = interceptor.newLazyParams();
             injectParams(lazyParams, params, invocationContext);
@@ -101,6 +108,9 @@ public interface WithLazyParams {
         }
 
         private void injectParams(Object target, Map<String, String> params, ActionContext invocationContext) {
+            if (threadAllowlist != null) {
+                threadAllowlist.allowClassHierarchy(target.getClass());
+            }
             for (Map.Entry<String, String> entry : params.entrySet()) {
                 Object paramValue = textParser.evaluate(new char[]{'$'}, entry.getValue(), valueEvaluator, TextParser.DEFAULT_LOOP_COUNT);
                 ognlUtil.setProperty(entry.getKey(), paramValue, target, invocationContext.getContextMap());

--- a/core/src/main/java/org/apache/struts2/interceptor/WithLazyParams.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/WithLazyParams.java
@@ -18,20 +18,21 @@
  */
 package org.apache.struts2.interceptor;
 
+import org.apache.struts2.ActionInvocation;
 import org.apache.struts2.ActionContext;
 import org.apache.struts2.inject.Inject;
 import org.apache.struts2.ognl.OgnlUtil;
 import org.apache.struts2.util.TextParseUtil;
 import org.apache.struts2.util.TextParser;
 import org.apache.struts2.util.ValueStack;
-import org.apache.struts2.util.reflection.ReflectionProvider;
 
 import java.util.Map;
 
 /**
  * Interceptors marked with this interface support dynamic parameter evaluation at action invocation time.
- * Parameters are set during interceptor creation (factory time), then re-evaluated during each action
- * invocation to resolve expressions like ${someValue}.
+ * Static parameters are set during interceptor creation (factory time), while lazy expression parameters
+ * are re-evaluated during each action invocation to resolve expressions like ${someValue} into an
+ * invocation-scoped parameter holder.
  * <p>
  * This enables both:
  * <ul>
@@ -45,16 +46,27 @@ import java.util.Map;
  *
  * @since 2.5.9
  */
-public interface WithLazyParams {
+public interface WithLazyParams<P> extends Interceptor {
+
+    /**
+     * Creates the per-invocation holder used for lazily resolved interceptor params.
+     */
+    P newLazyParams();
+
+    /**
+     * Intercepts using the per-invocation lazy params resolved for the current request.
+     */
+    String intercept(ActionInvocation invocation, P lazyParams) throws Exception;
+
+    @Override
+    default String intercept(ActionInvocation invocation) throws Exception {
+        return intercept(invocation, newLazyParams());
+    }
 
     class LazyParamInjector {
 
-        private static final ThreadLocal<Boolean> PARAM_INJECTION_IN_PROGRESS = new ThreadLocal<>();
-
         protected OgnlUtil ognlUtil;
         protected TextParser textParser;
-        protected ReflectionProvider reflectionProvider;
-
         private final TextParseUtil.ParsedValueEvaluator valueEvaluator;
 
         public LazyParamInjector(final ValueStack valueStack) {
@@ -68,30 +80,17 @@ public interface WithLazyParams {
         }
 
         @Inject
-        public void setReflectionProvider(ReflectionProvider reflectionProvider) {
-            this.reflectionProvider = reflectionProvider;
-        }
-
-        @Inject
         public void setOgnlUtil(OgnlUtil ognlUtil) {
             this.ognlUtil = ognlUtil;
         }
 
-        public static boolean isParamInjectionInProgress() {
-            return Boolean.TRUE.equals(PARAM_INJECTION_IN_PROGRESS.get());
-        }
-
-        public Interceptor injectParams(Interceptor interceptor, Map<String, String> params, ActionContext invocationContext) {
-            PARAM_INJECTION_IN_PROGRESS.set(Boolean.TRUE);
-            try {
-                for (Map.Entry<String, String> entry : params.entrySet()) {
-                    Object paramValue = textParser.evaluate(new char[]{'$'}, entry.getValue(), valueEvaluator, TextParser.DEFAULT_LOOP_COUNT);
-                    ognlUtil.setProperty(entry.getKey(), paramValue, interceptor, invocationContext.getContextMap());
-                }
-                return interceptor;
-            } finally {
-                PARAM_INJECTION_IN_PROGRESS.remove();
+        public <P> P injectParams(WithLazyParams<P> interceptor, Map<String, String> params, ActionContext invocationContext) {
+            P lazyParams = interceptor.newLazyParams();
+            for (Map.Entry<String, String> entry : params.entrySet()) {
+                Object paramValue = textParser.evaluate(new char[]{'$'}, entry.getValue(), valueEvaluator, TextParser.DEFAULT_LOOP_COUNT);
+                ognlUtil.setProperty(entry.getKey(), paramValue, lazyParams, invocationContext.getContextMap());
             }
+            return lazyParams;
         }
     }
 }

--- a/core/src/main/java/org/apache/struts2/interceptor/WithLazyParams.java
+++ b/core/src/main/java/org/apache/struts2/interceptor/WithLazyParams.java
@@ -49,6 +49,8 @@ public interface WithLazyParams {
 
     class LazyParamInjector {
 
+        private static final ThreadLocal<Boolean> PARAM_INJECTION_IN_PROGRESS = new ThreadLocal<>();
+
         protected OgnlUtil ognlUtil;
         protected TextParser textParser;
         protected ReflectionProvider reflectionProvider;
@@ -75,12 +77,21 @@ public interface WithLazyParams {
             this.ognlUtil = ognlUtil;
         }
 
+        public static boolean isParamInjectionInProgress() {
+            return Boolean.TRUE.equals(PARAM_INJECTION_IN_PROGRESS.get());
+        }
+
         public Interceptor injectParams(Interceptor interceptor, Map<String, String> params, ActionContext invocationContext) {
-            for (Map.Entry<String, String> entry : params.entrySet()) {
-                Object paramValue = textParser.evaluate(new char[]{'$'}, entry.getValue(), valueEvaluator, TextParser.DEFAULT_LOOP_COUNT);
-                ognlUtil.setProperty(entry.getKey(), paramValue, interceptor, invocationContext.getContextMap());
+            PARAM_INJECTION_IN_PROGRESS.set(Boolean.TRUE);
+            try {
+                for (Map.Entry<String, String> entry : params.entrySet()) {
+                    Object paramValue = textParser.evaluate(new char[]{'$'}, entry.getValue(), valueEvaluator, TextParser.DEFAULT_LOOP_COUNT);
+                    ognlUtil.setProperty(entry.getKey(), paramValue, interceptor, invocationContext.getContextMap());
+                }
+                return interceptor;
+            } finally {
+                PARAM_INJECTION_IN_PROGRESS.remove();
             }
-            return interceptor;
         }
     }
 }

--- a/core/src/test/java/org/apache/struts2/factory/DefaultInterceptorFactoryTest.java
+++ b/core/src/test/java/org/apache/struts2/factory/DefaultInterceptorFactoryTest.java
@@ -69,8 +69,41 @@ public class DefaultInterceptorFactoryTest extends XWorkTestCase {
         }
     }
 
+    public void testBuildInterceptorPreservesLegacyWithLazyParamsContract() throws Exception {
+        DefaultInterceptorFactory factory = new DefaultInterceptorFactory();
+        container.inject(factory);
+
+        InterceptorConfig config = new InterceptorConfig.Builder("legacyLazy", LegacyLazyInterceptor.class.getName())
+                .addParam("mode", "${lazyMode}")
+                .build();
+
+        LegacyLazyInterceptor interceptor =
+                (LegacyLazyInterceptor) factory.buildInterceptor(config, Collections.emptyMap());
+
+        assertEquals("${lazyMode}", interceptor.getMode());
+
+        ValueStack valueStack = container.getInstance(ValueStackFactory.class).createValueStack();
+        valueStack.push(new LegacyLazyAction("strict"));
+
+        ActionContext context = ActionContext.of(valueStack.getContext())
+                .withContainer(container)
+                .withValueStack(valueStack)
+                .bind();
+
+        try {
+            WithLazyParams.LazyParamInjector lazyParamInjector = new WithLazyParams.LazyParamInjector(valueStack);
+            container.inject(lazyParamInjector);
+
+            lazyParamInjector.injectParams(interceptor, config.getParams(), context);
+
+            assertEquals("strict", interceptor.getMode());
+        } finally {
+            ActionContext.clear();
+        }
+    }
+
     public static final class TypedLazyInterceptor extends AbstractInterceptor
-            implements WithLazyParams<TypedLazyInterceptor.LazyParams> {
+            implements WithLazyParams.InvocationScoped<TypedLazyInterceptor.LazyParams> {
         private Long maximumSize;
         private String mode;
 
@@ -97,7 +130,7 @@ public class DefaultInterceptorFactoryTest extends XWorkTestCase {
 
         @Override
         public String intercept(ActionInvocation invocation) throws Exception {
-            return WithLazyParams.super.intercept(invocation);
+            return WithLazyParams.InvocationScoped.super.intercept(invocation);
         }
 
         @Override
@@ -132,6 +165,23 @@ public class DefaultInterceptorFactoryTest extends XWorkTestCase {
         }
     }
 
+    public static final class LegacyLazyInterceptor extends AbstractInterceptor implements WithLazyParams {
+        private String mode;
+
+        public String getMode() {
+            return mode;
+        }
+
+        public void setMode(String mode) {
+            this.mode = mode;
+        }
+
+        @Override
+        public String intercept(ActionInvocation invocation) throws Exception {
+            return invocation.invoke();
+        }
+    }
+
     public static final class LazyParamAction {
         private final Long maxFileSize;
 
@@ -141,6 +191,18 @@ public class DefaultInterceptorFactoryTest extends XWorkTestCase {
 
         public Long getMaxFileSize() {
             return maxFileSize;
+        }
+    }
+
+    public static final class LegacyLazyAction {
+        private final String lazyMode;
+
+        private LegacyLazyAction(String lazyMode) {
+            this.lazyMode = lazyMode;
+        }
+
+        public String getLazyMode() {
+            return lazyMode;
         }
     }
 }

--- a/core/src/test/java/org/apache/struts2/factory/DefaultInterceptorFactoryTest.java
+++ b/core/src/test/java/org/apache/struts2/factory/DefaultInterceptorFactoryTest.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.struts2.factory;
+
+import org.apache.struts2.ActionContext;
+import org.apache.struts2.ActionInvocation;
+import org.apache.struts2.XWorkTestCase;
+import org.apache.struts2.config.entities.InterceptorConfig;
+import org.apache.struts2.interceptor.AbstractInterceptor;
+import org.apache.struts2.interceptor.WithLazyParams;
+import org.apache.struts2.util.ValueStack;
+import org.apache.struts2.util.ValueStackFactory;
+
+import java.util.Collections;
+
+public class DefaultInterceptorFactoryTest extends XWorkTestCase {
+
+    public void testBuildInterceptorDefersTypedLazyParamsUntilInvocationTime() throws Exception {
+        DefaultInterceptorFactory factory = new DefaultInterceptorFactory();
+        container.inject(factory);
+
+        InterceptorConfig config = new InterceptorConfig.Builder("typedLazy", TypedLazyInterceptor.class.getName())
+                .addParam("maximumSize", "${maxFileSize}")
+                .addParam("mode", "strict")
+                .build();
+
+        TypedLazyInterceptor interceptor =
+                (TypedLazyInterceptor) factory.buildInterceptor(config, Collections.emptyMap());
+
+        assertNull("Dynamic Long param should not be written into the singleton interceptor at factory time",
+                interceptor.getMaximumSize());
+        assertEquals("strict", interceptor.getMode());
+
+        ValueStack valueStack = container.getInstance(ValueStackFactory.class).createValueStack();
+        valueStack.push(new LazyParamAction(42L));
+
+        ActionContext context = ActionContext.of(valueStack.getContext())
+                .withContainer(container)
+                .withValueStack(valueStack)
+                .bind();
+
+        try {
+            WithLazyParams.LazyParamInjector lazyParamInjector = new WithLazyParams.LazyParamInjector(valueStack);
+            container.inject(lazyParamInjector);
+
+            TypedLazyInterceptor.LazyParams lazyParams =
+                    lazyParamInjector.injectParams(interceptor, config.getParams(), context);
+
+            assertEquals(Long.valueOf(42L), lazyParams.getMaximumSize());
+            assertEquals("strict", lazyParams.getMode());
+        } finally {
+            ActionContext.clear();
+        }
+    }
+
+    public static final class TypedLazyInterceptor extends AbstractInterceptor
+            implements WithLazyParams<TypedLazyInterceptor.LazyParams> {
+        private Long maximumSize;
+        private String mode;
+
+        public Long getMaximumSize() {
+            return maximumSize;
+        }
+
+        public void setMaximumSize(Long maximumSize) {
+            this.maximumSize = maximumSize;
+        }
+
+        public String getMode() {
+            return mode;
+        }
+
+        public void setMode(String mode) {
+            this.mode = mode;
+        }
+
+        @Override
+        public LazyParams newLazyParams() {
+            return new LazyParams(maximumSize, mode);
+        }
+
+        @Override
+        public String intercept(ActionInvocation invocation) throws Exception {
+            return WithLazyParams.super.intercept(invocation);
+        }
+
+        @Override
+        public String intercept(ActionInvocation invocation, LazyParams lazyParams) throws Exception {
+            return invocation.invoke();
+        }
+
+        public static final class LazyParams {
+            private Long maximumSize;
+            private String mode;
+
+            private LazyParams(Long maximumSize, String mode) {
+                this.maximumSize = maximumSize;
+                this.mode = mode;
+            }
+
+            public Long getMaximumSize() {
+                return maximumSize;
+            }
+
+            public void setMaximumSize(Long maximumSize) {
+                this.maximumSize = maximumSize;
+            }
+
+            public String getMode() {
+                return mode;
+            }
+
+            public void setMode(String mode) {
+                this.mode = mode;
+            }
+        }
+    }
+
+    public static final class LazyParamAction {
+        private final Long maxFileSize;
+
+        private LazyParamAction(Long maxFileSize) {
+            this.maxFileSize = maxFileSize;
+        }
+
+        public Long getMaxFileSize() {
+            return maxFileSize;
+        }
+    }
+}

--- a/core/src/test/java/org/apache/struts2/factory/DefaultInterceptorFactoryTest.java
+++ b/core/src/test/java/org/apache/struts2/factory/DefaultInterceptorFactoryTest.java
@@ -24,6 +24,7 @@ import org.apache.struts2.XWorkTestCase;
 import org.apache.struts2.config.entities.InterceptorConfig;
 import org.apache.struts2.interceptor.AbstractInterceptor;
 import org.apache.struts2.interceptor.WithLazyParams;
+import org.apache.struts2.ognl.ThreadAllowlist;
 import org.apache.struts2.util.ValueStack;
 import org.apache.struts2.util.ValueStackFactory;
 
@@ -65,6 +66,41 @@ public class DefaultInterceptorFactoryTest extends XWorkTestCase {
             assertEquals(Long.valueOf(42L), lazyParams.getMaximumSize());
             assertEquals("strict", lazyParams.getMode());
         } finally {
+            ActionContext.clear();
+        }
+    }
+
+    public void testBuildInterceptorAllowlistsInvocationScopedLazyParamsCarrier() throws Exception {
+        DefaultInterceptorFactory factory = new DefaultInterceptorFactory();
+        container.inject(factory);
+
+        InterceptorConfig config = new InterceptorConfig.Builder("typedLazy", TypedLazyInterceptor.class.getName())
+                .addParam("maximumSize", "${maxFileSize}")
+                .build();
+
+        TypedLazyInterceptor interceptor =
+                (TypedLazyInterceptor) factory.buildInterceptor(config, Collections.emptyMap());
+
+        ValueStack valueStack = container.getInstance(ValueStackFactory.class).createValueStack();
+        valueStack.push(new LazyParamAction(42L));
+
+        ActionContext context = ActionContext.of(valueStack.getContext())
+                .withContainer(container)
+                .withValueStack(valueStack)
+                .bind();
+
+        ThreadAllowlist threadAllowlist = container.getInstance(ThreadAllowlist.class);
+        threadAllowlist.clearAllowlist();
+
+        try {
+            WithLazyParams.LazyParamInjector lazyParamInjector = new WithLazyParams.LazyParamInjector(valueStack);
+            container.inject(lazyParamInjector);
+
+            lazyParamInjector.injectParams(interceptor, config.getParams(), context);
+
+            assertTrue(threadAllowlist.getAllowlist().contains(TypedLazyInterceptor.LazyParams.class));
+        } finally {
+            threadAllowlist.clearAllowlist();
             ActionContext.clear();
         }
     }

--- a/core/src/test/java/org/apache/struts2/interceptor/ActionFileUploadInterceptorTest.java
+++ b/core/src/test/java/org/apache/struts2/interceptor/ActionFileUploadInterceptorTest.java
@@ -899,8 +899,7 @@ public class ActionFileUploadInterceptorTest extends StrutsInternalTestCase {
             runUploadAttempt(
                     controlInterceptor,
                     controlAction,
-                    createUploadRequest("control.html", "text/html", htmlContent),
-                    controlAction.getAllowedMimeTypes()
+                    createUploadRequest("control.html", "text/html", htmlContent)
             );
 
             assertThat(controlAction.getUploadFiles()).isNull();
@@ -925,8 +924,7 @@ public class ActionFileUploadInterceptorTest extends StrutsInternalTestCase {
             Future<String> plainResult = executor.submit(() -> runUploadAttempt(
                     sharedInterceptor,
                     plainPolicyAction,
-                    createUploadRequest("plain-policy.html", "text/html", htmlContent),
-                    plainPolicyAction.getAllowedMimeTypes()
+                    createUploadRequest("plain-policy.html", "text/html", htmlContent)
             ));
 
             assertThat(sharedInterceptor.awaitFirstValidation()).isTrue();
@@ -934,8 +932,7 @@ public class ActionFileUploadInterceptorTest extends StrutsInternalTestCase {
             Future<String> htmlResult = executor.submit(() -> runUploadAttempt(
                     sharedInterceptor,
                     htmlPolicyAction,
-                    createUploadRequest("html-policy.html", "text/html", htmlContent),
-                    htmlPolicyAction.getAllowedMimeTypes()
+                    createUploadRequest("html-policy.html", "text/html", htmlContent)
             ));
 
             assertThat(htmlResult.get(10, TimeUnit.SECONDS)).isEqualTo("success");
@@ -959,8 +956,7 @@ public class ActionFileUploadInterceptorTest extends StrutsInternalTestCase {
 
     private String runUploadAttempt(ActionFileUploadInterceptor actionFileUploadInterceptor,
                                     MyDynamicFileUploadAction action,
-                                    MockHttpServletRequest uploadRequest,
-                                    String allowedTypes) throws Exception {
+                                    MockHttpServletRequest uploadRequest) throws Exception {
         MultiPartRequestWrapper multiPartRequest = createMultipartRequest(uploadRequest, -1, -1, 3, -1);
         ValueStack valueStack = container.getInstance(ValueStackFactory.class).createValueStack();
         valueStack.push(action);

--- a/core/src/test/java/org/apache/struts2/interceptor/ActionFileUploadInterceptorTest.java
+++ b/core/src/test/java/org/apache/struts2/interceptor/ActionFileUploadInterceptorTest.java
@@ -34,6 +34,8 @@ import org.apache.struts2.locale.DefaultLocaleProvider;
 import org.apache.struts2.mock.MockActionInvocation;
 import org.apache.struts2.mock.MockActionProxy;
 import org.apache.struts2.util.ClassLoaderUtil;
+import org.apache.struts2.util.ValueStack;
+import org.apache.struts2.util.ValueStackFactory;
 import org.assertj.core.util.Files;
 import org.springframework.mock.web.MockHttpServletRequest;
 
@@ -41,8 +43,16 @@ import java.io.File;
 import java.net.URI;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -536,6 +546,10 @@ public class ActionFileUploadInterceptorTest extends StrutsInternalTestCase {
     }
 
     private MultiPartRequestWrapper createMultipartRequest(int maxsize, int maxfilesize, int maxfiles, int maxStringLength) {
+        return createMultipartRequest(request, maxsize, maxfilesize, maxfiles, maxStringLength);
+    }
+
+    private MultiPartRequestWrapper createMultipartRequest(MockHttpServletRequest multipartRequest, int maxsize, int maxfilesize, int maxfiles, int maxStringLength) {
         JakartaMultiPartRequest jak = new JakartaMultiPartRequest();
         jak.setMaxSize(String.valueOf(maxsize));
         jak.setMaxFileSize(String.valueOf(maxfilesize));
@@ -543,7 +557,17 @@ public class ActionFileUploadInterceptorTest extends StrutsInternalTestCase {
         jak.setMaxStringLength(String.valueOf(maxStringLength));
         jak.setDefaultEncoding(StandardCharsets.UTF_8.name());
 
-        return new MultiPartRequestWrapper(jak, request, tempDir.getAbsolutePath(), new DefaultLocaleProvider());
+        return new MultiPartRequestWrapper(jak, multipartRequest, tempDir.getAbsolutePath(), new DefaultLocaleProvider());
+    }
+
+    private MockHttpServletRequest createUploadRequest(String filename, String contentType, String content) {
+        MockHttpServletRequest uploadRequest = new MockHttpServletRequest();
+        uploadRequest.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        uploadRequest.setMethod("POST");
+        uploadRequest.addHeader("Content-type", "multipart/form-data; boundary=\"" + boundary + "\"");
+        uploadRequest.setContent((encodeTextFile(filename, contentType, content) + endLine + "--" + boundary + "--")
+                .getBytes(StandardCharsets.UTF_8));
+        return uploadRequest;
     }
 
     protected void setUp() throws Exception {
@@ -647,7 +671,7 @@ public class ActionFileUploadInterceptorTest extends StrutsInternalTestCase {
 
         // Simulate WithLazyParams injection by manually setting the parameters
         // In real execution, DefaultActionInvocation.invoke() would call LazyParamInjector
-        interceptor.setAllowedTypes(action.getAllowedMimeTypes());
+        injectDynamicUploadPolicy(interceptor, ActionContext.getContext(), true, false, false);
 
         interceptor.intercept(mai);
 
@@ -683,7 +707,7 @@ public class ActionFileUploadInterceptorTest extends StrutsInternalTestCase {
         ActionContext.getContext().getValueStack().push(action1);
         ActionContext.getContext().withServletRequest(createMultipartRequestMaxFiles());
 
-        interceptor.setAllowedTypes(action1.getAllowedMimeTypes());
+        injectDynamicUploadPolicy(interceptor, ActionContext.getContext(), true, false, false);
         interceptor.intercept(mai1);
 
         assertThat(action1.getUploadFiles()).isNotNull().hasSize(1);
@@ -712,7 +736,7 @@ public class ActionFileUploadInterceptorTest extends StrutsInternalTestCase {
         ActionContext.getContext().withServletRequest(createMultipartRequestMaxFiles());
 
         // Simulate new parameter evaluation for second request
-        interceptor.setAllowedTypes(action2.getAllowedMimeTypes());
+        injectDynamicUploadPolicy(interceptor, ActionContext.getContext(), true, false, false);
         interceptor.intercept(mai2);
 
         assertThat(action2.getUploadFiles()).isNotNull().hasSize(1);
@@ -743,7 +767,7 @@ public class ActionFileUploadInterceptorTest extends StrutsInternalTestCase {
         ActionContext.getContext().getValueStack().push(action);
         ActionContext.getContext().withServletRequest(createMultipartRequestMaxFiles());
 
-        interceptor.setAllowedExtensions(action.getAllowedExtensions());
+        injectDynamicUploadPolicy(interceptor, ActionContext.getContext(), false, true, false);
         interceptor.intercept(mai);
 
         List<UploadedFile> files = action.getUploadFiles();
@@ -782,7 +806,7 @@ public class ActionFileUploadInterceptorTest extends StrutsInternalTestCase {
         ActionContext.getContext().getValueStack().push(action);
         ActionContext.getContext().withServletRequest(createMultipartRequestMaxFiles());
 
-        interceptor.setMaximumSize(action.getMaxFileSize());
+        injectDynamicUploadPolicy(interceptor, ActionContext.getContext(), false, false, true);
         interceptor.intercept(mai);
 
         // File should be rejected due to size
@@ -816,8 +840,7 @@ public class ActionFileUploadInterceptorTest extends StrutsInternalTestCase {
         ActionContext.getContext().getValueStack().push(action);
         ActionContext.getContext().withServletRequest(createMultipartRequestMaxFiles());
 
-        interceptor.setAllowedTypes(action.getAllowedMimeTypes());
-        interceptor.setAllowedExtensions(action.getAllowedExtensions());
+        injectDynamicUploadPolicy(interceptor, ActionContext.getContext(), true, true, false);
         interceptor.intercept(mai);
 
         List<UploadedFile> files = action.getUploadFiles();
@@ -853,7 +876,7 @@ public class ActionFileUploadInterceptorTest extends StrutsInternalTestCase {
         ActionContext.getContext().getValueStack().push(action);
         ActionContext.getContext().withServletRequest(createMultipartRequestMaxFiles());
 
-        interceptor.setAllowedTypes(action.getAllowedMimeTypes());
+        injectDynamicUploadPolicy(interceptor, ActionContext.getContext(), true, false, false);
         interceptor.intercept(mai);
 
         List<UploadedFile> files = action.getUploadFiles();
@@ -862,6 +885,125 @@ public class ActionFileUploadInterceptorTest extends StrutsInternalTestCase {
         assertThat(files).isNotNull().hasSize(2);
         assertThat(files.get(0).getContentType()).startsWith("image/");
         assertThat(files.get(1).getContentType()).startsWith("image/");
+    }
+
+    public void testConcurrentDynamicPoliciesStayIsolatedPerRequest() throws Exception {
+        ActionFileUploadInterceptor controlInterceptor = new ActionFileUploadInterceptor();
+        container.inject(controlInterceptor);
+
+        MyDynamicFileUploadAction controlAction = new MyDynamicFileUploadAction();
+        controlAction.setAllowedMimeTypes("text/plain");
+        container.inject(controlAction);
+
+        try {
+            runUploadAttempt(
+                    controlInterceptor,
+                    controlAction,
+                    createUploadRequest("control.html", "text/html", htmlContent),
+                    controlAction.getAllowedMimeTypes()
+            );
+
+            assertThat(controlAction.getUploadFiles()).isNull();
+            assertThat(controlAction.getFieldErrors()).containsKey("file");
+        } finally {
+            controlInterceptor.destroy();
+        }
+
+        CoordinatedActionFileUploadInterceptor sharedInterceptor = new CoordinatedActionFileUploadInterceptor();
+        container.inject(sharedInterceptor);
+
+        MyDynamicFileUploadAction plainPolicyAction = new MyDynamicFileUploadAction();
+        plainPolicyAction.setAllowedMimeTypes("text/plain");
+        container.inject(plainPolicyAction);
+
+        MyDynamicFileUploadAction htmlPolicyAction = new MyDynamicFileUploadAction();
+        htmlPolicyAction.setAllowedMimeTypes("text/html");
+        container.inject(htmlPolicyAction);
+
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            Future<String> plainResult = executor.submit(() -> runUploadAttempt(
+                    sharedInterceptor,
+                    plainPolicyAction,
+                    createUploadRequest("plain-policy.html", "text/html", htmlContent),
+                    plainPolicyAction.getAllowedMimeTypes()
+            ));
+
+            assertThat(sharedInterceptor.awaitFirstValidation()).isTrue();
+
+            Future<String> htmlResult = executor.submit(() -> runUploadAttempt(
+                    sharedInterceptor,
+                    htmlPolicyAction,
+                    createUploadRequest("html-policy.html", "text/html", htmlContent),
+                    htmlPolicyAction.getAllowedMimeTypes()
+            ));
+
+            assertThat(htmlResult.get(10, TimeUnit.SECONDS)).isEqualTo("success");
+            sharedInterceptor.releaseFirstValidation();
+            assertThat(plainResult.get(10, TimeUnit.SECONDS)).isEqualTo("success");
+        } finally {
+            sharedInterceptor.releaseFirstValidation();
+            executor.shutdownNow();
+            sharedInterceptor.destroy();
+        }
+
+        assertThat(plainPolicyAction.getAllowedMimeTypes()).isEqualTo("text/plain");
+        assertThat(plainPolicyAction.getUploadFiles()).isNull();
+        assertThat(plainPolicyAction.getFieldErrors()).containsKey("file");
+
+        assertThat(htmlPolicyAction.hasFieldErrors()).isFalse();
+        assertThat(htmlPolicyAction.getUploadFiles()).isNotNull().hasSize(1);
+        assertThat(htmlPolicyAction.getUploadFiles().get(0).getOriginalName()).isEqualTo("html-policy.html");
+        assertThat(htmlPolicyAction.getUploadFiles().get(0).getContentType()).isEqualTo("text/html");
+    }
+
+    private String runUploadAttempt(ActionFileUploadInterceptor actionFileUploadInterceptor,
+                                    MyDynamicFileUploadAction action,
+                                    MockHttpServletRequest uploadRequest,
+                                    String allowedTypes) throws Exception {
+        MultiPartRequestWrapper multiPartRequest = createMultipartRequest(uploadRequest, -1, -1, 3, -1);
+        ValueStack valueStack = container.getInstance(ValueStackFactory.class).createValueStack();
+        valueStack.push(action);
+
+        ActionContext context = ActionContext.of(valueStack.getContext())
+                .withContainer(container)
+                .withValueStack(valueStack)
+                .withServletRequest(multiPartRequest)
+                .bind();
+
+        try {
+            MockActionInvocation invocation = new MockActionInvocation();
+            invocation.setAction(action);
+            invocation.setResultCode("success");
+            invocation.setInvocationContext(context);
+
+            injectDynamicUploadPolicy(actionFileUploadInterceptor, context, true, false, false);
+            return actionFileUploadInterceptor.intercept(invocation);
+        } finally {
+            ActionContext.clear();
+        }
+    }
+
+    private void injectDynamicUploadPolicy(ActionFileUploadInterceptor actionFileUploadInterceptor,
+                                           ActionContext context,
+                                           boolean includeAllowedTypes,
+                                           boolean includeAllowedExtensions,
+                                           boolean includeMaximumSize) {
+        Map<String, String> params = new HashMap<>();
+        if (includeAllowedTypes) {
+            params.put("allowedTypes", "${allowedMimeTypes}");
+        }
+        if (includeAllowedExtensions) {
+            params.put("allowedExtensions", "${allowedExtensions}");
+        }
+        if (includeMaximumSize) {
+            params.put("maximumSize", "${maxFileSize}");
+        }
+
+        WithLazyParams.LazyParamInjector lazyParamInjector =
+                new WithLazyParams.LazyParamInjector(context.getValueStack());
+        container.inject(lazyParamInjector);
+        lazyParamInjector.injectParams(actionFileUploadInterceptor, params, context);
     }
 
     public static class MyFileUploadAction extends ActionSupport implements UploadedFilesAware {
@@ -917,6 +1059,40 @@ public class ActionFileUploadInterceptorTest extends StrutsInternalTestCase {
 
         public void setMaxFileSize(Long maxFileSize) {
             this.maxFileSize = maxFileSize;
+        }
+    }
+
+    private static final class CoordinatedActionFileUploadInterceptor extends ActionFileUploadInterceptor {
+        private final AtomicBoolean pauseFirstValidation = new AtomicBoolean(true);
+        private final CountDownLatch firstValidationEntered = new CountDownLatch(1);
+        private final CountDownLatch allowFirstValidationToContinue = new CountDownLatch(1);
+
+        @Override
+        protected boolean acceptFile(Object action, UploadedFile file, String originalFilename, String contentType, String inputName) {
+            if (pauseFirstValidation.compareAndSet(true, false)) {
+                firstValidationEntered.countDown();
+                awaitUnchecked(allowFirstValidationToContinue);
+            }
+            return super.acceptFile(action, file, originalFilename, contentType, inputName);
+        }
+
+        private boolean awaitFirstValidation() throws InterruptedException {
+            return firstValidationEntered.await(10, TimeUnit.SECONDS);
+        }
+
+        private void releaseFirstValidation() {
+            allowFirstValidationToContinue.countDown();
+        }
+
+        private void awaitUnchecked(CountDownLatch latch) {
+            try {
+                if (!latch.await(10, TimeUnit.SECONDS)) {
+                    throw new AssertionError("Timed out waiting for concurrent validation release");
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new AssertionError("Interrupted while waiting for concurrent validation release", e);
+            }
         }
     }
 

--- a/core/src/test/java/org/apache/struts2/interceptor/ActionFileUploadInterceptorTest.java
+++ b/core/src/test/java/org/apache/struts2/interceptor/ActionFileUploadInterceptorTest.java
@@ -671,9 +671,7 @@ public class ActionFileUploadInterceptorTest extends StrutsInternalTestCase {
 
         // Simulate WithLazyParams injection by manually setting the parameters
         // In real execution, DefaultActionInvocation.invoke() would call LazyParamInjector
-        injectDynamicUploadPolicy(interceptor, ActionContext.getContext(), true, false, false);
-
-        interceptor.intercept(mai);
+        interceptor.intercept(mai, injectDynamicUploadPolicy(interceptor, ActionContext.getContext(), true, false, false));
 
         List<UploadedFile> files = action.getUploadFiles();
 
@@ -707,8 +705,7 @@ public class ActionFileUploadInterceptorTest extends StrutsInternalTestCase {
         ActionContext.getContext().getValueStack().push(action1);
         ActionContext.getContext().withServletRequest(createMultipartRequestMaxFiles());
 
-        injectDynamicUploadPolicy(interceptor, ActionContext.getContext(), true, false, false);
-        interceptor.intercept(mai1);
+        interceptor.intercept(mai1, injectDynamicUploadPolicy(interceptor, ActionContext.getContext(), true, false, false));
 
         assertThat(action1.getUploadFiles()).isNotNull().hasSize(1);
         assertThat(action1.getUploadFiles().get(0).getContentType()).isEqualTo("text/plain");
@@ -736,8 +733,7 @@ public class ActionFileUploadInterceptorTest extends StrutsInternalTestCase {
         ActionContext.getContext().withServletRequest(createMultipartRequestMaxFiles());
 
         // Simulate new parameter evaluation for second request
-        injectDynamicUploadPolicy(interceptor, ActionContext.getContext(), true, false, false);
-        interceptor.intercept(mai2);
+        interceptor.intercept(mai2, injectDynamicUploadPolicy(interceptor, ActionContext.getContext(), true, false, false));
 
         assertThat(action2.getUploadFiles()).isNotNull().hasSize(1);
         assertThat(action2.getUploadFiles().get(0).getContentType()).isEqualTo("text/html");
@@ -767,8 +763,7 @@ public class ActionFileUploadInterceptorTest extends StrutsInternalTestCase {
         ActionContext.getContext().getValueStack().push(action);
         ActionContext.getContext().withServletRequest(createMultipartRequestMaxFiles());
 
-        injectDynamicUploadPolicy(interceptor, ActionContext.getContext(), false, true, false);
-        interceptor.intercept(mai);
+        interceptor.intercept(mai, injectDynamicUploadPolicy(interceptor, ActionContext.getContext(), false, true, false));
 
         List<UploadedFile> files = action.getUploadFiles();
 
@@ -806,8 +801,7 @@ public class ActionFileUploadInterceptorTest extends StrutsInternalTestCase {
         ActionContext.getContext().getValueStack().push(action);
         ActionContext.getContext().withServletRequest(createMultipartRequestMaxFiles());
 
-        injectDynamicUploadPolicy(interceptor, ActionContext.getContext(), false, false, true);
-        interceptor.intercept(mai);
+        interceptor.intercept(mai, injectDynamicUploadPolicy(interceptor, ActionContext.getContext(), false, false, true));
 
         // File should be rejected due to size
         assertThat(action.hasFieldErrors()).isTrue();
@@ -840,8 +834,7 @@ public class ActionFileUploadInterceptorTest extends StrutsInternalTestCase {
         ActionContext.getContext().getValueStack().push(action);
         ActionContext.getContext().withServletRequest(createMultipartRequestMaxFiles());
 
-        injectDynamicUploadPolicy(interceptor, ActionContext.getContext(), true, true, false);
-        interceptor.intercept(mai);
+        interceptor.intercept(mai, injectDynamicUploadPolicy(interceptor, ActionContext.getContext(), true, true, false));
 
         List<UploadedFile> files = action.getUploadFiles();
 
@@ -876,8 +869,7 @@ public class ActionFileUploadInterceptorTest extends StrutsInternalTestCase {
         ActionContext.getContext().getValueStack().push(action);
         ActionContext.getContext().withServletRequest(createMultipartRequestMaxFiles());
 
-        injectDynamicUploadPolicy(interceptor, ActionContext.getContext(), true, false, false);
-        interceptor.intercept(mai);
+        interceptor.intercept(mai, injectDynamicUploadPolicy(interceptor, ActionContext.getContext(), true, false, false));
 
         List<UploadedFile> files = action.getUploadFiles();
 
@@ -973,18 +965,20 @@ public class ActionFileUploadInterceptorTest extends StrutsInternalTestCase {
             invocation.setResultCode("success");
             invocation.setInvocationContext(context);
 
-            injectDynamicUploadPolicy(actionFileUploadInterceptor, context, true, false, false);
-            return actionFileUploadInterceptor.intercept(invocation);
+            return actionFileUploadInterceptor.intercept(
+                    invocation,
+                    injectDynamicUploadPolicy(actionFileUploadInterceptor, context, true, false, false)
+            );
         } finally {
             ActionContext.clear();
         }
     }
 
-    private void injectDynamicUploadPolicy(ActionFileUploadInterceptor actionFileUploadInterceptor,
-                                           ActionContext context,
-                                           boolean includeAllowedTypes,
-                                           boolean includeAllowedExtensions,
-                                           boolean includeMaximumSize) {
+    private AbstractFileUploadInterceptor.UploadValidationPolicy injectDynamicUploadPolicy(ActionFileUploadInterceptor actionFileUploadInterceptor,
+                                                                                           ActionContext context,
+                                                                                           boolean includeAllowedTypes,
+                                                                                           boolean includeAllowedExtensions,
+                                                                                           boolean includeMaximumSize) {
         Map<String, String> params = new HashMap<>();
         if (includeAllowedTypes) {
             params.put("allowedTypes", "${allowedMimeTypes}");
@@ -999,7 +993,7 @@ public class ActionFileUploadInterceptorTest extends StrutsInternalTestCase {
         WithLazyParams.LazyParamInjector lazyParamInjector =
                 new WithLazyParams.LazyParamInjector(context.getValueStack());
         container.inject(lazyParamInjector);
-        lazyParamInjector.injectParams(actionFileUploadInterceptor, params, context);
+        return lazyParamInjector.injectParams(actionFileUploadInterceptor, params, context);
     }
 
     public static class MyFileUploadAction extends ActionSupport implements UploadedFilesAware {
@@ -1064,12 +1058,17 @@ public class ActionFileUploadInterceptorTest extends StrutsInternalTestCase {
         private final CountDownLatch allowFirstValidationToContinue = new CountDownLatch(1);
 
         @Override
-        protected boolean acceptFile(Object action, UploadedFile file, String originalFilename, String contentType, String inputName) {
+        protected boolean acceptFile(Object action,
+                                     UploadedFile file,
+                                     String originalFilename,
+                                     String contentType,
+                                     String inputName,
+                                     UploadValidationPolicy validationPolicy) {
             if (pauseFirstValidation.compareAndSet(true, false)) {
                 firstValidationEntered.countDown();
                 awaitUnchecked(allowFirstValidationToContinue);
             }
-            return super.acceptFile(action, file, originalFilename, contentType, inputName);
+            return super.acceptFile(action, file, originalFilename, contentType, inputName, validationPolicy);
         }
 
         private boolean awaitFirstValidation() throws InterruptedException {

--- a/core/src/test/java/org/apache/struts2/mock/MockLazyInterceptor.java
+++ b/core/src/test/java/org/apache/struts2/mock/MockLazyInterceptor.java
@@ -23,7 +23,7 @@ import org.apache.struts2.SimpleAction;
 import org.apache.struts2.interceptor.AbstractInterceptor;
 import org.apache.struts2.interceptor.WithLazyParams;
 
-public class MockLazyInterceptor extends AbstractInterceptor implements WithLazyParams<MockLazyInterceptor.LazyParams> {
+public class MockLazyInterceptor extends AbstractInterceptor implements WithLazyParams.InvocationScoped<MockLazyInterceptor.LazyParams> {
 
     private String foo = "";
     private String bar = "";
@@ -46,7 +46,7 @@ public class MockLazyInterceptor extends AbstractInterceptor implements WithLazy
 
     @Override
     public String intercept(ActionInvocation invocation) throws Exception {
-        return WithLazyParams.super.intercept(invocation);
+        return WithLazyParams.InvocationScoped.super.intercept(invocation);
     }
 
     @Override

--- a/core/src/test/java/org/apache/struts2/mock/MockLazyInterceptor.java
+++ b/core/src/test/java/org/apache/struts2/mock/MockLazyInterceptor.java
@@ -23,7 +23,7 @@ import org.apache.struts2.SimpleAction;
 import org.apache.struts2.interceptor.AbstractInterceptor;
 import org.apache.struts2.interceptor.WithLazyParams;
 
-public class MockLazyInterceptor extends AbstractInterceptor implements WithLazyParams {
+public class MockLazyInterceptor extends AbstractInterceptor implements WithLazyParams<MockLazyInterceptor.LazyParams> {
 
     private String foo = "";
     private String bar = "";
@@ -44,14 +44,51 @@ public class MockLazyInterceptor extends AbstractInterceptor implements WithLazy
         return bar;
     }
 
+    @Override
     public String intercept(ActionInvocation invocation) throws Exception {
+        return WithLazyParams.super.intercept(invocation);
+    }
+
+    @Override
+    public LazyParams newLazyParams() {
+        return new LazyParams(foo, bar);
+    }
+
+    @Override
+    public String intercept(ActionInvocation invocation, LazyParams lazyParams) throws Exception {
         if (invocation.getAction() instanceof SimpleAction) {
-            ((SimpleAction) invocation.getAction()).setName(foo);
+            ((SimpleAction) invocation.getAction()).setName(lazyParams.getFoo());
             // Only set blah if bar is configured (not empty)
-            if (bar != null && !bar.isEmpty()) {
-                ((SimpleAction) invocation.getAction()).setBlah(bar);
+            if (lazyParams.getBar() != null && !lazyParams.getBar().isEmpty()) {
+                ((SimpleAction) invocation.getAction()).setBlah(lazyParams.getBar());
             }
         }
         return invocation.invoke();
+    }
+
+    public static final class LazyParams {
+        private String foo = "";
+        private String bar = "";
+
+        private LazyParams(String foo, String bar) {
+            this.foo = foo;
+            this.bar = bar;
+        }
+
+        public String getFoo() {
+            return foo;
+        }
+
+        public void setFoo(String foo) {
+            this.foo = foo;
+        }
+
+        public String getBar() {
+            return bar;
+        }
+
+        public void setBar(String bar) {
+            this.bar = bar;
+        }
     }
 }


### PR DESCRIPTION
Follow-up to [WW-5585](https://issues.apache.org/jira/browse/WW-5585).

When `allowedTypes`, `allowedExtensions`, or `maximumSize` are resolved lazily from `${...}`, those resolved values currently get written back onto the shared interceptor instance. That lets concurrent requests bleed into each other before file validation runs.

This keeps the lazily resolved upload policy request-scoped for the lifetime of the interceptor call and clears it afterwards. Static interceptor configuration still behaves the same.

Tests:
- `./mvnw -pl core -Dtest=org.apache.struts2.interceptor.ActionFileUploadInterceptorTest#testConcurrentDynamicPoliciesStayIsolatedPerRequest test`
- `./mvnw -pl core -Dtest=org.apache.struts2.interceptor.ActionFileUploadInterceptorTest,org.apache.struts2.DefaultActionInvocationTest test`