### PR TITLE
build(ci): report the required check when only .claude/ changed

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -19,8 +19,8 @@ on:
   # Deliberately NOT filtered by path. "Build and Test (JDK 17)" is a required
   # status check in .asf.yaml, and a workflow skipped by path filtering never
   # reports its checks - they stay Pending and the pull request can never be
-  # merged. The build job is skipped by condition instead (see `changes` below),
-  # which does report, as "skipped", and satisfies the requirement.
+  # merged. The build job always runs instead, and its steps are skipped by
+  # condition when only .claude/ changed (see `changes` below).
   pull_request:
   push:
     branches:
@@ -77,7 +77,12 @@ jobs:
   build:
     name: Build and Test (JDK ${{ matrix.java }})${{ matrix.profile == '-Pjakartaee11' && ' (Jakarta EE 11 + Spring 7)' || matrix.profile }}
     needs: changes
-    if: needs.changes.outputs.code == 'true'
+    # No job-level `if:` here on purpose. A matrix job whose condition is false
+    # is skipped *before* the matrix expands, so it reports a single check run
+    # named after the raw `${{ matrix.* }}` template - never "Build and Test
+    # (JDK 17)". The required context then never reports at all and the pull
+    # request stays blocked. Gate the steps instead: the matrix expands, every
+    # expected check reports success, and nothing is built.
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -95,20 +100,23 @@ jobs:
             profile: '-Pjakartaee11'
     steps:
       - name: Checkout code
+        if: needs.changes.outputs.code == 'true'
         uses: actions/checkout@v7
       - name: Setup Java ${{ matrix.java }}
+        if: needs.changes.outputs.code == 'true'
         uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: ${{ matrix.java }}
           cache: 'maven'
       - name: Maven Verify on Java ${{ matrix.java }}${{ matrix.profile == '-Pjakartaee11' && ' (Jakarta EE 11 + Spring 7)' || matrix.profile }}
+        if: needs.changes.outputs.code == 'true'
         run: mvn -B -V -DskipAssembly verify ${{ matrix.profile }} --no-transfer-progress
 
       - name: Test Summary ${{ matrix.java }} ${{ matrix.profile }}
         uses: mikepenz/action-junit-report@d9f48fc87bc235f7e214acf696ca5abc0a986f16 #v6.4.2
         continue-on-error: true
-        if: always()
+        if: always() && needs.changes.outputs.code == 'true'
         with:
           annotate_only: true # forked repo cannot write to checks so just do annotations
           report_paths: |


### PR DESCRIPTION
#1846 stopped `.claude`-only changes from triggering full builds, and deliberately avoided `paths-ignore` on `pull_request` because a workflow skipped by path filtering never reports its checks. It gated the `build` job with a job-level `if:` instead, on the reasoning that a job skipped that way *does* report — as `skipped` — and required checks accept `successful, skipped, or neutral`.

That holds for a plain job. It does not hold for a **matrix** job.

## What actually happens

A matrix job whose condition is false is skipped *before the matrix expands*, so it emits a single check run named after the raw name template rather than one per matrix entry. On #1848 the reported check was literally:

```
Build and Test (JDK ${{ matrix.java }})${{ (((matrix.profile == '-Pjakartaee11') && ' (Jakarta EE 11 + Spring 7)') || matrix.profile) }}   skipped
```

while `.asf.yaml` requires the context `Build and Test (JDK 17)`. That context never appeared at all, so it stayed Pending and the PR landed on `mergeStateStatus: BLOCKED` — the exact failure #1846 set out to avoid, reached by a different route.

## The fix

Drop the job-level `if:` and gate the four steps instead. The matrix expands, all five checks report `success` under their expanded names, and no Maven build runs. A `.claude`-only PR now costs five idle runners for a few seconds rather than five full builds — still the point of #1846, just paid for honestly.

`Test Summary` keeps `always()` so it still runs after a failed build, combined as `always() && needs.changes.outputs.code == 'true'`.

Jenkins is unaffected: stage-level `when` has no matrix to expand.

Once this merges, #1848 needs a rebase or an empty commit to pick up the corrected workflow.

Only the 7.x line is changed here; `support/struts-6-x-x` carries neither #1846 nor this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)