### PR TITLE
WW-5711 fix(conversion): bound fraction digits when formatting BigDecimal

### DIFF
--- a/core/src/main/java/org/apache/struts2/conversion/impl/StringConverter.java
+++ b/core/src/main/java/org/apache/struts2/conversion/impl/StringConverter.java
@@ -36,6 +36,18 @@ import java.util.Objects;
 
 public class StringConverter extends DefaultTypeConverter {
 
+    /**
+     * Upper bound on the number of fraction digits emitted when formatting a number.
+     * <p>
+     * Covers every {@code double} and {@code float} value in full - the widest is
+     * {@link Double#MIN_VALUE} at 325 fraction digits - so the round-trip precision
+     * introduced by WW-4871 is preserved. Beyond that bound the length of the output
+     * would follow the scale of the value rather than its precision, so a
+     * {@link BigDecimal} scaled past this limit is rounded to it.
+     */
+    private static final int MAX_FRACTION_DIGITS = 340;
+
+
     @Override
     public Object convertValue(Map<String, Object> context, Object target, Member member, String propertyName, Object value, Class toType) {
         String result;
@@ -86,7 +98,7 @@ public class StringConverter extends DefaultTypeConverter {
             // TODO: delete this variable and corresponding if statement when jdk fixed java.text.NumberFormat.format's behavior with Float
             Object fixedValue = value;
             if (value instanceof BigDecimal || value instanceof Double || value instanceof Float) {
-                format.setMaximumFractionDigits(Integer.MAX_VALUE);
+                format.setMaximumFractionDigits(MAX_FRACTION_DIGITS);
                 if (value instanceof Float) {
                     fixedValue = Double.valueOf(value.toString());
                 }

--- a/core/src/test/java/org/apache/struts2/conversion/impl/StringConverterTest.java
+++ b/core/src/test/java/org/apache/struts2/conversion/impl/StringConverterTest.java
@@ -22,6 +22,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.struts2.StrutsInternalTestCase;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.Locale;
 import java.util.Map;
 
@@ -100,6 +101,18 @@ public class StringConverterTest extends StrutsInternalTestCase {
 
         // then does not lose integer and fraction digits
         assertEquals(aBitBiggerThanDouble.substring(0, 309) + "," + aBitBiggerThanDouble.substring(310), value);
+    }
+
+    public void testBigDecimalFractionDigitsAreBounded() throws Exception {
+        // given
+        StringConverter converter = new StringConverter();
+        Map<String, Object> context = createContextWithLocale(new Locale("pl", "PL"));
+
+        // when the scale of the value exceeds the supported number of fraction digits
+        Object value = converter.convertValue(context, null, null, null, new BigDecimal(BigInteger.ONE, 100_000), null);
+
+        // then the length of the output is bounded by the converter, not by the scale of the value
+        assertEquals("0", value);
     }
 
     public void testStringArrayToStringConversion() {


### PR DESCRIPTION
`StringConverter` formatted `BigDecimal`, `Double` and `Float` with `maximumFractionDigits` set to `Integer.MAX_VALUE`.

That constant arrived with [WW-4871](https://issues.apache.org/jira/browse/WW-4871), which fixed round-trip precision loss for `double` and `float`. Both of those types are naturally bounded — the widest `double` needs 325 fraction digits (`Double.MIN_VALUE`) and the widest `float` needs 45 — so `Integer.MAX_VALUE` is far wider than WW-4871 required.

`BigDecimal` carries no such bound. `DecimalFormat` honours `maximumFractionDigits` literally and pads the fraction out to the value's full scale, so the length of the formatted output followed the scale of the value rather than its precision.

Bound the setting to 340 instead.

### Backward compatibility

Every `double` and `float` value still formats in full, so WW-4871's behaviour is preserved exactly. Every `BigDecimal` with a scale of 340 or less is also unchanged. A `BigDecimal` scaled beyond 340 is now rounded to that bound rather than padded out in full — the only observable difference.

The existing round-trip assertions are untouched and still pass: `testDoubleToStringConversionPL` pins `Double.MIN_VALUE` at 325 fraction digits, and `testBigDecimalToStringConversionPL` pins a value slightly wider than `double` at 326.

### Scope

Render side only. `NumberConverter.convertToBigDecimal` is unchanged in this PR.

### Testing

`mvn test -DskipAssembly -pl core` — 3301 tests, 0 failures.

Fixes [WW-5711](https://issues.apache.org/jira/browse/WW-5711)