### PR TITLE
WW-5677 Remove the remaining redundant getPackage() lookups on the OGNL member-access path

### DIFF
--- a/core/src/main/java/org/apache/struts2/ognl/SecurityMemberAccess.java
+++ b/core/src/main/java/org/apache/struts2/ognl/SecurityMemberAccess.java
@@ -310,6 +310,15 @@ public class SecurityMemberAccess implements MemberAccess {
     }
 
     /**
+     * Blocks access to classes in the default (unnamed) package.
+     * <p>
+     * The emptiness of {@link #toPackageName(Class)} is the same test as the
+     * {@code getPackage() == null || getPackage().getName().isEmpty()} form this replaced, for every
+     * class shape: {@code getPackage()} is null for arrays, primitives and {@code void}, and names the
+     * unnamed package with the empty string, all of which {@code toPackageName} reports as empty. It
+     * avoids the {@code getPackage()} lookup through the defining classloader's package map, which
+     * ran twice per class here. See WW-5677.
+     *
      * @return {@code true} if member access is allowed
      */
     protected boolean checkDefaultPackageAccess(Object target, Member member) {
@@ -317,7 +326,7 @@ public class SecurityMemberAccess implements MemberAccess {
             return true;
         }
         Class<?> memberClass = member.getDeclaringClass();
-        if (memberClass.getPackage() == null || memberClass.getPackage().getName().isEmpty()) {
+        if (toPackageName(memberClass).isEmpty()) {
             LOG.warn("Class [{}] from the default package is excluded!", memberClass);
             return false;
         }
@@ -325,7 +334,7 @@ public class SecurityMemberAccess implements MemberAccess {
             return true;
         }
         Class<?> targetClass = target.getClass();
-        if (targetClass.getPackage() == null || targetClass.getPackage().getName().isEmpty()) {
+        if (toPackageName(targetClass).isEmpty()) {
             LOG.warn("Class [{}] from the default package is excluded!", targetClass);
             return false;
         }
@@ -407,7 +416,9 @@ public class SecurityMemberAccess implements MemberAccess {
     }
 
     protected boolean isExcludedPackageNamePatterns(Class<?> clazz) {
-        return excludedPackageNamePatterns.stream().anyMatch(pattern -> pattern.matcher(toPackageName(clazz)).matches());
+        // Resolved once rather than inside the lambda, which re-resolved it per configured pattern.
+        String packageName = toPackageName(clazz);
+        return excludedPackageNamePatterns.stream().anyMatch(pattern -> pattern.matcher(packageName).matches());
     }
 
     protected boolean isExcludedPackageNames(Class<?> clazz) {

--- a/core/src/test/java/org/apache/struts2/ognl/SecurityMemberAccessPackageMatchingTest.java
+++ b/core/src/test/java/org/apache/struts2/ognl/SecurityMemberAccessPackageMatchingTest.java
@@ -54,6 +54,15 @@ public class SecurityMemberAccessPackageMatchingTest {
     }
 
     /**
+     * The default-package condition replaced by WW-5677 in {@code checkDefaultPackageAccess},
+     * retained verbatim as the reference oracle. Deliberately calls {@link Class#getPackage()}
+     * directly rather than delegating to production code, so that it cannot drift with it.
+     */
+    private static boolean legacyDefaultPackageCondition(Class<?> clazz) {
+        return clazz.getPackage() == null || clazz.getPackage().getName().isEmpty();
+    }
+
+    /**
      * The {@code toPackageName} implementation replaced by WW-5674, retained as the reference oracle.
      */
     private static String legacyToPackageName(Class<?> clazz) {
@@ -165,6 +174,21 @@ public class SecurityMemberAccessPackageMatchingTest {
             assertThat(toPackageName(clazz))
                     .as("toPackageName(%s)", clazz.getName())
                     .isEqualTo(legacyToPackageName(clazz));
+        }
+    }
+
+    /**
+     * WW-5677 replaced {@code getPackage() == null || getPackage().getName().isEmpty()} in
+     * {@code checkDefaultPackageAccess} with {@code toPackageName(clazz).isEmpty()}. That gate
+     * decides whether a class counts as living in the default package, so the equivalence is
+     * asserted against the frozen oracle over every class shape rather than argued.
+     */
+    @Test
+    public void defaultPackageConditionMatchesLegacyAcrossClassShapes() throws Exception {
+        for (Class<?> clazz : classShapes()) {
+            assertThat(toPackageName(clazz).isEmpty())
+                    .as("default-package condition for %s", clazz.getName())
+                    .isEqualTo(legacyDefaultPackageCondition(clazz));
         }
     }
 

--- a/core/src/test/java/org/apache/struts2/ognl/SecurityMemberAccessTest.java
+++ b/core/src/test/java/org/apache/struts2/ognl/SecurityMemberAccessTest.java
@@ -404,6 +404,33 @@ public class SecurityMemberAccessTest {
         assertFalse("default package isn't excluded!", actual);
     }
 
+    /**
+     * WW-5677 routed {@code checkDefaultPackageAccess} through {@code toPackageName}. A class in a
+     * named package must still pass the gate when the setting is on.
+     */
+    @Test
+    public void testDefaultPackageAccessPermitsNamedPackageClass() throws Exception {
+        sma.useDisallowDefaultPackageAccess(Boolean.TRUE.toString());
+
+        Member member = FooBar.class.getMethod("getStringField");
+
+        assertTrue("a named-package class is blocked!", sma.checkDefaultPackageAccess(new FooBar(), member));
+    }
+
+    /**
+     * WW-5677 equivalence at the shape most likely to break it: an array target reports the empty
+     * package under both the old {@code getPackage() == null} form and the new one, so it must stay
+     * blocked. The member here declares in {@code java.lang}, so only the target branch can block.
+     */
+    @Test
+    public void testDefaultPackageAccessBlocksArrayTarget() throws Exception {
+        sma.useDisallowDefaultPackageAccess(Boolean.TRUE.toString());
+
+        Member member = Object.class.getMethod("toString");
+
+        assertFalse("an array target isn't blocked!", sma.checkDefaultPackageAccess(new String[0], member));
+    }
+
     @Test
     public void testDefaultPackageExclusion2() throws Exception {
         // given


### PR DESCRIPTION
Fixes [WW-5677](https://issues.apache.org/jira/browse/WW-5677)

Sub-task of WW-5667. WW-5674 replaced `Class.getPackage()` with the cached `Class.getPackageName()` inside `toPackageName`, but deliberately left two neighbouring call sites alone as out of scope. Both sit on the same per-access path, within twenty lines of it. This finishes the job. **No behaviour change.**

## 1. `checkDefaultPackageAccess` made four `getPackage()` calls

```diff
-if (memberClass.getPackage() == null || memberClass.getPackage().getName().isEmpty()) {
+if (toPackageName(memberClass).isEmpty()) {
```

…and the same for `targetClass`. `Class.getPackage()` resolves through the defining classloader's package map on every call, and the old condition evaluated it twice per class, for up to two classes per access.

The two forms agree for every class shape: `getPackage()` returns `null` for arrays, primitives and `void`, and names the unnamed package with the empty string — all of which `toPackageName` reports as empty.

## 2. `isExcludedPackageNamePatterns` recomputed the package name per pattern

```diff
-return excludedPackageNamePatterns.stream().anyMatch(pattern -> pattern.matcher(toPackageName(clazz)).matches());
+String packageName = toPackageName(clazz);
+return excludedPackageNamePatterns.stream().anyMatch(pattern -> pattern.matcher(packageName).matches());
```

`toPackageName` was evaluated inside the lambda, so it ran once per configured pattern. Now once per call.

## Testing

This is the OGNL security gate, so per the ticket the equivalence is **asserted rather than argued**:

- **`defaultPackageConditionMatchesLegacyAcrossClassShapes`** runs the replaced condition — frozen verbatim as `legacyDefaultPackageCondition`, which calls `getPackage()` directly and never delegates to production code — against the new one over the existing `classShapes()` matrix: arrays, primitives, `void`, a default-package class, a lambda and a JDK proxy.
- **`testDefaultPackageAccessPermitsNamedPackageClass`** — a named-package class still passes the gate with `struts.disallowDefaultPackageAccess=true`.
- **`testDefaultPackageAccessBlocksArrayTarget`** — an array target, the shape most likely to break the equivalence, stays blocked. The member declares in `java.lang`, so only the target branch can block.

All three were mutation-checked rather than assumed non-vacuous:

| mutation | fails |
|---|---|
| arrays/primitives resolve to `java.lang` | `defaultPackageConditionMatchesLegacyAcrossClassShapes`, `testDefaultPackageAccessBlocksArrayTarget` (plus the two WW-5674 equivalence tests) |
| member-class condition inverted | `testDefaultPackageAccessPermitsNamedPackageClass` (plus the existing `testDefaultPackageExclusionSetting`) |

`mvn test -DskipAssembly -pl core` — 3190 tests, 0 failures, 0 errors.

## Scope deliberately not taken

- The `LOG.warn` calls in `checkExclusionList` also call `getPackage()`, but only on the deny path, so there is no hot-path value — and switching them would change the log text from `package java.io` to `java.io`.
- Not threading a single package name through `isPackageExcluded` into both helpers. That would remove the last redundant call, but `isExcludedPackageNames`/`isExcludedPackageNamePatterns` are `protected` and subclasses may override them, so changing their signatures is source-breaking. WW-5678 owns that cleanup for 8.0.0. `toPackageName` is now a cached field read plus a branch, so calling it twice is negligible.

## Impact

Neither path runs by default: `checkDefaultPackageAccess` only when `struts.disallowDefaultPackageAccess` is enabled, and the pattern loop only when `struts.excludedPackageNamePatterns` is configured — both pattern constants are commented out in `struts-excluded-classes.xml`. This is a consistency fix for deployments that do enable them, not where the WW-5667 9% lives; that was WW-5675.

🤖 Generated with [Claude Code](https://claude.com/claude-code)