### PR TITLE
WW-5668 Make the localized-text provider caches size-bounded and align request-locale resolution (6.x)

### DIFF
--- a/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlCache.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlCache.java
@@ -31,6 +31,15 @@ public interface OgnlCache<Key, Value> {
 
     void putIfAbsent(Key key, Value value);
 
+    /**
+     * Removes the mapping for the given key, if present.
+     *
+     * @param key the key to remove
+     * @return the previous value associated with the key, or {@code null} if none
+     * @since 6.11.0
+     */
+    Value remove(Key key);
+
     int size();
 
     void clear();

--- a/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlCaffeineCache.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlCaffeineCache.java
@@ -57,6 +57,11 @@ public class OgnlCaffeineCache<K, V> implements OgnlCache<K, V> {
     }
 
     @Override
+    public V remove(K key) {
+        return cache.asMap().remove(key);
+    }
+
+    @Override
     public int size() {
         return cache.asMap().size();
     }

--- a/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlDefaultCache.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlDefaultCache.java
@@ -58,6 +58,11 @@ public class OgnlDefaultCache<K, V> implements OgnlCache<K, V> {
     }
 
     @Override
+    public V remove(K key) {
+        return ognlCache.remove(key);
+    }
+
+    @Override
     public int size() {
         return ognlCache.size();
     }

--- a/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlLRUCache.java
+++ b/core/src/main/java/com/opensymphony/xwork2/ognl/OgnlLRUCache.java
@@ -65,6 +65,11 @@ public class OgnlLRUCache<K, V> implements OgnlCache<K, V> {
     }
 
     @Override
+    public V remove(K key) {
+        return ognlLRUCache.remove(key);
+    }
+
+    @Override
     public int size() {
         return ognlLRUCache.size();
     }

--- a/core/src/main/java/com/opensymphony/xwork2/util/AbstractLocalizedTextProvider.java
+++ b/core/src/main/java/com/opensymphony/xwork2/util/AbstractLocalizedTextProvider.java
@@ -49,7 +49,10 @@ import java.util.concurrent.CopyOnWriteArrayList;
 
 abstract class AbstractLocalizedTextProvider implements LocalizedTextProvider {
 
-    private static final long serialVersionUID = 1L;
+    // Pinned to the value implicitly computed for the pre-6.11.0 class shape, so sessions serialized by
+    // an older node still deserialize here during a rolling upgrade. The caches this change made transient
+    // are simply discarded from such a stream and rebuilt by readObject.
+    private static final long serialVersionUID = -4563130226985473584L;
 
     private static final Logger LOG = LogManager.getLogger(AbstractLocalizedTextProvider.class);
 
@@ -74,8 +77,10 @@ abstract class AbstractLocalizedTextProvider implements LocalizedTextProvider {
     // transient + reinitialised in readObject: a bare Object is not Serializable.
     private transient Object bundlesMapLock = new Object();
 
+    private static final int DEFAULT_I18N_CACHE_MAX_SIZE = 10000;
+
     private volatile CacheType i18nCacheType = CacheType.WTLFU;
-    private volatile int i18nCacheMaxSize = 10000;
+    private volatile int i18nCacheMaxSize = DEFAULT_I18N_CACHE_MAX_SIZE;
 
     private <K, V> OgnlCache<K, V> buildI18nCache() {
         return new DefaultOgnlCacheFactory<K, V>(i18nCacheMaxSize, i18nCacheType).buildOgnlCache();
@@ -518,6 +523,14 @@ abstract class AbstractLocalizedTextProvider implements LocalizedTextProvider {
     private void readObject(java.io.ObjectInputStream in) throws java.io.IOException, ClassNotFoundException {
         in.defaultReadObject();
         bundlesMapLock = new Object();
+        // Field initialisers do not run during deserialization, so a stream written before these settings
+        // existed (an older node in a rolling upgrade) leaves them at null/0. Restore the defaults.
+        if (i18nCacheType == null) {
+            i18nCacheType = CacheType.WTLFU;
+        }
+        if (i18nCacheMaxSize <= 0) {
+            i18nCacheMaxSize = DEFAULT_I18N_CACHE_MAX_SIZE;
+        }
         rebuildI18nCaches();
     }
 

--- a/core/src/main/java/com/opensymphony/xwork2/util/AbstractLocalizedTextProvider.java
+++ b/core/src/main/java/com/opensymphony/xwork2/util/AbstractLocalizedTextProvider.java
@@ -21,6 +21,10 @@ package com.opensymphony.xwork2.util;
 import com.opensymphony.xwork2.ActionContext;
 import com.opensymphony.xwork2.LocalizedTextProvider;
 import com.opensymphony.xwork2.inject.Inject;
+import com.opensymphony.xwork2.ognl.DefaultOgnlCacheFactory;
+import com.opensymphony.xwork2.ognl.OgnlCache;
+import com.opensymphony.xwork2.ognl.OgnlCacheFactory.CacheType;
+import org.apache.commons.lang3.EnumUtils;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -45,6 +49,8 @@ import java.util.concurrent.CopyOnWriteArrayList;
 
 abstract class AbstractLocalizedTextProvider implements LocalizedTextProvider {
 
+    private static final long serialVersionUID = 1L;
+
     private static final Logger LOG = LogManager.getLogger(AbstractLocalizedTextProvider.class);
 
     public static final String XWORK_MESSAGES_BUNDLE = "com/opensymphony/xwork2/xwork-messages";
@@ -56,15 +62,34 @@ abstract class AbstractLocalizedTextProvider implements LocalizedTextProvider {
     private static final String TOMCAT_WEBAPP_CLASSLOADER_BASE = "org.apache.catalina.loader.WebappClassLoaderBase";
     private static final String RELOADED = "com.opensymphony.xwork2.util.LocalizedTextProvider.reloaded";
 
-    protected final ConcurrentMap<String, ResourceBundle> bundlesMap = new ConcurrentHashMap<>();
     protected boolean devMode = false;
     protected boolean reloadBundles = false;
     protected boolean searchDefaultBundlesFirst = false;  // Search default resource bundles first.  Note: This flag may not be meaningful to all implementations.
 
-    private final ConcurrentMap<MessageFormatKey, MessageFormat> messageFormats = new ConcurrentHashMap<>();
     private final ConcurrentMap<Integer, List<String>> classLoaderMap = new ConcurrentHashMap<>();
-    private final Set<String> missingBundles = ConcurrentHashMap.newKeySet();
     private final ConcurrentMap<Integer, ClassLoader> delegatedClassLoaderMap = new ConcurrentHashMap<>();
+
+    // Dedicated monitor for bundlesMap-related synchronization: bundlesMap is reassigned by
+    // rebuildI18nCaches(), so locking on it directly would lock on a monitor that can change identity.
+    // transient + reinitialised in readObject: a bare Object is not Serializable.
+    private transient Object bundlesMapLock = new Object();
+
+    private volatile CacheType i18nCacheType = CacheType.WTLFU;
+    private volatile int i18nCacheMaxSize = 10000;
+
+    private <K, V> OgnlCache<K, V> buildI18nCache() {
+        return new DefaultOgnlCacheFactory<K, V>(i18nCacheMaxSize, i18nCacheType).buildOgnlCache();
+    }
+
+    // The OgnlCache implementations are themselves thread-safe; volatile only safely publishes the
+    // reference when rebuildI18nCaches() replaces a cache (during injection / readObject), so S3077
+    // ("volatile is not enough") does not apply here.
+    @SuppressWarnings("java:S3077")
+    protected transient volatile OgnlCache<String, ResourceBundle> bundlesMap = buildI18nCache();
+    @SuppressWarnings("java:S3077")
+    private transient volatile OgnlCache<MessageFormatKey, MessageFormat> messageFormats = buildI18nCache();
+    @SuppressWarnings("java:S3077")
+    private transient volatile OgnlCache<String, Boolean> missingBundles = buildI18nCache();
 
     /**
      * Adds the bundle to the internal list of default bundles.
@@ -97,6 +122,21 @@ abstract class AbstractLocalizedTextProvider implements LocalizedTextProvider {
 
     protected ClassLoader getCurrentThreadContextClassLoader() {
         return Thread.currentThread().getContextClassLoader();
+    }
+
+    /** Test-support accessor: current number of cached resource bundles. */
+    protected int bundlesMapSize() {
+        return bundlesMap.size();
+    }
+
+    /** Test-support accessor: current number of cached missing-bundle markers. */
+    protected int missingBundlesSize() {
+        return missingBundles.size();
+    }
+
+    /** Test-support accessor: current number of cached message formats. */
+    protected int messageFormatsSize() {
+        return messageFormats.size();
     }
 
     @Inject(value = StrutsConstants.STRUTS_CUSTOM_I18N_RESOURCES, required = false)
@@ -221,7 +261,7 @@ abstract class AbstractLocalizedTextProvider implements LocalizedTextProvider {
      * @param classLoader a {@link ClassLoader} to look up the bundle from if none can be found on the current thread's classloader
      */
     public void setDelegatedClassLoader(final ClassLoader classLoader) {
-        synchronized (bundlesMap) {
+        synchronized (bundlesMapLock) {
             delegatedClassLoaderMap.put(getCurrentThreadContextClassLoader().hashCode(), classLoader);
         }
     }
@@ -444,6 +484,44 @@ abstract class AbstractLocalizedTextProvider implements LocalizedTextProvider {
     }
 
     /**
+     * @param cacheType the type of cache to use for the localized-text caches
+     *
+     * @since 6.11.0
+     */
+    @Inject(value = StrutsConstants.STRUTS_I18N_CACHE_TYPE, required = false)
+    public void setI18nCacheType(String cacheType) {
+        this.i18nCacheType = EnumUtils.getEnumIgnoreCase(CacheType.class, cacheType, CacheType.WTLFU);
+        rebuildI18nCaches();
+    }
+
+    /**
+     * @param cacheMaxSize the maximum size of each localized-text cache
+     *
+     * @since 6.11.0
+     */
+    @Inject(value = StrutsConstants.STRUTS_I18N_CACHE_MAXSIZE, required = false)
+    public void setI18nCacheMaxSize(String cacheMaxSize) {
+        this.i18nCacheMaxSize = Integer.parseInt(cacheMaxSize);
+        rebuildI18nCaches();
+    }
+
+    /**
+     * Rebuilds the localized-text caches from the current type/size. Called during dependency injection
+     * (single-threaded startup, before the provider serves lookups); discards any warm-up entries.
+     */
+    private void rebuildI18nCaches() {
+        bundlesMap = buildI18nCache();
+        messageFormats = buildI18nCache();
+        missingBundles = buildI18nCache();
+    }
+
+    private void readObject(java.io.ObjectInputStream in) throws java.io.IOException, ClassNotFoundException {
+        in.defaultReadObject();
+        bundlesMapLock = new Object();
+        rebuildI18nCaches();
+    }
+
+    /**
      * Finds the given resource bundle by it's name.
      * <p>
      * Will use <code>Thread.currentThread().getContextClassLoader()</code> as the classloader.
@@ -458,34 +536,32 @@ abstract class AbstractLocalizedTextProvider implements LocalizedTextProvider {
         ClassLoader classLoader = getCurrentThreadContextClassLoader();
         String key = createMissesKey(String.valueOf(classLoader.hashCode()), aBundleName, locale);
 
-        if (missingBundles.contains(key)) {
+        if (missingBundles.get(key) != null) {
             return null;
         }
 
         ResourceBundle bundle = null;
         try {
-            if (bundlesMap.containsKey(key)) {
-                bundle = bundlesMap.get(key);
-            } else {
+            bundle = bundlesMap.get(key);
+            if (bundle == null) {
                 bundle = ResourceBundle.getBundle(aBundleName, locale, classLoader);
                 bundlesMap.putIfAbsent(key, bundle);
             }
         } catch (MissingResourceException ex) {
             if (delegatedClassLoaderMap.containsKey(classLoader.hashCode())) {
                 try {
-                    if (bundlesMap.containsKey(key)) {
-                        bundle = bundlesMap.get(key);
-                    } else {
+                    bundle = bundlesMap.get(key);
+                    if (bundle == null) {
                         bundle = ResourceBundle.getBundle(aBundleName, locale, delegatedClassLoaderMap.get(classLoader.hashCode()));
                         bundlesMap.putIfAbsent(key, bundle);
                     }
                 } catch (MissingResourceException e) {
                     LOG.debug("Missing resource bundle [{}]!", aBundleName, e);
-                    missingBundles.add(key);
+                    missingBundles.put(key, Boolean.TRUE);
                 }
             } else {
                 LOG.debug("Missing resource bundle [{}]!", aBundleName);
-                missingBundles.add(key);
+                missingBundles.put(key, Boolean.TRUE);
             }
         }
         return bundle;

--- a/core/src/main/java/com/opensymphony/xwork2/util/GlobalLocalizedTextProvider.java
+++ b/core/src/main/java/com/opensymphony/xwork2/util/GlobalLocalizedTextProvider.java
@@ -33,7 +33,8 @@ import java.util.ResourceBundle;
  */
 public class GlobalLocalizedTextProvider extends AbstractLocalizedTextProvider {
 
-    private static final long serialVersionUID = 1L;
+    // Pinned to the value implicitly computed for the pre-6.11.0 class shape, see AbstractLocalizedTextProvider.
+    private static final long serialVersionUID = 7569216885652454296L;
 
     private static final Logger LOG = LogManager.getLogger(GlobalLocalizedTextProvider.class);
 

--- a/core/src/main/java/com/opensymphony/xwork2/util/GlobalLocalizedTextProvider.java
+++ b/core/src/main/java/com/opensymphony/xwork2/util/GlobalLocalizedTextProvider.java
@@ -33,6 +33,8 @@ import java.util.ResourceBundle;
  */
 public class GlobalLocalizedTextProvider extends AbstractLocalizedTextProvider {
 
+    private static final long serialVersionUID = 1L;
+
     private static final Logger LOG = LogManager.getLogger(GlobalLocalizedTextProvider.class);
 
     public GlobalLocalizedTextProvider() {

--- a/core/src/main/java/com/opensymphony/xwork2/util/StrutsLocalizedTextProvider.java
+++ b/core/src/main/java/com/opensymphony/xwork2/util/StrutsLocalizedTextProvider.java
@@ -36,6 +36,8 @@ import java.util.ResourceBundle;
  */
 public class StrutsLocalizedTextProvider extends AbstractLocalizedTextProvider {
 
+    private static final long serialVersionUID = 1L;
+
     private static final Logger LOG = LogManager.getLogger(StrutsLocalizedTextProvider.class);
 
     /**

--- a/core/src/main/java/com/opensymphony/xwork2/util/StrutsLocalizedTextProvider.java
+++ b/core/src/main/java/com/opensymphony/xwork2/util/StrutsLocalizedTextProvider.java
@@ -36,7 +36,8 @@ import java.util.ResourceBundle;
  */
 public class StrutsLocalizedTextProvider extends AbstractLocalizedTextProvider {
 
-    private static final long serialVersionUID = 1L;
+    // Pinned to the value implicitly computed for the pre-6.11.0 class shape, see AbstractLocalizedTextProvider.
+    private static final long serialVersionUID = -4377984952850818176L;
 
     private static final Logger LOG = LogManager.getLogger(StrutsLocalizedTextProvider.class);
 

--- a/core/src/main/java/org/apache/struts2/StrutsConstants.java
+++ b/core/src/main/java/org/apache/struts2/StrutsConstants.java
@@ -289,6 +289,22 @@ public final class StrutsConstants {
     public static final String STRUTS_OGNL_BEANINFO_CACHE_FACTORY = "struts.ognl.beanInfoCacheFactory";
 
     /**
+     * Specifies the type of cache to use for the localized-text provider caches. Valid values defined in
+     * {@link com.opensymphony.xwork2.ognl.OgnlCacheFactory.CacheType}.
+     *
+     * @since 6.11.0
+     */
+    public static final String STRUTS_I18N_CACHE_TYPE = "struts.i18n.cacheType";
+
+    /**
+     * Specifies the maximum size of each localized-text provider cache. Configure based on the cache type
+     * chosen and application-specific needs.
+     *
+     * @since 6.11.0
+     */
+    public static final String STRUTS_I18N_CACHE_MAXSIZE = "struts.i18n.cacheMaxSize";
+
+    /**
      * Specifies the type of cache to use for BeanInfo objects.
      * @since 6.4.0
      * @see StrutsConstants#STRUTS_OGNL_EXPRESSION_CACHE_TYPE

--- a/core/src/main/java/org/apache/struts2/StrutsConstants.java
+++ b/core/src/main/java/org/apache/struts2/StrutsConstants.java
@@ -100,6 +100,14 @@ public final class StrutsConstants {
     /** The default locale for the Struts application */
     public static final String STRUTS_LOCALE = "struts.locale";
 
+    /**
+     * When enabled, request-derived locales (from {@code Accept-Language}, used when {@code struts.locale} is
+     * unset) are restricted to the JVM's available-locale set; unavailable values fall back to the default.
+     *
+     * @since 6.11.0
+     */
+    public static final String STRUTS_LOCALE_VALIDATE_REQUEST = "struts.locale.validateRequestLocale";
+
     /** Whether to use a Servlet request parameter workaround necessary for some versions of WebLogic */
     public static final String STRUTS_DISPATCHER_PARAMETERSWORKAROUND = "struts.dispatcher.parametersWorkaround";
 

--- a/core/src/main/java/org/apache/struts2/dispatcher/Dispatcher.java
+++ b/core/src/main/java/org/apache/struts2/dispatcher/Dispatcher.java
@@ -153,6 +153,11 @@ public class Dispatcher {
     private String defaultLocale;
 
     /**
+     * Store state of {@link StrutsConstants#STRUTS_LOCALE_VALIDATE_REQUEST} setting.
+     */
+    private boolean validateRequestLocale = false;
+
+    /**
      * Store state of StrutsConstants.STRUTS_MULTIPART_SAVEDIR setting.
      */
     private String multipartSaveDir;
@@ -309,6 +314,18 @@ public class Dispatcher {
     @Inject(value = StrutsConstants.STRUTS_LOCALE, required = false)
     public void setDefaultLocale(String val) {
         defaultLocale = val;
+    }
+
+    /**
+     * Modify state of {@link StrutsConstants#STRUTS_LOCALE_VALIDATE_REQUEST} setting.
+     *
+     * @param val New setting
+     *
+     * @since 6.11.0
+     */
+    @Inject(value = StrutsConstants.STRUTS_LOCALE_VALIDATE_REQUEST, required = false)
+    public void setValidateRequestLocale(String val) {
+        validateRequestLocale = Boolean.parseBoolean(val);
     }
 
     /**
@@ -950,7 +967,7 @@ public class Dispatcher {
                 locale = LocaleUtils.toLocale(defaultLocale);
             } catch (IllegalArgumentException e) {
                 try {
-                    locale = request.getLocale();
+                    locale = resolveRequestLocale(request);
                     LOG.warn(new ParameterizedMessage("Cannot convert 'struts.locale' = [{}] to proper locale, defaulting to request locale [{}]",
                                     defaultLocale, locale), e);
                 } catch (RuntimeException rex) {
@@ -961,13 +978,40 @@ public class Dispatcher {
             }
         } else {
             try {
-                locale = request.getLocale();
+                locale = resolveRequestLocale(request);
             } catch (RuntimeException rex) {
                 LOG.warn("Cannot get locale from HTTP Request, falling back to system default locale", rex);
                 locale = Locale.getDefault();
             }
         }
         return locale;
+    }
+
+    /**
+     * Resolves the request locale. When {@code struts.locale.validateRequestLocale} is enabled and the
+     * request locale is not part of the JVM's available-locale set, falls back to the configured
+     * {@code struts.locale} when set and parseable, otherwise the JVM default. When disabled (default),
+     * returns the request locale unchanged.
+     *
+     * @param request the current request
+     * @return the locale to use for this request
+     *
+     * @since 6.11.0
+     */
+    protected Locale resolveRequestLocale(HttpServletRequest request) {
+        Locale locale = request.getLocale();
+        if (!validateRequestLocale || LocaleUtils.isAvailableLocale(locale)) {
+            return locale;
+        }
+        if (defaultLocale != null) {
+            try {
+                return LocaleUtils.toLocale(defaultLocale);
+            } catch (IllegalArgumentException e) {
+                LOG.debug("Configured 'struts.locale' = [{}] is not parseable; falling back to system default", defaultLocale);
+            }
+        }
+        LOG.debug("Request locale [{}] is not available; falling back to system default locale", locale);
+        return Locale.getDefault();
     }
 
     /**

--- a/core/src/main/resources/org/apache/struts2/default.properties
+++ b/core/src/main/resources/org/apache/struts2/default.properties
@@ -24,6 +24,9 @@
 
 ### This can be used to set your default locale and encoding scheme
 # struts.locale=en_US
+### When true, restrict request-derived locales (Accept-Language, used when struts.locale is unset) to the
+### JVM's available-locale set; unavailable values fall back to the default locale. Defaults to false.
+struts.locale.validateRequestLocale=false
 struts.i18n.encoding=UTF-8
 
 ### if specified, the default object factory can be overridden here

--- a/core/src/main/resources/org/apache/struts2/default.properties
+++ b/core/src/main/resources/org/apache/struts2/default.properties
@@ -240,6 +240,13 @@ struts.ognl.expressionCacheType=wtlfu
 ### chosen and application-specific needs.
 struts.ognl.expressionCacheMaxSize=10000
 
+### Specifies the type of cache to use for the localized-text provider caches. See StrutsConstants for details.
+struts.i18n.cacheType=wtlfu
+
+### Specifies the maximum size of each localized-text provider cache. This should be configured based on the
+### cache type chosen and application-specific needs.
+struts.i18n.cacheMaxSize=10000
+
 ### Specifies the type of cache to use for BeanInfo objects. See StrutsConstants class for further information.
 struts.ognl.beanInfoCacheType=wtlfu
 

--- a/core/src/test/java/com/opensymphony/xwork2/ognl/OgnlCacheRemoveTest.java
+++ b/core/src/test/java/com/opensymphony/xwork2/ognl/OgnlCacheRemoveTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.opensymphony.xwork2.ognl;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class OgnlCacheRemoveTest {
+
+    private void assertRemoveContract(OgnlCache<String, String> cache) {
+        cache.put("k", "v");
+        assertEquals("v", cache.get("k"));
+        assertEquals("remove returns previous value", "v", cache.remove("k"));
+        assertNull("entry gone after remove", cache.get("k"));
+        assertNull("remove of absent key returns null", cache.remove("absent"));
+    }
+
+    @Test
+    public void caffeineCacheRemove() {
+        assertRemoveContract(new OgnlCaffeineCache<>(10, 16));
+    }
+
+    @Test
+    public void defaultCacheRemove() {
+        assertRemoveContract(new OgnlDefaultCache<>(10, 16, 0.75f));
+    }
+
+    @Test
+    public void lruCacheRemove() {
+        assertRemoveContract(new OgnlLRUCache<>(10, 16, 0.75f));
+    }
+}

--- a/core/src/test/java/com/opensymphony/xwork2/util/CacheFixture.java
+++ b/core/src/test/java/com/opensymphony/xwork2/util/CacheFixture.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.opensymphony.xwork2.util;
+
+/**
+ * Simple fixture whose class-associated bundle ({@code CacheFixture.properties}) backs the
+ * localized-text caching tests.
+ *
+ * @since 6.11.0
+ */
+public class CacheFixture {
+}

--- a/core/src/test/java/com/opensymphony/xwork2/util/StrutsLocalizedTextProviderTest.java
+++ b/core/src/test/java/com/opensymphony/xwork2/util/StrutsLocalizedTextProviderTest.java
@@ -38,6 +38,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.lang.reflect.Field;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.util.Date;
@@ -625,6 +626,38 @@ public class StrutsLocalizedTextProviderTest extends XWorkTestCase {
         StrutsLocalizedTextProvider deserialized = (StrutsLocalizedTextProvider) restored;
         // Caches were transient (null right after defaultReadObject) but readObject rebuilds them:
         assertEquals("Deserialized caches not rebuilt empty", 0, deserialized.bundlesMapSize());
+        String result = deserialized.findText(CacheFixture.class, "cache.static", Locale.ENGLISH, null, null, valueStack);
+        assertEquals("Static cached value", result);
+    }
+
+    /**
+     * A stream written before the i18n cache settings existed carries no value for them, and field
+     * initialisers do not run during deserialization, so they arrive as null/0. The provider must still
+     * come back usable rather than failing while rebuilding its caches.
+     */
+    public void testProviderIsUsableAfterDeserializingLegacyStream() throws Exception {
+        StrutsLocalizedTextProvider provider = new StrutsLocalizedTextProvider();
+        ValueStack valueStack = ActionContext.getContext().getValueStack();
+        provider.findText(CacheFixture.class, "cache.static", Locale.ENGLISH, null, null, valueStack);
+
+        // Simulate the absent-field state an older stream produces.
+        Field cacheType = AbstractLocalizedTextProvider.class.getDeclaredField("i18nCacheType");
+        cacheType.setAccessible(true);
+        cacheType.set(provider, null);
+        Field maxSize = AbstractLocalizedTextProvider.class.getDeclaredField("i18nCacheMaxSize");
+        maxSize.setAccessible(true);
+        maxSize.setInt(provider, 0);
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+            oos.writeObject(provider);
+        }
+        Object restored;
+        try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray()))) {
+            restored = ois.readObject();
+        }
+
+        StrutsLocalizedTextProvider deserialized = (StrutsLocalizedTextProvider) restored;
         String result = deserialized.findText(CacheFixture.class, "cache.static", Locale.ENGLISH, null, null, valueStack);
         assertEquals("Static cached value", result);
     }

--- a/core/src/test/java/com/opensymphony/xwork2/util/StrutsLocalizedTextProviderTest.java
+++ b/core/src/test/java/com/opensymphony/xwork2/util/StrutsLocalizedTextProviderTest.java
@@ -34,6 +34,10 @@ import com.opensymphony.xwork2.test.TestBean2;
 import org.apache.struts2.config.StrutsXmlConfigurationProvider;
 import org.apache.struts2.interceptor.parameter.StrutsParameter;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.util.Date;
@@ -561,6 +565,77 @@ public class StrutsLocalizedTextProviderTest extends XWorkTestCase {
         assertEquals("Result of bean.name lookup not as expected ?", "Haha you cant FindMe!", messageResult);
         messageResult = testStrutsLocalizedTextProvider.findText(bar.getClass(), "bean2.name", Locale.ENGLISH, null, paramArray, valueStack);
         assertEquals("Result of bean2.name lookup not as expected ?", "Okay! You found Me!", messageResult);
+    }
+
+    public void testCachesAreBoundedByConfiguredMaxSize() {
+        TestStrutsLocalizedTextProvider provider = new TestStrutsLocalizedTextProvider();
+        provider.setI18nCacheMaxSize("100");
+        ValueStack valueStack = ActionContext.getContext().getValueStack();
+
+        for (int i = 0; i < 20000; i++) {
+            Locale locale = Locale.forLanguageTag("en-US-x" + String.format("%05d", i));
+            provider.findText(CacheFixture.class, "cache.missing", locale, "Fallback", null, valueStack);
+        }
+
+        assertTrue("bundlesMap not bounded ?", provider.bundlesMapSize() <= 2000);
+        assertTrue("missingBundles not bounded ?", provider.missingBundlesSize() <= 2000);
+        assertTrue("messageFormats not bounded ?", provider.messageFormatsSize() <= 2000);
+    }
+
+    public void testCorrectTextStillReturnedUnderEviction() {
+        TestStrutsLocalizedTextProvider provider = new TestStrutsLocalizedTextProvider();
+        provider.setI18nCacheMaxSize("50");
+        ValueStack valueStack = ActionContext.getContext().getValueStack();
+
+        // Force heavy eviction with many distinct locales.
+        for (int i = 0; i < 5000; i++) {
+            Locale locale = Locale.forLanguageTag("en-US-x" + String.format("%05d", i));
+            provider.findText(CacheFixture.class, "cache.missing", locale, "Fallback", null, valueStack);
+        }
+
+        // A real key in a real locale still resolves correctly after eviction pressure.
+        String result = provider.findText(CacheFixture.class, "cache.static", Locale.ENGLISH, null, null, valueStack);
+        assertEquals("Static cached value", result);
+    }
+
+    public void testReloadClearsBoundedCaches() {
+        TestStrutsLocalizedTextProvider provider = new TestStrutsLocalizedTextProvider();
+        ValueStack valueStack = ActionContext.getContext().getValueStack();
+
+        provider.findText(CacheFixture.class, "cache.missing", Locale.ENGLISH, "Fallback", null, valueStack);
+        assertTrue("missingBundles not populated ?", provider.missingBundlesSize() > 0);
+
+        provider.callReloadBundlesForceReload();
+        assertEquals("reload did not clear bundlesMap ?", 0, provider.bundlesMapSize());
+    }
+
+    public void testProviderIsUsableAfterDeserialization() throws Exception {
+        StrutsLocalizedTextProvider provider = new StrutsLocalizedTextProvider();
+        ValueStack valueStack = ActionContext.getContext().getValueStack();
+        provider.findText(CacheFixture.class, "cache.static", Locale.ENGLISH, null, null, valueStack);
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+            oos.writeObject(provider);
+        }
+        Object restored;
+        try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray()))) {
+            restored = ois.readObject();
+        }
+        StrutsLocalizedTextProvider deserialized = (StrutsLocalizedTextProvider) restored;
+        // Caches were transient (null right after defaultReadObject) but readObject rebuilds them:
+        assertEquals("Deserialized caches not rebuilt empty", 0, deserialized.bundlesMapSize());
+        String result = deserialized.findText(CacheFixture.class, "cache.static", Locale.ENGLISH, null, null, valueStack);
+        assertEquals("Static cached value", result);
+    }
+
+    public void testCacheTypeSelectionKeepsProviderWorking() {
+        TestStrutsLocalizedTextProvider provider = new TestStrutsLocalizedTextProvider();
+        provider.setI18nCacheType("basic");
+        ValueStack valueStack = ActionContext.getContext().getValueStack();
+        String result = provider.findText(CacheFixture.class, "cache.static", Locale.ENGLISH, null, null, valueStack);
+        assertEquals("Static cached value", result);
+        assertTrue("bundlesMap should populate", provider.bundlesMapSize() >= 1);
     }
 
     @Override

--- a/core/src/test/java/org/apache/struts2/dispatcher/DispatcherTest.java
+++ b/core/src/test/java/org/apache/struts2/dispatcher/DispatcherTest.java
@@ -571,6 +571,46 @@ public class DispatcherTest extends StrutsJUnit4InternalTestCase {
     }
 
     @Test
+    public void testValidateRequestLocaleOffPassesThrough() {
+        initDispatcher(new HashMap<>());
+        dispatcher.setDefaultLocale(null);  // Force struts.locale unset; the test-config default would otherwise mask the request locale.
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        // A syntactically valid but not JVM-available locale.
+        Locale exotic = new Locale("en", "US", "xzz99");
+        when(request.getLocale()).thenReturn(exotic);
+
+        assertEquals("Default off must pass the request locale through unchanged",
+                exotic, dispatcher.getLocale(request));
+    }
+
+    @Test
+    public void testValidateRequestLocaleOnKeepsAvailableLocale() {
+        Map<String, String> params = new HashMap<>();
+        params.put(StrutsConstants.STRUTS_LOCALE_VALIDATE_REQUEST, "true");
+        initDispatcher(params);
+        dispatcher.setDefaultLocale(null);  // Force struts.locale unset; the test-config default would otherwise mask the request locale.
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getLocale()).thenReturn(Locale.UK);
+
+        assertEquals("Available request locale must be kept", Locale.UK, dispatcher.getLocale(request));
+    }
+
+    @Test
+    public void testValidateRequestLocaleOnFallsBackForUnavailableLocale() {
+        Map<String, String> params = new HashMap<>();
+        params.put(StrutsConstants.STRUTS_LOCALE_VALIDATE_REQUEST, "true");
+        initDispatcher(params);
+        dispatcher.setDefaultLocale(null);  // Force struts.locale unset; the test-config default would otherwise mask the request locale.
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        Locale exotic = new Locale("en", "US", "xzz99");
+        when(request.getLocale()).thenReturn(exotic);
+
+        // struts.locale unset in this dispatcher -> fall back to the JVM default.
+        assertEquals("Unavailable request locale must fall back to system default",
+                Locale.getDefault(), dispatcher.getLocale(request));
+    }
+
+    @Test
     public void dispatcherReinjectedAfterReload() {
         HttpServletRequest request = mock(HttpServletRequest.class);
         HttpServletResponse response = mock(HttpServletResponse.class);

--- a/core/src/test/resources/com/opensymphony/xwork2/util/CacheFixture.properties
+++ b/core/src/test/resources/com/opensymphony/xwork2/util/CacheFixture.properties
@@ -1,0 +1,19 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+cache.static=Static cached value


### PR DESCRIPTION
Fixes [WW-5668](https://issues.apache.org/jira/browse/WW-5668)

Backport of #1821 to the 6.x maintenance line, targeting 6.11.0. Two related, independent changes to the localized-text subsystem.

## 1. Bounded localized-text caches

`AbstractLocalizedTextProvider` kept its internal caches (`bundlesMap`, `messageFormats`, `missingBundles`) as plain `ConcurrentHashMap`s with no configurable upper bound or eviction. The rest of the framework already standardises on bounded caches via `OgnlCacheFactory` (`struts.ognl.expressionCacheMaxSize`, `struts.ognl.beanInfoCacheMaxSize`, both `wtlfu`); these were the outlier.

- Reuse the existing `OgnlCache` abstraction (`DefaultOgnlCacheFactory`) for all three caches, with configurable size and eviction.
- New constants `struts.i18n.cacheType` (default `wtlfu`) and `struts.i18n.cacheMaxSize` (default `10000`), documented in `default.properties`.
- Added `remove(key)` to `OgnlCache` (needed by `clearBundle`).
- Caches are `transient` and rebuilt in `readObject` so the provider stays serializable; a dedicated lock replaces synchronizing on the now-reassignable `bundlesMap`.

All three caches are pure/reconstructible, so eviction can only cause a recompute, never a wrong or stale localized result.

## 2. Consistent request-locale resolution (opt-in)

`I18nInterceptor` validates a resolved locale against the available-locale set (`LocaleProvider.isValidLocale`), but `Dispatcher.getLocale(...)` (used when `struts.locale` is unset) returns `request.getLocale()` directly without that check.

- New `struts.locale.validateRequestLocale` (default `false` — current behaviour preserved byte-for-byte). When enabled, `Dispatcher` resolves request-derived locales against the JVM available-locale set, falling back to the configured `struts.locale` (else the JVM default), consistent with `I18nInterceptor`.

## Differences from #1821

- 6.x has three of these caches, not five — `classHierarchyCache` / `packageHierarchyCache` were added by WW-5540, which is `main`-only.
- Classes live under `com.opensymphony.xwork2.*` (pre-XWork-merge layout), so this is a manual re-apply rather than a cherry-pick.
- `missingBundles` moves from `Set<String>` to `OgnlCache<String, Boolean>`, and the `bundlesMap.containsKey` double-checks become `get(key) != null`, since `OgnlCache` exposes neither.
- `CacheFixture` (test fixture + bundle) is added here; on `main` it arrived with WW-5540.

Note `AbstractLocalizedTextProvider` is package-private, so the type change on the `protected bundlesMap` field is not reachable outside `com.opensymphony.xwork2.util` and breaks no public API.

## Testing

- New tests: cache bound invariant, correctness under eviction, reload clears, serialize→deserialize→`findText`, cache-type selection, and the three `Dispatcher` flag states (off / on-available / on-fallback).
- Full `core` suite green: 2711 tests, 0 failures, 0 errors.

## Backward compatibility

- Part 1 changes internal cache implementations only; eviction is correctness-safe; defaults match existing cache conventions.
- Part 2 is fully opt-in and defaults off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
