### PR TITLE
docs: point CLAUDE.md at THREAT_MODEL.md for security scope

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,9 @@ For any security-related activity — vulnerability scans, security analysis, dr
 Read it first and follow its pre-reporting checks, assessment checklist, and reporting requirements. Reports must be sent privately to
 `security@struts.apache.org`; do not open a public GitHub issue, Jira issue, pull request, or mailing list thread for a suspected vulnerability before private
 triage. [`AGENTS.md`](AGENTS.md) is a shorter LLM-facing wrapper around the same process.
+[`THREAT_MODEL.md`](THREAT_MODEL.md) is where the scope lives — trust boundaries, the security properties the framework does and does not provide, the
+recurring non-findings (§11a), and the triage dispositions (§13). Read it before judging whether a finding is real: on Struts most candidate findings are
+closed as application responsibility or non-default configuration rather than as framework bugs.
 
 ## Testing
 


### PR DESCRIPTION
The **Security Reports & Scans** section of `CLAUDE.md` named [`SECURITY.md`](SECURITY.md) and [`AGENTS.md`](AGENTS.md) but not [`THREAT_MODEL.md`](THREAT_MODEL.md). Anything working from `CLAUDE.md` alone therefore reached the *reporting process* without the *scope* that decides whether there is anything to report — `THREAT_MODEL.md` was only reachable transitively, through a link in `SECURITY.md:8` or `AGENTS.md:17`.

This matters most for automated review. A generic security pass over a Struts diff will confidently flag unannotated setters, direct JSP access, raw `${}` EL and "generic DoS" — every one of which `THREAT_MODEL.md` §11a already closes as a known non-finding, and §13 routes to `OUT-OF-MODEL: application-responsibility` or `non-default-config`.

So name the file directly and say what it is for.

Documentation only — no ticket, per the `docs:` convention in `CLAUDE.md`. No code, build or CI files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AtyHU8BzNmeZNncXRu7yjB