### PR TITLE
WW-5700 fix(ognl): skip the store when a map or list element cannot be converted

### DIFF
--- a/core/src/main/java/org/apache/struts2/ognl/accessor/XWorkListPropertyAccessor.java
+++ b/core/src/main/java/org/apache/struts2/ognl/accessor/XWorkListPropertyAccessor.java
@@ -20,6 +20,7 @@ package org.apache.struts2.ognl.accessor;
 
 import org.apache.struts2.ObjectFactory;
 import org.apache.struts2.conversion.ObjectTypeDeterminer;
+import org.apache.struts2.conversion.TypeConverter;
 import org.apache.struts2.conversion.impl.XWorkConverter;
 import org.apache.struts2.inject.Inject;
 import org.apache.struts2.ognl.OgnlUtil;
@@ -30,6 +31,8 @@ import ognl.OgnlException;
 import ognl.PropertyAccessor;
 import org.apache.struts2.StrutsConstants;
 import org.apache.struts2.StrutsException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.Collection;
 import java.util.List;
@@ -42,6 +45,8 @@ import java.util.List;
  * @author Gabriel Zimmerman
  */
 public class XWorkListPropertyAccessor extends ListPropertyAccessor {
+
+    private static final Logger LOG = LogManager.getLogger(XWorkListPropertyAccessor.class);
 
     private XWorkCollectionPropertyAccessor _sAcc = new XWorkCollectionPropertyAccessor();
 
@@ -167,6 +172,10 @@ public class XWorkListPropertyAccessor extends ListPropertyAccessor {
         }
 
         Object realValue = getRealValue(context, value, convertToClass);
+        if (realValue == TypeConverter.NO_CONVERSION_POSSIBLE) {
+            LOG.debug("Unable to convert value for index [{}] to the declared element type, skipping assignment", name);
+            return;
+        }
 
         if (target instanceof List list && name instanceof Number) {
             //make sure there are enough spaces in the List to set

--- a/core/src/main/java/org/apache/struts2/ognl/accessor/XWorkMapPropertyAccessor.java
+++ b/core/src/main/java/org/apache/struts2/ognl/accessor/XWorkMapPropertyAccessor.java
@@ -20,6 +20,7 @@ package org.apache.struts2.ognl.accessor;
 
 import org.apache.struts2.ObjectFactory;
 import org.apache.struts2.conversion.ObjectTypeDeterminer;
+import org.apache.struts2.conversion.TypeConverter;
 import org.apache.struts2.conversion.impl.XWorkConverter;
 import org.apache.struts2.inject.Inject;
 import org.apache.struts2.util.reflection.ReflectionContextState;
@@ -127,8 +128,17 @@ public class XWorkMapPropertyAccessor extends MapPropertyAccessor {
         LOG.trace("Entering setProperty({},{},{},{})", context, target, name, value);
 
         Object key = getKey(context, name);
+        if (key == TypeConverter.NO_CONVERSION_POSSIBLE) {
+            LOG.debug("Unable to convert key [{}] to the declared key type, skipping assignment", name);
+            return;
+        }
+        Object convertedValue = getValue(context, value);
+        if (convertedValue == TypeConverter.NO_CONVERSION_POSSIBLE) {
+            LOG.debug("Unable to convert value for key [{}] to the declared element type, skipping assignment", key);
+            return;
+        }
         Map map = (Map) target;
-        map.put(key, getValue(context, value));
+        map.put(key, convertedValue);
     }
 
     private Object getValue(OgnlContext context, Object value) {

--- a/core/src/test/java/org/apache/struts2/interceptor/parameter/ParametersInterceptorTest.java
+++ b/core/src/test/java/org/apache/struts2/interceptor/parameter/ParametersInterceptorTest.java
@@ -48,6 +48,7 @@ import org.apache.struts2.action.ParameterNameAware;
 import org.apache.struts2.action.ParameterValueAware;
 import org.apache.struts2.config.StrutsXmlConfigurationProvider;
 import org.apache.struts2.dispatcher.HttpParameters;
+import org.apache.struts2.util.Element;
 import org.junit.Assert;
 
 import java.io.File;
@@ -1011,6 +1012,44 @@ public class ParametersInterceptorTest extends XWorkTestCase {
 
         ActionConfig config = configuration.getRuntimeConfiguration().getActionConfig("", MockConfigurationProvider.PARAM_INTERCEPTOR_ACTION_NAME);
         container.inject(config.getInterceptors().get(0).getInterceptor());
+    }
+
+    /**
+     * WW-5700: a value that cannot be converted to the map's element type must not be stored.
+     * An unchecked s:checkbox with submitUnchecked="true" submits the CheckboxInterceptor's
+     * uncheckedValue, "false", which cannot become an Integer.
+     */
+    public void testUnconvertibleValueIsNotBoundIntoTypedMap() {
+        CheckboxAction action = new CheckboxAction();
+        ValueStack vs = ActionContext.getContext().getValueStack();
+        vs.push(action);
+
+        ParametersInterceptor pi = new ParametersInterceptor();
+        container.inject(pi);
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("capDeferral[100]", "1");
+        params.put("capDeferral[200]", "false");
+
+        pi.applyParameters(action, vs, HttpParameters.create(params).build());
+
+        Map<Long, Integer> capDeferral = action.getCapDeferral();
+        assertEquals("sanity: the convertible value must still bind", Integer.valueOf(1), capDeferral.get(100L));
+        for (Object entry : ((Map) capDeferral).entrySet()) {
+            Map.Entry e = (Map.Entry) entry;
+            assertTrue("key is not a Long: " + e.getKey(), e.getKey() instanceof Long);
+            assertTrue("value is not an Integer: " + e.getValue(), e.getValue() instanceof Integer);
+        }
+    }
+
+    public static class CheckboxAction {
+        @Element(value = Integer.class)
+        private final Map<Long, Integer> capDeferral = new HashMap<>();
+
+        @StrutsParameter(depth = 1)
+        public Map<Long, Integer> getCapDeferral() {
+            return capDeferral;
+        }
     }
 
 }

--- a/core/src/test/java/org/apache/struts2/ognl/accessor/XWorkListPropertyAccessorTest.java
+++ b/core/src/test/java/org/apache/struts2/ognl/accessor/XWorkListPropertyAccessorTest.java
@@ -64,6 +64,22 @@ public class XWorkListPropertyAccessorTest extends XWorkTestCase {
         assertEquals(myList.size(), vs.findValue("strings.size"));
     }
 
+    public void testUnconvertibleElementIsNotStored() {
+        ValueStack vs = ActionContext.getContext().getValueStack();
+        ListHolder listHolder = new ListHolder();
+        listHolder.setLongs(new ArrayList<>());
+        vs.push(listHolder);
+
+        vs.setValue("longs[0]", "1");
+        vs.setValue("longs[1]", "not-a-number");
+
+        assertEquals(Long.valueOf(1), listHolder.getLongs().get(0));
+        for (Object element : (List) listHolder.getLongs()) {
+            assertTrue("list must not hold a non-Long element: " + element,
+                    element == null || element instanceof Long);
+        }
+    }
+
     public void testAutoGrowthCollectionLimit() {
         PropertyAccessor accessor = container.getInstance(PropertyAccessor.class, ArrayList.class.getName());
         ((XWorkListPropertyAccessor) accessor).setAutoGrowCollectionLimit("2");

--- a/core/src/test/java/org/apache/struts2/ognl/accessor/XWorkMapPropertyAccessorTest.java
+++ b/core/src/test/java/org/apache/struts2/ognl/accessor/XWorkMapPropertyAccessorTest.java
@@ -25,6 +25,7 @@ import org.apache.struts2.util.ValueStack;
 import org.apache.struts2.util.reflection.ReflectionContextState;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 public class XWorkMapPropertyAccessorTest extends XWorkTestCase {
@@ -55,6 +56,50 @@ public class XWorkMapPropertyAccessorTest extends XWorkTestCase {
         vs.push(new MapHolder(Collections.emptyMap()));
         ReflectionContextState.setCreatingNullObjects(vs.getContext(), false);
         assertNull(vs.findValue("map['key']"));
+    }
+
+    public void testUnconvertibleValueIsNotStored() {
+        TypedMapHolder holder = new TypedMapHolder();
+        ValueStack vs = ActionContext.getContext().getValueStack();
+        vs.push(holder);
+
+        vs.setValue("counts[1]", "5");
+        vs.setValue("counts[2]", "not-a-number");
+
+        assertEquals(Integer.valueOf(5), holder.getCounts().get(1L));
+        assertOnlyDeclaredTypes(holder.getCounts());
+    }
+
+    public void testUnconvertibleKeyIsNotStored() {
+        TypedMapHolder holder = new TypedMapHolder();
+        ValueStack vs = ActionContext.getContext().getValueStack();
+        vs.push(holder);
+
+        vs.setValue("counts[1]", "5");
+        vs.setValue("counts['abc']", "6");
+
+        assertEquals(Integer.valueOf(5), holder.getCounts().get(1L));
+        assertOnlyDeclaredTypes(holder.getCounts());
+    }
+
+    /**
+     * A Map declared to hold Long keys and Integer values must never be left holding anything else.
+     */
+    private static void assertOnlyDeclaredTypes(Map<Long, Integer> map) {
+        for (Object o : ((Map) map).entrySet()) {
+            Map.Entry entry = (Map.Entry) o;
+            assertTrue("key is not a Long: " + entry.getKey(), entry.getKey() instanceof Long);
+            assertTrue("value is not an Integer: " + entry.getValue(), entry.getValue() instanceof Integer);
+        }
+    }
+
+    public static class TypedMapHolder {
+        @Element(value = Integer.class)
+        private final Map<Long, Integer> counts = new HashMap<>();
+
+        public Map<Long, Integer> getCounts() {
+            return counts;
+        }
     }
 
     private static class MapHolder {


### PR DESCRIPTION
Fixes [WW-5700](https://issues.apache.org/jira/browse/WW-5700)

### Problem

`XWorkConverter.convertValue()` signals a failed conversion by returning
`TypeConverter.NO_CONVERSION_POSSIBLE` — which is itself a plain `String`,
`"ognl.NoConversionPossible"`. `XWorkMapPropertyAccessor` and
`XWorkListPropertyAccessor` stored that return value into the target collection
without checking for it.

Generics are erased at that point, so the `put` succeeds silently and the
`ClassCastException` only surfaces later, when application code reads the entry
back — with a stack trace pointing away from the framework, which makes this
very hard to recognise from a bug report.

Reported on user@ as *"Struts setting a String object instead of Integer in the
form"*: an unchecked `<s:checkbox submitUnchecked="true"/>` causes
`CheckboxInterceptor` to submit its `uncheckedValue`, `"false"`, which cannot
become an `Integer`.

### Fix

Guard both accessors and skip the assignment. The conversion error has already
been registered by `convertValue()`, so nothing is lost — validation-driven
actions see no change at all.

Details worth a reviewer's attention:

- The map accessor guards the **key** as well as the value. An unconvertible key
  poisons iteration over the whole map rather than a single entry, and is
  reachable because `ACCEPTED_PATTERNS` is asymmetric: the bare-bracket branch
  accepts digits only, `(\[\d+])`, but the quoted-key branch accepts word
  characters, `(\['(\w-?|[一-龥]-?)+'])`. So `capDeferral['abc']` is an accepted
  parameter name even where the declared key type is numeric.
- **Identity comparison**, not `equals()`, matching OGNL's own guard in
  `OgnlRuntime`. The constant is declared `Object`, not `String`
  (`TypeConverter.java:49`), so it is not a JLS constant variable and is not
  inlined into referencing class files — every reference resolves to the one field
  value at runtime. A parameter value built by a servlet container from request
  bytes is a distinct object, so reference comparison separates *"the converter
  signalled failure"* from *"the user submitted this text"*. Please do not
  simplify this back to `equals()`.

  To be precise about the limit: this protects values arriving from a request,
  which is the case that matters here. It does **not** protect a value that
  happens to be interned — application code calling the converter programmatically
  with a String literal shares the constant's exact instance, since all identical
  literals are interned together. Closing that as well would mean giving the
  marker an identity no user string can share, which changes a published constant
  and is a binary-compatibility question rather than a bug fix. Out of scope here,
  and noted so the limit is not misread as an oversight.
- The guard **skips rather than throws**: on the `XWorkMethodAccessor.callMethod`
  path an exception here would be swallowed and only logged.
- In the list accessor the guard sits **before** the auto-grow block, so an
  unconvertible value does not grow the list.

### Not included

`XWorkCollectionPropertyAccessor` carries the same unguarded pattern, but its
scalar `setProperty` path is not reachable through the value stack — `ids[0]` on
a `Set` is rejected by OGNL before it gets there. No failing test could be
written, so it is deliberately left untouched rather than changed blind.

### Precedent

[WW-3762](https://issues.apache.org/jira/browse/WW-3762) fixed this same bug class
in `XWorkBasicConverter.doConvertToCollection` in 2.3.3, and `CollectionConverter`
still carries that guard today, three times. The property accessors were simply
never given the equivalent check.

### Testing

Written test-first; each test was watched failing for the right reason before the
fix, with a valid entry binding first so none can pass vacuously. For the
end-to-end test the production change was stashed to confirm it fails without it.

- `XWorkMapPropertyAccessorTest` — unconvertible value, unconvertible key
- `XWorkListPropertyAccessorTest` — unconvertible element
- `ParametersInterceptorTest` — the reported checkbox scenario, end to end

Full core suite: **3201 tests, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
