### PR TITLE
WW-5707 Deprecate legacy restful and restful2 action mappers in core (6.x)

### DIFF
--- a/core/src/main/java/org/apache/struts2/dispatcher/mapper/Restful2ActionMapper.java
+++ b/core/src/main/java/org/apache/struts2/dispatcher/mapper/Restful2ActionMapper.java
@@ -33,7 +33,11 @@ import java.util.StringTokenizer;
 /**
  * Extended version of {@link RestfulActionMapper}, see documentation for more details
  * <a href="https://struts.apache.org/core-developers/restful-action-mapper.html">Restful2ActionMapper</a>
+ *
+ * @deprecated since 6.12.0, this legacy mapper predates the Struts REST plugin, which is the maintained
+ * way to build REST-style applications with Struts. Scheduled for removal in the next major release.
  */
+@Deprecated
 public class Restful2ActionMapper extends DefaultActionMapper {
 
     private static final Logger LOG = LogManager.getLogger(Restful2ActionMapper.class);

--- a/core/src/main/java/org/apache/struts2/dispatcher/mapper/RestfulActionMapper.java
+++ b/core/src/main/java/org/apache/struts2/dispatcher/mapper/RestfulActionMapper.java
@@ -34,7 +34,11 @@ import java.util.StringTokenizer;
  * Simple Restfull Action Mapper to support REST application
  * See docs for more information
  * <a href="https://struts.apache.org/core-developers/restful-action-mapper.html">RestfulActionMapper</a>
+ *
+ * @deprecated since 6.12.0, this legacy mapper predates the Struts REST plugin, which is the maintained
+ * way to build REST-style applications with Struts. Scheduled for removal in the next major release.
  */
+@Deprecated
 public class RestfulActionMapper implements ActionMapper {
 
     protected static final Logger LOG = LogManager.getLogger(RestfulActionMapper.class);

--- a/core/src/main/resources/struts-beans.xml
+++ b/core/src/main/resources/struts-beans.xml
@@ -79,6 +79,8 @@
           class="org.apache.struts2.dispatcher.mapper.CompositeActionMapper"/>
     <bean type="org.apache.struts2.dispatcher.mapper.ActionMapper" name="prefix"
           class="org.apache.struts2.dispatcher.mapper.PrefixBasedActionMapper"/>
+    <!-- Deprecated for removal: the legacy "restful" and "restful2" mappers predate the Struts REST
+         plugin, which is the maintained way to build REST-style applications. -->
     <bean type="org.apache.struts2.dispatcher.mapper.ActionMapper" name="restful"
           class="org.apache.struts2.dispatcher.mapper.RestfulActionMapper"/>
     <bean type="org.apache.struts2.dispatcher.mapper.ActionMapper" name="restful2"


### PR DESCRIPTION
6.x backport of #1882.

The core `restful` (`RestfulActionMapper`) and `restful2` (`Restful2ActionMapper`) action mappers predate the Struts REST plugin, which is the maintained way to build REST-style applications with Struts.

This marks both classes `@Deprecated` (plain form, as this line targets Java 8) with javadoc pointing users to the REST plugin, and notes the deprecation next to their bean registrations in `struts-beans.xml`. No behaviour changes.

Removal is tracked separately as [WW-5708](https://issues.apache.org/jira/browse/WW-5708).

Fixes [WW-5707](https://issues.apache.org/jira/browse/WW-5707)

🤖 Generated with [Claude Code](https://claude.com/claude-code)