### PR TITLE
docs: hand over a paste-ready body in creating-release-vote-mail

### DIFF
--- a/.claude/skills/creating-release-vote-mail/SKILL.md
+++ b/.claude/skills/creating-release-vote-mail/SKILL.md
@@ -79,7 +79,8 @@ Subject is exactly `[VOTE] Apache Struts X.Y.Z`.
 
 ## Draft it, do not send it
 
-Create a Gmail draft with To, Bcc, Subject and body set. **Never send.**
+Create a Gmail draft with To, Bcc, Subject and body set, and write the same body to a file whose
+path you hand over. **Never send.**
 
 | Rationalization | Reality |
 |---|---|
@@ -90,6 +91,26 @@ Create a Gmail draft with To, Bcc, Subject and body set. **Never send.**
 
 Sending opens a binding vote on a permanently archived public list and commits the PMC to the
 artifacts as staged.
+
+### Gmail mangles the links — hand over a paste-ready body
+
+Gmail's linkifier rewrites URLs server-side as the draft is stored, so the four link lines
+arrive as `https://www.google.com/url?q=...&source=gmail&ust=...` and the 72-column wrap is
+reflowed. There is no way to pass the body through the Gmail tool that avoids it:
+
+| Body passed as | Result |
+|---|---|
+| `body` only | Wrapped hrefs; plain rendering shows `bare-url <google.com/url?q=…>` |
+| `htmlBody` only | No plain-text part at all — HTML-only mail, wrong for an ASF list |
+| both | Worst: the plain part's *visible* text becomes the wrapped URL |
+
+`body` only is the least-bad, and is what to use. **Also write the exact body to a file and
+give the release manager its path.** Pasting plain text over the compose window restores both
+the bare URLs and the wrap, making the fix one select-all-paste instead of four hand-edited
+URLs.
+
+**Never re-run the draft-update tool on a draft whose links have already been fixed by hand** —
+it re-mangles them. A draft the release manager has corrected is finished; leave it alone.
 
 ## The boilerplate is frozen
 
@@ -123,6 +144,7 @@ A vote opened on a 404 burns the window before anyone can test.
 - A new paragraph inserted into the vote boilerplate
 - A quality checkbox arriving pre-ticked
 - An opening sentence carried over from the previous release
+- Re-running the draft-update tool on a draft whose links were already fixed by hand
 
 ## Common Mistakes
 

--- a/.claude/skills/creating-release-vote-mail/vote-mail-template.md
+++ b/.claude/skills/creating-release-vote-mail/vote-mail-template.md
@@ -114,7 +114,9 @@ On behalf of the Apache Struts project
 ```
 
 Hard-wrap the body at 72 columns, continuation lines unindented, so the list stays legible in
-the ASF archives and in quoted replies.
+the ASF archives and in quoted replies. Gmail reflows the wrap and rewrites the link lines when
+it stores the draft — see *Gmail mangles the links* in [`SKILL.md`](SKILL.md) for why the body
+also has to be handed over as a file.
 
 ## Frozen text
 
@@ -143,3 +145,5 @@ repository does not.
 - [ ] All four checkboxes empty
 - [ ] No severity, CVE, S2-XXX, bulletin link or reporter detail anywhere
 - [ ] Exactly one mail
+- [ ] Body also saved to a file and its path handed over, so the mangled links and wrap can be
+      fixed with one paste


### PR DESCRIPTION
Follow-up from the 6.11.0 vote drafting run.

## Problem

Gmail's linkifier rewrites URLs server-side as the draft is stored. The four link lines in the 6.11.0 vote draft came out as:

```
* https://www.google.com/url?q=https://dist.apache.org/repos/dist/dev/struts/6.11.0/&source=gmail&ust=1786257641041000&sa=E
```

and the 72-column hard wrap was reflowed. The release manager had to hand-edit all four URLs.

## What was tested

All three ways of passing the body through the Gmail tool are rewritten — there is no argument combination that avoids it:

| Body passed as | Result |
|---|---|
| `body` only | Wrapped hrefs; plain rendering shows `bare-url <google.com/url?q=…>` |
| `htmlBody` only | No plain-text part at all — HTML-only mail, wrong for an ASF list |
| both | Worst: the plain part's *visible* text becomes the wrapped URL |

`body` only — what the skill already produced — is the least-bad of the three.

## Change

Since the mangling can't be prevented, the fix is made structural rather than left as advice:

- The skill now produces the draft **and** a file containing the exact body, so the correction is one select-all-paste in the compose window instead of four hand-edited URLs. Pasting plain text restores both the bare URLs and the wrap.
- Added to the `Draft it, do not send it` instruction, the pre-draft checklist, and the template's hard-wrap note, so it sits in the steps already being followed rather than only in prose.
- Added a red flag for re-running the draft-update tool on a draft whose links were already fixed by hand — that re-mangles them.

Docs/process only; no ticket, consistent with #1826, #1828 and #1836.

🤖 Generated with [Claude Code](https://claude.com/claude-code)