### PR TITLE
build(ci): stop .claude-only changes from triggering full builds

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,7 +21,13 @@ on:
       - 'main'
       - 'release/*'
       - 'support/*'
+    paths-ignore:
+      - '.claude/**'
+  # Safe to filter by path here: no check from this workflow is required in
+  # .asf.yaml, so a run that never happens blocks nothing.
   pull_request:
+    paths-ignore:
+      - '.claude/**'
 
 permissions:
   # Needed to upload the results to code-scanning dashboard.

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -16,6 +16,11 @@
 name: Java Maven
 
 on:
+  # Deliberately NOT filtered by path. "Build and Test (JDK 17)" is a required
+  # status check in .asf.yaml, and a workflow skipped by path filtering never
+  # reports its checks - they stay Pending and the pull request can never be
+  # merged. The build job is skipped by condition instead (see `changes` below),
+  # which does report, as "skipped", and satisfies the requirement.
   pull_request:
   push:
     branches:
@@ -23,6 +28,8 @@ on:
       - 'develop'
       - 'release/*'
       - 'support/*'
+    paths-ignore:
+      - '.claude/**'
   workflow_dispatch:
   workflow_call:
 
@@ -33,8 +40,44 @@ env:
   LANG: en_US.utf8
 
 jobs:
+  changes:
+    name: Detect changes outside .claude
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - name: Check which paths the pull request touches
+        id: filter
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -eu
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "Not a pull request - building."
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          files=$(gh api --paginate \
+            "repos/${{ github.repository }}/pulls/${{ github.event.number }}/files" \
+            --jq '.[].filename')
+          echo "Changed files:"
+          printf '%s\n' "$files"
+          # Anything outside .claude/ means a real build is needed; an empty
+          # diff, or one confined to .claude/, does not. Tested by emptiness
+          # rather than with `grep -qv`, whose exit status is not reliable
+          # across grep implementations.
+          outside=$(printf '%s\n' "$files" | grep -vE '^(\.claude/|$)' || true)
+          if [ -n "$outside" ]; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Only .claude/ changed - skipping the build."
+            echo "code=false" >> "$GITHUB_OUTPUT"
+          fi
+
   build:
     name: Build and Test (JDK ${{ matrix.java }})${{ matrix.profile == '-Pjakartaee11' && ' (Jakarta EE 11 + Spring 7)' || matrix.profile }}
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/owasp.yml
+++ b/.github/workflows/owasp.yml
@@ -16,13 +16,19 @@
 name: OWASP checkup
 
 on:
+  # Safe to filter by path here: no check from this workflow is required in
+  # .asf.yaml, so a run that never happens blocks nothing.
   pull_request:
+    paths-ignore:
+      - '.claude/**'
   push:
     branches:
       - 'main'
       - 'develop'
       - 'release/*'
       - 'support/*'
+    paths-ignore:
+      - '.claude/**'
   workflow_dispatch: #Allow manual triggers
 
 permissions: read-all

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -16,10 +16,16 @@
 name: SonarCloud
 
 on:
+  # Safe to filter by path here: no check from this workflow is required in
+  # .asf.yaml, so a run that never happens blocks nothing.
   pull_request:
+    paths-ignore:
+      - '.claude/**'
   push:
     branches:
       - 'main'
+    paths-ignore:
+      - '.claude/**'
 
 permissions: read-all
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,9 +41,37 @@ pipeline {
             cleanWs deleteDirs: true, patterns: [[pattern: '**/target/**', type: 'INCLUDE']]
           }
         }
+        stage('Detect changes') {
+          steps {
+            script {
+              // Skip the build when a push only touched .claude/ - agent
+              // instructions, not code. Fails open: anything unexpected (no
+              // previous successful build, an unreachable commit, a git error)
+              // reports true and the build runs as before.
+              env.CODE_CHANGED = sh(returnStdout: true, script: '''
+                set -u
+                base="${GIT_PREVIOUS_SUCCESSFUL_COMMIT:-}"
+                if [ -z "$base" ] || ! git cat-file -e "${base}^{commit}" 2>/dev/null; then
+                  echo true
+                  exit 0
+                fi
+                outside=$(git diff --name-only "$base" HEAD | grep -vE '^(\\.claude/|$)' || true)
+                if [ -n "$outside" ]; then
+                  echo true
+                else
+                  echo false
+                fi
+              ''').trim()
+              echo "Changes outside .claude/: ${env.CODE_CHANGED}"
+            }
+          }
+        }
       }
     }
     stage('JDK 21') {
+      when {
+        expression { env.CODE_CHANGED != 'false' }
+      }
       agent {
         label 'ubuntu'
       }
@@ -74,6 +102,9 @@ pipeline {
       }
     }
     stage('JDK 17') {
+      when {
+        expression { env.CODE_CHANGED != 'false' }
+      }
       agent {
         label 'ubuntu'
       }


### PR DESCRIPTION
Editing an agent skill under `.claude/` rebuilt the whole project on GitHub Actions and Jenkins. No code changed, so every one of those runs was wasted.

### The trap this has to avoid

`.asf.yaml` makes **`Build and Test (JDK 17)`** a required status check on `main` (and `Build and Test (8)` on `support/struts-6-x-x`). GitHub documents that a workflow skipped by path filtering never reports its checks — they stay *Pending*, and "a pull request that requires those checks to be successful will be blocked from merging."

So a plain `paths-ignore` on `maven.yml`'s `pull_request` trigger would make every docs-only PR permanently unmergeable. A job skipped by an `if:` condition is different: it does report, as `skipped`, and required checks accept "`successful`, `skipped`, or `neutral`".

### What changed

| File | Approach |
|---|---|
| `codeql.yml`, `owasp.yml`, `sonar.yml` | `paths-ignore` on both `push` and `pull_request` — none of their checks are required, so a run that never happens blocks nothing |
| `maven.yml` | `paths-ignore` on `push` only; on `pull_request` a small `changes` job reads the PR's file list and the build job carries `if: needs.changes.outputs.code == 'true'` |
| `Jenkinsfile` | `pollSCM` can't be path-filtered, so the two JDK stages are guarded by a `Detect changes` stage instead |

Jenkins detection **fails open**: no previous successful commit, an unreachable commit, or any git error reports `true` and the build runs exactly as before.

### One thing worth knowing

The filter tests for a non-empty list of files outside `.claude/` rather than using `grep -qv`. While testing I hit **ugrep 7.5.0** (installed locally as `grep`) returning 1 from `-qv` on input where `-cv` counts 1 and `-v` prints the line — which silently inverts the decision and would have skipped builds for real code changes. GNU grep on the runners wouldn't do that, but testing emptiness behaves the same everywhere.

Exercised against six inputs: `.claude/`-only (skip), mixed `.claude/` + code (**build**), empty (skip), `.claudefoo/` (build — must not be treated as `.claude/`), code-only (build), nested `.claude/.../scripts/*.sh` (skip).

### Not verified yet

This PR itself touches `.github/` and `Jenkinsfile`, so it exercises the *build* path, not the skip path. The skip path is first proven by the next `.claude/`-only PR — #1844 is one, once this merges. If the required check somehow fails to report there, the fallback is to drop the `if:` from `maven.yml` and keep the `push` filter.

Only the 7.x line is changed here; `support/struts-6-x-x` needs the same edit on its own branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)