### PR TITLE
docs: drop hardcoded test-class counts from the review guides

### DIFF
--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -26,12 +26,14 @@ Deeper references, when a review needs them:
 `org.junit.jupiter` imports. Two styles coexist and a new test must match the
 style already in the file it joins:
 
-- **JUnit 3 style** — around 117 classes extend `XWorkTestCase`, which extends
+- **JUnit 3 style** — classes extending `XWorkTestCase`, which extends
   `junit.framework.TestCase`. Test methods must be named `testXxx()`. A Jupiter
   `@Test` annotation added to one of these **silently never runs** — it does not
   fail, it is simply not collected. Flag this as blocking whenever you see
   `org.junit.jupiter` in a diff.
-- **JUnit 4 style** — around 212 classes use `import org.junit.Test`.
+- **JUnit 4 style** — classes using `import org.junit.Test`.
+
+Both styles are widespread and neither is being migrated away from.
 
 AssertJ assertions and Mockito mocks are both available and widely used.
 Introducing JUnit 5 is a build-infrastructure change that needs its own `WW-`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,10 +79,13 @@ Run with `mvn test -DskipAssembly`.
 **Tests are JUnit 4 — there is no JUnit 5 anywhere in this repo.** `parent/pom.xml` declares
 `junit:junit:4.13.2`; there are zero `org.junit.jupiter` imports. Two styles coexist:
 
-- **JUnit 3 style** — ~114 classes extend `XWorkTestCase` (which extends `junit.framework.TestCase`).
+- **JUnit 3 style** — classes extending `XWorkTestCase` (which extends `junit.framework.TestCase`).
   Methods must be named `testXxx()`. A Jupiter `@Test` annotation added to one of these **silently
   never runs** — it does not fail, it is simply not collected.
-- **JUnit 4 style** — ~210 classes use `import org.junit.Test`.
+- **JUnit 4 style** — classes using `import org.junit.Test`.
+
+Both styles are widespread and neither is being migrated away from; `grep -rl` for either marker
+gives the current split.
 
 Before adding a test, open the target file and match the style already there. AssertJ assertions and
 Mockito mocks are both available and widely used. Introducing Jupiter is a build-infrastructure change


### PR DESCRIPTION
Follow-up to #1885 and #1876.

`CLAUDE.md` and `.github/skills/code-review/SKILL.md` each stated how many test classes use the JUnit 3 and JUnit 4 styles. Both were already stale:

| | `SKILL.md` | `CLAUDE.md` | actual |
|---|---|---|---|
| `extends XWorkTestCase` | ~117 | ~114 | **117** |
| `import org.junit.Test` | ~212 | ~210 | **215** |
| `org.junit.jupiter` | 0 | 0 | **0** |

Both were hedged with "around"/"~", so neither was wrong today. But a count that only moves in one direction, duplicated across two files with nothing watching it, is a drift surface for no benefit — the numbers carry no review weight.

What matters is retained: both styles are current, a new test must match the file it joins, and there are **zero** `org.junit.jupiter` imports. That last one is the load-bearing claim and it stays in both files.

The two files serve different consumers — `CLAUDE.md` for Claude Code, `.github/skills/` for GitHub Copilot code review (#1876) — so they are updated in step rather than merged.

Documentation only — no ticket, per the `docs:` convention in `CLAUDE.md`. No code, build or CI files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AtyHU8BzNmeZNncXRu7yjB