### PR TITLE
WW-5668 Keep the localized-text providers deserializable across a version upgrade

### DIFF
--- a/core/src/main/java/org/apache/struts2/text/AbstractLocalizedTextProvider.java
+++ b/core/src/main/java/org/apache/struts2/text/AbstractLocalizedTextProvider.java
@@ -50,7 +50,10 @@ import java.util.concurrent.CopyOnWriteArrayList;
 
 abstract class AbstractLocalizedTextProvider implements LocalizedTextProvider {
 
-    private static final long serialVersionUID = 1L;
+    // Pinned to the value implicitly computed for the Struts 7.2.1 class shape, so sessions serialized by
+    // an older node still deserialize here during a rolling upgrade. The caches that became transient are
+    // simply discarded from such a stream and rebuilt by readObject.
+    private static final long serialVersionUID = -4455624669971032217L;
 
     private static final Logger LOG = LogManager.getLogger(AbstractLocalizedTextProvider.class);
 
@@ -77,8 +80,10 @@ abstract class AbstractLocalizedTextProvider implements LocalizedTextProvider {
     // transient + reinitialised in readObject: a bare Object is not Serializable.
     private transient Object bundlesMapLock = new Object();
 
+    private static final int DEFAULT_I18N_CACHE_MAX_SIZE = 10000;
+
     private volatile CacheType i18nCacheType = CacheType.WTLFU;
-    private volatile int i18nCacheMaxSize = 10000;
+    private volatile int i18nCacheMaxSize = DEFAULT_I18N_CACHE_MAX_SIZE;
 
     private <K, V> OgnlCache<K, V> buildI18nCache() {
         return new DefaultOgnlCacheFactory<K, V>(i18nCacheMaxSize, i18nCacheType).buildOgnlCache();
@@ -473,6 +478,14 @@ abstract class AbstractLocalizedTextProvider implements LocalizedTextProvider {
     private void readObject(java.io.ObjectInputStream in) throws java.io.IOException, ClassNotFoundException {
         in.defaultReadObject();
         bundlesMapLock = new Object();
+        // Field initialisers do not run during deserialization, so a stream written before these settings
+        // existed (an older node in a rolling upgrade) leaves them at null/0. Restore the defaults.
+        if (i18nCacheType == null) {
+            i18nCacheType = CacheType.WTLFU;
+        }
+        if (i18nCacheMaxSize <= 0) {
+            i18nCacheMaxSize = DEFAULT_I18N_CACHE_MAX_SIZE;
+        }
         rebuildI18nCaches();
     }
 

--- a/core/src/main/java/org/apache/struts2/text/GlobalLocalizedTextProvider.java
+++ b/core/src/main/java/org/apache/struts2/text/GlobalLocalizedTextProvider.java
@@ -34,7 +34,8 @@ import java.util.ResourceBundle;
  */
 public class GlobalLocalizedTextProvider extends AbstractLocalizedTextProvider {
 
-    private static final long serialVersionUID = 1L;
+    // Pinned to the value implicitly computed for the Struts 7.2.1 class shape, see AbstractLocalizedTextProvider.
+    private static final long serialVersionUID = 3777960740495792359L;
 
     private static final Logger LOG = LogManager.getLogger(GlobalLocalizedTextProvider.class);
 

--- a/core/src/main/java/org/apache/struts2/text/StrutsLocalizedTextProvider.java
+++ b/core/src/main/java/org/apache/struts2/text/StrutsLocalizedTextProvider.java
@@ -38,7 +38,8 @@ import java.util.ResourceBundle;
  */
 public class StrutsLocalizedTextProvider extends AbstractLocalizedTextProvider {
 
-    private static final long serialVersionUID = 1L;
+    // Pinned to the value implicitly computed for the Struts 7.2.1 class shape, see AbstractLocalizedTextProvider.
+    private static final long serialVersionUID = 1939638936989370989L;
 
     private static final Logger LOG = LogManager.getLogger(StrutsLocalizedTextProvider.class);
     private transient ReflectionProvider reflectionProvider;

--- a/core/src/test/java/org/apache/struts2/text/StrutsLocalizedTextProviderTest.java
+++ b/core/src/test/java/org/apache/struts2/text/StrutsLocalizedTextProviderTest.java
@@ -812,6 +812,38 @@ public class StrutsLocalizedTextProviderTest extends XWorkTestCase {
         assertEquals("Static cached value", result);
     }
 
+    /**
+     * A stream written before the i18n cache settings existed carries no value for them, and field
+     * initialisers do not run during deserialization, so they arrive as null/0. The provider must still
+     * come back usable rather than failing while rebuilding its caches.
+     */
+    public void testProviderIsUsableAfterDeserializingLegacyStream() throws Exception {
+        TestStrutsLocalizedTextProvider provider = new TestStrutsLocalizedTextProvider();
+        ValueStack valueStack = ActionContext.getContext().getValueStack();
+        provider.findText(CacheFixture.class, "cache.static", Locale.ENGLISH, null, null, valueStack);
+
+        // Simulate the absent-field state an older stream produces.
+        java.lang.reflect.Field cacheType = AbstractLocalizedTextProvider.class.getDeclaredField("i18nCacheType");
+        cacheType.setAccessible(true);
+        cacheType.set(provider, null);
+        java.lang.reflect.Field maxSize = AbstractLocalizedTextProvider.class.getDeclaredField("i18nCacheMaxSize");
+        maxSize.setAccessible(true);
+        maxSize.setInt(provider, 0);
+
+        java.io.ByteArrayOutputStream baos = new java.io.ByteArrayOutputStream();
+        try (java.io.ObjectOutputStream oos = new java.io.ObjectOutputStream(baos)) {
+            oos.writeObject(provider);
+        }
+        Object restored;
+        try (java.io.ObjectInputStream ois = new java.io.ObjectInputStream(new java.io.ByteArrayInputStream(baos.toByteArray()))) {
+            restored = ois.readObject();
+        }
+
+        TestStrutsLocalizedTextProvider deserialized = (TestStrutsLocalizedTextProvider) restored;
+        String result = deserialized.findText(CacheFixture.class, "cache.static", Locale.ENGLISH, null, null, valueStack);
+        assertEquals("Static cached value", result);
+    }
+
     public void testCacheTypeSelectionKeepsProviderWorking() {
         TestStrutsLocalizedTextProvider provider = new TestStrutsLocalizedTextProvider();
         provider.setI18nCacheType("basic");


### PR DESCRIPTION
Fixes [WW-5668](https://issues.apache.org/jira/browse/WW-5668)

Follow-up to #1821, which is already merged. Two defects in the serialization handling that change shipped, both only observable when deserializing a stream written by an **earlier** release — which is exactly what a rolling upgrade does.

## 1. `serialVersionUID = 1L` breaks upgrades from 7.2.1

The localized-text providers are reachable from the `ValueStack` and really are serialized — that is why #1821 had to make the caches `transient` in the first place. Where a session is replicated or persisted, a 7.2.1 node's stream can be read by a 7.3.0 node.

7.2.1 declared no explicit `serialVersionUID`, so its streams carry the value the JVM computed from that class shape. Pinning `1L` does not match it, and deserialization fails:

```
java.io.InvalidClassException: org.apache.struts2.text.AbstractLocalizedTextProvider;
  local class incompatible: stream classdesc serialVersionUID = -4455624669971032217,
  local class serialVersionUID = 1
```

This pins each provider to the value `serialver` reports for the `STRUTS_7_2_1` tag instead:

| Class | Value |
| ----- | ----- |
| `AbstractLocalizedTextProvider` | `-4455624669971032217L` |
| `StrutsLocalizedTextProvider` | `1939638936989370989L` |
| `GlobalLocalizedTextProvider` | `3777960740495792359L` |

Accepting the older stream is safe precisely *because* #1821 made the caches `transient`: the stream's stale cache contents no longer match a field in the class, so they are discarded, and `readObject` rebuilds the caches empty.

## 2. `readObject` throws NPE on a stream without the new cache settings

`i18nCacheType` and `i18nCacheMaxSize` are non-transient fields with initialisers. Field initialisers do not run during deserialization, and a 7.2.1 stream carries no value for them, so `defaultReadObject` leaves them `null`/`0` and `rebuildI18nCaches()` fails:

```
java.lang.NullPointerException: Cannot invoke "CacheType.ordinal()" because "cacheType" is null
  at AbstractLocalizedTextProvider.rebuildI18nCaches(...)
  at AbstractLocalizedTextProvider.readObject(...)
```

On merged `main` this is masked by the `InvalidClassException` above, so fixing only item 1 would have exposed it. `readObject` now restores the defaults before rebuilding.

The existing `testProviderIsUsableAfterDeserialization` could not catch this: it round-trips a stream written by the *current* class, which does carry both fields.

## Testing

- New `testProviderIsUsableAfterDeserializingLegacyStream` reproduces the absent-field state and fails with the exact NPE above when the guard is removed.
- Verified end to end outside the suite: a provider serialized against a build of the `STRUTS_7_2_1` tag now deserializes cleanly against this branch, and fails with the `InvalidClassException` above against `main` as merged.
- Full `core` suite green: 3149 tests, 0 failures, 0 errors.

## Backward compatibility

Restores compatibility that #1821 removed. No API or behavioural change; a same-version round trip is unaffected, since both settings are still serialized normally.

The equivalent fix for the 6.x line is in #1823.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
