### PR TITLE
WW-5656 Mark ConversionRule.COLLECTION and the Collection_ prefix as @Deprecated

### DIFF
--- a/core/src/main/java/org/apache/struts2/conversion/annotations/ConversionRule.java
+++ b/core/src/main/java/org/apache/struts2/conversion/annotations/ConversionRule.java
@@ -28,7 +28,17 @@ import org.apache.struts2.conversion.impl.DefaultObjectTypeDeterminer;
  */
 public enum ConversionRule {
 
-    PROPERTY, COLLECTION, MAP, KEY, KEY_PROPERTY, ELEMENT, CREATE_IF_NULL;
+    PROPERTY,
+
+    /**
+     * @deprecated since 7.3.0, use {@link #ELEMENT} instead. The {@code Collection_xxx} key format has
+     * been superseded by {@code Element_xxx} since WebWork 2.1.x; both are handled identically by the
+     * engine, and {@code Element_xxx} additionally covers the values of a {@code Map}.
+     */
+    @Deprecated(since = "7.3.0")
+    COLLECTION,
+
+    MAP, KEY, KEY_PROPERTY, ELEMENT, CREATE_IF_NULL;
 
     /**
      * The prefix a conversion mapping key carries for this rule, as read back by
@@ -43,6 +53,9 @@ public enum ConversionRule {
      * @return the mapping key prefix, never null; an empty string when the rule has none
      * @since 7.3.0
      */
+    // the switch is deliberately exhaustive with no default, so the deprecated COLLECTION arm - and
+    // with it the reference to the deprecated prefix constant - cannot be dropped
+    @SuppressWarnings("deprecation")
     public String prefix() {
         return switch (this) {
             case COLLECTION -> DefaultObjectTypeDeterminer.DEPRECATED_ELEMENT_PREFIX;

--- a/core/src/main/java/org/apache/struts2/conversion/annotations/TypeConversion.java
+++ b/core/src/main/java/org/apache/struts2/conversion/annotations/TypeConversion.java
@@ -141,7 +141,7 @@ import java.lang.annotation.Target;
  *   &#64;TypeConversion(rule = ConversionRule.CREATE_IF_NULL, value = "true")
  *   private List users = null;
  *
- *   &#64;TypeConversion(rule = ConversionRule.COLLECTION, converterClass = String.class)
+ *   &#64;TypeConversion(rule = ConversionRule.ELEMENT, converterClass = String.class)
  *   public void setUsers( List users ) {
  *       this.users = users;
  *   }
@@ -196,7 +196,8 @@ public @interface TypeConversion {
     ConversionType type() default ConversionType.CLASS;
 
     /**
-     * The ConversionRule can be a PROPERTY, KEY, KEY_PROPERTY, ELEMENT, COLLECTION (deprecated) or a MAP.
+     * The ConversionRule can be a PROPERTY, KEY, KEY_PROPERTY, ELEMENT, CREATE_IF_NULL or a MAP.
+     * {@link ConversionRule#COLLECTION} is also accepted, but deprecated - use ELEMENT instead.
      * Note: Collection and Map conversion rules can be determined via org.apache.struts2.conversion.impl.DefaultObjectTypeDeterminer.
      *
      * @see DefaultObjectTypeDeterminer

--- a/core/src/main/java/org/apache/struts2/conversion/impl/DefaultConversionAnnotationProcessor.java
+++ b/core/src/main/java/org/apache/struts2/conversion/impl/DefaultConversionAnnotationProcessor.java
@@ -53,6 +53,9 @@ public class DefaultConversionAnnotationProcessor implements ConversionAnnotatio
         this.converterHolder = converterHolder;
     }
 
+    // ConversionRule.COLLECTION is referenced deliberately: it remains a legal value on @TypeConversion
+    // and has to keep being treated exactly like ELEMENT.
+    @SuppressWarnings("deprecation")
     public void process(Map<String, Object> mapping, TypeConversion tc, String key) {
         LOG.debug("TypeConversion [{}/{}] with key: [{}]", tc.converter(), tc.converterClass(), key);
         if (key == null) {

--- a/core/src/main/java/org/apache/struts2/conversion/impl/DefaultConversionFileProcessor.java
+++ b/core/src/main/java/org/apache/struts2/conversion/impl/DefaultConversionFileProcessor.java
@@ -52,6 +52,9 @@ public class DefaultConversionFileProcessor implements ConversionFileProcessor {
         this.converterCreator = converterCreator;
     }
 
+    // DEPRECATED_ELEMENT_PREFIX is referenced deliberately: existing -conversion.properties files may
+    // still spell Collection_xxx, and those keys must keep being recognised as element metadata.
+    @SuppressWarnings("deprecation")
     public void process(Map<String, Object> mapping, Class clazz, String converterFilename) {
         try {
             InputStream is = fileManager.loadFile(ClassLoaderUtil.getResource(converterFilename, clazz));

--- a/core/src/main/java/org/apache/struts2/conversion/impl/DefaultObjectTypeDeterminer.java
+++ b/core/src/main/java/org/apache/struts2/conversion/impl/DefaultObjectTypeDeterminer.java
@@ -62,6 +62,13 @@ public class DefaultObjectTypeDeterminer implements ObjectTypeDeterminer {
     public static final String ELEMENT_PREFIX = "Element_";
     public static final String KEY_PROPERTY_PREFIX = "KeyProperty_";
     public static final String CREATE_IF_NULL_PREFIX = "CreateIfNull_";
+    /**
+     * @deprecated since 7.3.0, use {@link #ELEMENT_PREFIX} instead. The {@code Collection_xxx} key
+     * format has been superseded by {@code Element_xxx} since WebWork 2.1.x. Existing
+     * {@code -conversion.properties} files keep working: {@link #getElementClass(Class, String, Object)}
+     * still falls back to this prefix.
+     */
+    @Deprecated(since = "7.3.0")
     public static final String DEPRECATED_ELEMENT_PREFIX = "Collection_";
 
     private final ReflectionProvider reflectionProvider;

--- a/core/src/main/java/org/apache/struts2/conversion/impl/XWorkConverter.java
+++ b/core/src/main/java/org/apache/struts2/conversion/impl/XWorkConverter.java
@@ -152,6 +152,12 @@ public class XWorkConverter extends DefaultTypeConverter {
     public static final String REPORT_CONVERSION_ERRORS = "report.conversion.errors";
     public static final String CONVERSION_PROPERTY_FULLNAME = "conversion.property.fullName";
     public static final String CONVERSION_ERROR_PROPERTY_PREFIX = "invalid.fieldvalue.";
+    /**
+     * @deprecated since 7.3.0, use {@link DefaultObjectTypeDeterminer#ELEMENT_PREFIX} instead. A second
+     * public spelling of the same deprecated {@code Collection_} prefix as
+     * {@link DefaultObjectTypeDeterminer#DEPRECATED_ELEMENT_PREFIX}, unused by the framework itself.
+     */
+    @Deprecated(since = "7.3.0")
     public static final String CONVERSION_COLLECTION_PREFIX = "Collection_";
 
     public static final String LAST_BEAN_CLASS_ACCESSED = "last.bean.accessed";

--- a/core/src/test/java/org/apache/struts2/conversion/ConversionTestAction.java
+++ b/core/src/test/java/org/apache/struts2/conversion/ConversionTestAction.java
@@ -71,6 +71,8 @@ public class ConversionTestAction implements Action {
         return users;
     }
 
+    // deliberately declares the deprecated COLLECTION rule, to keep the Collection_ fallback covered
+    @SuppressWarnings("deprecation")
     @TypeConversion(rule = ConversionRule.COLLECTION, converterClass = String.class)
     public void setUsers( List users ) {
         this.users = users;

--- a/core/src/test/java/org/apache/struts2/conversion/annotations/ConversionRuleTest.java
+++ b/core/src/test/java/org/apache/struts2/conversion/annotations/ConversionRuleTest.java
@@ -24,6 +24,8 @@ import static org.junit.Assert.assertEquals;
 
 public class ConversionRuleTest {
 
+    // COLLECTION is deprecated but must keep deriving Collection_ for existing annotations
+    @SuppressWarnings("deprecation")
     @Test
     public void prefixIsDefinedForEveryRule() {
         assertEquals("", ConversionRule.PROPERTY.prefix());

--- a/core/src/test/java/org/apache/struts2/conversion/impl/XWorkConverterTest.java
+++ b/core/src/test/java/org/apache/struts2/conversion/impl/XWorkConverterTest.java
@@ -836,6 +836,7 @@ public class XWorkConverterTest extends XWorkTestCase {
                 XWorkConverter.resolveKey(ConversionType.CLASS, ConversionRule.CREATE_IF_NULL, "users"));
     }
 
+    @SuppressWarnings("deprecation")
     public void testResolveKeyLeavesAnAlreadyPrefixedKeyAlone() {
         assertEquals("KeyProperty_annotatedBeanMap",
                 XWorkConverter.resolveKey(ConversionType.CLASS, ConversionRule.KEY_PROPERTY, "KeyProperty_annotatedBeanMap"));

--- a/core/src/test/java/org/apache/struts2/test/AnnotationUser.java
+++ b/core/src/test/java/org/apache/struts2/test/AnnotationUser.java
@@ -83,6 +83,8 @@ public class AnnotationUser implements AnnotationUserMarker {
         list = l;
     }
 
+    // deliberately declares the deprecated COLLECTION rule, to keep the Collection_ fallback covered
+    @SuppressWarnings("deprecation")
     @KeyProperty(value = "name")
     @TypeConversion(converterClass = String.class, rule = ConversionRule.COLLECTION)
     public List getList() {


### PR DESCRIPTION
Fixes [WW-5656](https://issues.apache.org/jira/browse/WW-5656)

`ConversionRule.COLLECTION` and `DefaultObjectTypeDeterminer.DEPRECATED_ELEMENT_PREFIX` (`"Collection_"`) have been documented as deprecated since WebWork 2.1.x, but neither carried an actual `@Deprecated` annotation. Users got no compile-time signal — only prose in Javadoc and an `INFO` log line that fires solely when the fallback is actually hit.

`Collection_` and `Element_` express the same thing: the element type inside a collection. `Element_` additionally covers the **values** of a `Map`, which is why WebWork 2.1 introduced it as the single name for both cases and kept `Collection_` working as a fallback.

## Changes

| Item | Change |
|---|---|
| `ConversionRule.COLLECTION` | `@Deprecated(since = "7.3.0")` + `@deprecated` Javadoc pointing at `ELEMENT` |
| `DefaultObjectTypeDeterminer.DEPRECATED_ELEMENT_PREFIX` | same treatment, pointing at `ELEMENT_PREFIX` |
| `XWorkConverter.CONVERSION_COLLECTION_PREFIX` | same treatment — see note below |
| `TypeConversion` Javadoc | example switched from `ConversionRule.COLLECTION` to `ELEMENT`, and `rule()` reworded |
| Deliberate call sites | `@SuppressWarnings("deprecation")` with a comment explaining why the reference stays |
| Runtime behaviour | **unchanged** — the `Collection_` fallback keeps working |

`ConversionRule.prefix()` needs its suppression because the switch is deliberately exhaustive with no `default`, so the `COLLECTION` arm cannot be dropped without a compile error. The two test fixtures (`AnnotationUser`, `ConversionTestAction`) keep declaring `rule = COLLECTION` on purpose, so the fallback stays covered.

## Beyond the ticket's scope

`XWorkConverter.CONVERSION_COLLECTION_PREFIX` was not listed in the ticket. It is a public constant holding the same `"Collection_"` literal, with no readers anywhere in the tree. Leaving it unannotated would mean one public spelling of the prefix still gives users no signal, so it is deprecated here too — happy to drop it from this PR if you would rather keep the change strictly to the ticket's table.

## Follow-up

The removal is tracked as [WW-5673](https://issues.apache.org/jira/browse/WW-5673), targeting **8.0.0**. It also carries the open decision on whether that removal covers the `Collection_` **properties-file** fallback, which is a larger and independent call from dropping the Java constants.

`forRemoval` is deliberately **not** set: removing the enum constant is source-breaking for applications and belongs in a major release.

## Testing

Full `core` suite: 3149 tests, 0 failures. Compiled with `-Xlint:deprecation` to confirm the suppression set is exactly right and no new warnings leak into the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
