### PR TITLE
WW-5690 perf(dispatcher): load the dev-mode error template on first use

### DIFF
--- a/core/src/main/java/org/apache/struts2/dispatcher/DefaultDispatcherErrorHandler.java
+++ b/core/src/main/java/org/apache/struts2/dispatcher/DefaultDispatcherErrorHandler.java
@@ -30,7 +30,6 @@ import org.apache.commons.lang3.BooleanUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.struts2.StrutsConstants;
-import org.apache.struts2.StrutsException;
 import org.apache.struts2.views.freemarker.FreemarkerManager;
 
 import java.io.IOException;
@@ -48,9 +47,12 @@ public class DefaultDispatcherErrorHandler implements DispatcherErrorHandler {
 
     private static final Logger LOG = LogManager.getLogger(DefaultDispatcherErrorHandler.class);
 
+    private static final String ERROR_TEMPLATE = "/org/apache/struts2/dispatcher/error.ftl";
+
     private FreemarkerManager freemarkerManager;
     private boolean devMode;
-    private Template template;
+    private ServletContext servletContext;
+    private volatile Template template;
 
     @Inject
     public void setFreemarkerManager(FreemarkerManager freemarkerManager) {
@@ -63,12 +65,28 @@ public class DefaultDispatcherErrorHandler implements DispatcherErrorHandler {
     }
 
     public void init(ServletContext ctx) {
-        try {
-            freemarker.template.Configuration config = freemarkerManager.getConfiguration(ctx);
-            template = config.getTemplate("/org/apache/struts2/dispatcher/error.ftl");
-        } catch (IOException e) {
-            throw new StrutsException(e);
+        this.servletContext = ctx;
+    }
+
+    /**
+     * Loads the problem report template on first use rather than at startup: it is only ever
+     * rendered in devMode, so a production application should never build a FreeMarker
+     * configuration on its behalf.
+     * <p>
+     * Two threads racing on the very first error may both load the template. That is harmless -
+     * FreeMarker caches templates in its own configuration - and cheaper than locking a path taken
+     * once per application.
+     *
+     * @return the problem report template
+     * @throws IOException if the template cannot be loaded
+     */
+    protected Template getTemplate() throws IOException {
+        Template result = template;
+        if (result == null) {
+            result = freemarkerManager.getConfiguration(servletContext).getTemplate(ERROR_TEMPLATE);
+            template = result;
         }
+        return result;
     }
 
     public void handleError(HttpServletRequest request, HttpServletResponse response, int code, Exception e) {
@@ -115,7 +133,7 @@ public class DefaultDispatcherErrorHandler implements DispatcherErrorHandler {
             } while ((cur = cur.getCause()) != null);
 
             Writer writer = new StringWriter();
-            template.process(createReportData(e, chain), writer);
+            getTemplate().process(createReportData(e, chain), writer);
 
             response.setContentType("text/html");
             response.getWriter().write(writer.toString());

--- a/core/src/main/java/org/apache/struts2/dispatcher/DefaultDispatcherErrorHandler.java
+++ b/core/src/main/java/org/apache/struts2/dispatcher/DefaultDispatcherErrorHandler.java
@@ -52,7 +52,7 @@ public class DefaultDispatcherErrorHandler implements DispatcherErrorHandler {
     private FreemarkerManager freemarkerManager;
     private boolean devMode;
     private ServletContext servletContext;
-    private volatile Template template;
+    private Template template;
 
     @Inject
     public void setFreemarkerManager(FreemarkerManager freemarkerManager) {
@@ -73,20 +73,18 @@ public class DefaultDispatcherErrorHandler implements DispatcherErrorHandler {
      * rendered in devMode, so a production application should never build a FreeMarker
      * configuration on its behalf.
      * <p>
-     * Two threads racing on the very first error may both load the template. That is harmless -
-     * FreeMarker caches templates in its own configuration - and cheaper than locking a path taken
-     * once per application.
+     * Synchronised rather than lock-free: this runs only when devMode is on and a request has
+     * already failed, and {@link FreemarkerManager#getConfiguration(ServletContext)} is itself
+     * synchronised, so the lock costs nothing that this path was not paying already.
      *
      * @return the problem report template
      * @throws IOException if the template cannot be loaded
      */
-    protected Template getTemplate() throws IOException {
-        Template result = template;
-        if (result == null) {
-            result = freemarkerManager.getConfiguration(servletContext).getTemplate(ERROR_TEMPLATE);
-            template = result;
+    protected synchronized Template getTemplate() throws IOException {
+        if (template == null) {
+            template = freemarkerManager.getConfiguration(servletContext).getTemplate(ERROR_TEMPLATE);
         }
-        return result;
+        return template;
     }
 
     public void handleError(HttpServletRequest request, HttpServletResponse response, int code, Exception e) {

--- a/core/src/test/java/org/apache/struts2/dispatcher/DefaultDispatcherErrorHandlerTest.java
+++ b/core/src/test/java/org/apache/struts2/dispatcher/DefaultDispatcherErrorHandlerTest.java
@@ -18,10 +18,14 @@
  */
 package org.apache.struts2.dispatcher;
 
+import freemarker.template.Configuration;
 import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.Collections;
 import org.apache.struts2.StrutsInternalTestCase;
 
+import jakarta.servlet.ServletContext;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.apache.struts2.views.freemarker.FreemarkerManager;
@@ -128,6 +132,61 @@ public class DefaultDispatcherErrorHandlerTest extends StrutsInternalTestCase {
             fail("Mock sendError call setup failed.  Ex: " + ioe);
         }
         defaultDispatcherErrorHandler.handleError(requestMock, responseMock, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, fakeException);
+    }
+
+    /**
+     * The dev-mode problem report is the only thing that needs FreeMarker here, so booting the
+     * application must not build a FreeMarker configuration just to have the template ready.
+     */
+    public void testInitDoesNotLoadErrorTemplate() {
+        RecordingFreemarkerManager freemarkerManager = createFreemarkerManager();
+        DefaultDispatcherErrorHandler defaultDispatcherErrorHandler = new DefaultDispatcherErrorHandler();
+        defaultDispatcherErrorHandler.setDevMode("true");
+        defaultDispatcherErrorHandler.setFreemarkerManager(freemarkerManager);
+
+        defaultDispatcherErrorHandler.init(dispatcher.servletContext);
+
+        assertFalse("init() must not touch FreeMarker", freemarkerManager.configurationRequested);
+    }
+
+    /**
+     * The deferred load must still happen, otherwise the problem report silently stops rendering.
+     */
+    public void testErrorTemplateLoadedOnFirstDevModeError() throws IOException {
+        RecordingFreemarkerManager freemarkerManager = createFreemarkerManager();
+        DefaultDispatcherErrorHandler defaultDispatcherErrorHandler = new DefaultDispatcherErrorHandler();
+        defaultDispatcherErrorHandler.setDevMode("true");
+        defaultDispatcherErrorHandler.setFreemarkerManager(freemarkerManager);
+        defaultDispatcherErrorHandler.init(dispatcher.servletContext);
+        Exception fakeException = new Exception("Fake Exception, devMode true");
+        responseMock.setContentType("text/html");
+        expectLastCall();
+        expect(responseMock.getWriter()).andStubReturn(new PrintWriter(new StringWriter()));
+        replay(responseMock);
+
+        defaultDispatcherErrorHandler.handleError(requestMock, responseMock, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, fakeException);
+
+        assertTrue("problem report must load the template on first use", freemarkerManager.configurationRequested);
+    }
+
+    private RecordingFreemarkerManager createFreemarkerManager() {
+        RecordingFreemarkerManager freemarkerManager = new RecordingFreemarkerManager();
+        container.inject(freemarkerManager);
+        return freemarkerManager;
+    }
+
+    /**
+     * Records whether the FreeMarker configuration was ever asked for, while still delegating so the
+     * template really renders.
+     */
+    private static class RecordingFreemarkerManager extends FreemarkerManager {
+        private boolean configurationRequested;
+
+        @Override
+        public Configuration getConfiguration(ServletContext servletContext) {
+            configurationRequested = true;
+            return super.getConfiguration(servletContext);
+        }
     }
 
     protected void setUp() {


### PR DESCRIPTION
Fixes [WW-5690](https://issues.apache.org/jira/browse/WW-5690)

`DefaultDispatcherErrorHandler.init()` built a FreeMarker configuration and loaded `/org/apache/struts2/dispatcher/error.ftl` on **every** startup — including production, where the problem report is never rendered. `handleError()` only reaches it when devMode is on; otherwise it delegates to the container's error page.

So every Struts application today pays to initialise FreeMarker for a page most of them never show.

## Change

`init()` now just stores the `ServletContext`. A new `protected synchronized getTemplate()` loads the template on first use and caches it.

The lock is deliberate rather than lock-free: this path only runs when devMode is on and a request has already failed, so it is never hot, and `FreemarkerManager.getConfiguration` is itself `synchronized` — the path was already taking a lock. A plain field behind a synchronized getter is simpler to verify than a `volatile` one, and avoids `java:S3077` (volatile publishes the reference, not the object's state, and `Template` extends `Configurable`).

## One behavioural change

A missing or unparsable `error.ftl` used to throw `StrutsException` from `init()` and fail the application at boot. It now surfaces on the first dev-mode error, where the existing `catch (Exception exp)` in `handleErrorInDevMode()` already degrades to `sendError(code, "Unable to show problem report: ...")`.

I'd argue that's an improvement — a dev-only template shouldn't stop a production application starting — but it is a change in failure timing and worth a reviewer's eye.

## Scope

Startup cost only. The `FreemarkerManager` injection, the `freemarker.template.Template` import and `error.ftl` itself all stay — removing them is [WW-5693](https://issues.apache.org/jira/browse/WW-5693), targeted at 8.0.0 because it deletes a template that can be overridden on the classpath.

Both are part of the lean-core work tracked in [WW-5689](https://issues.apache.org/jira/browse/WW-5689), alongside [WW-5691](https://issues.apache.org/jira/browse/WW-5691) and [WW-5692](https://issues.apache.org/jira/browse/WW-5692) for the other two places core reaches into `views.freemarker`.

## Tests

Two added to `DefaultDispatcherErrorHandlerTest`, using a `FreemarkerManager` subclass that records whether `getConfiguration` was called (no mocking framework needed — it delegates to `super`, so the template really renders):

- `testInitDoesNotLoadErrorTemplate` — asserts `init()` leaves FreeMarker untouched. **Verified failing before the change**, on the assertion, which is what makes it a real regression guard.
- `testErrorTemplateLoadedOnFirstDevModeError` — asserts the deferred load actually happens, so the report can't silently stop rendering.

The four existing tests are unchanged and still pass. Full `core` suite: 3197 tests, 0 failures, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)